### PR TITLE
Fixed frontmatter for "Get Involved" page

### DIFF
--- a/src/getinvolved.md
+++ b/src/getinvolved.md
@@ -1,6 +1,6 @@
 ---
 title: 'Get Involved'
-metaDesc: 'Learn how to get involved with Open Web Advocacy's efforts.'
+metaDesc: "Learn how to get involved with Open Web Advocacy's efforts."
 layout: 'layouts/page.njk'
 ---
 


### PR DESCRIPTION
Minor tweak. This was causing errors for me when attempting to build the site due to the quote marks.
Thought I'd provide this back in case it's causing issues for others.