### PR TITLE
Added simple initial accessibility page content

### DIFF
--- a/src/pages/accessibility.md
+++ b/src/pages/accessibility.md
@@ -5,4 +5,20 @@ metaDesc: 'Learn about the accessibility of the Open Web Advocacy website.'
 layout: 'layouts/page.njk'
 ---
 
-Maecenas sed diam eget risus varius blandit sit amet non magna. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nullam id dolor id nibh ultricies vehicula ut id elit. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+This accessibility statement applies to this current website you're visiting (https://open-web-advocacy.org/).
+
+This website is run by the Open Web Advocacy group members. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+- Zoom in up to 300% without the text spilling off the screen.
+- Navigate most of the website using just a keyboard.
+- Navigate most of the website using speech recognition software.
+- Listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver).
+
+We’ve also made the website text as simple as possible to understand.
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please
+[raise an issue via GitHub](https://github.com/OpenWebAdvocacy/website/issues) or [raise your concerns on Discord](https://discord.gg/x53hkqrRKx).
+

--- a/src/pages/accessibility.md
+++ b/src/pages/accessibility.md
@@ -19,6 +19,6 @@ We’ve also made the website text as simple as possible to understand.
 
 ## Reporting accessibility problems with this website
 
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please
+We’re always looking to improve the accessibility of this website. If you find any accessibility problems, or think we’re not meeting accessibility requirements, please
 [raise an issue via GitHub](https://github.com/OpenWebAdvocacy/website/issues) or [raise your concerns on Discord](https://discord.gg/x53hkqrRKx).
 


### PR DESCRIPTION
## Summary of Changes

This PR simply adds some initial accessibility page content, just enough to cover the basics to for going live.
The content is following [gov.uk guidance](https://www.gov.uk/government/publications/sample-accessibility-statement/sample-accessibility-statement-for-a-fictional-public-sector-website), and [gov.uk's own accessibility statement](https://www.gov.uk/help/accessibility-statement) although I've cut it down to just the essentials for us, as a advocacy group site (Compared to a government body). 

I've avoided listing anything that assures process/compliance/support as it's not really my place to assure anything on behalf of the project, and I'm not sure that's required in the scope of our site.

When the site's a bit further along, we could define the standards we're striving to meet and potentially our compliance status but, for the scope of this initial version in this PR, I'm just aiming to have something presentable that covers fundamentals which provides a method of reporting issues.