### PR TITLE
Added some initial privacy page content

### DIFF
--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,7 +1,63 @@
 ---
 title: 'Privacy Policy'
 permalink: '/privacy/'
+metaDesc: 'Learn about your privacy when using the Open Web Advocacy website.'
 layout: 'layouts/page.njk'
 ---
 
-Maecenas sed diam eget risus varius blandit sit amet non magna. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nullam id dolor id nibh ultricies vehicula ut id elit. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+This website is provided by the members of the Open Web Advocacy group.
+
+## What data we collect
+
+The personal data we collect from you includes:
+
+- Questions, queries or feedback you leave, including your name & email address if you contact us via email.
+
+We use Netlify as our hosting provider for this website. Details regarding the information they collect can be found on their [data protection commitment page](https://www.netlify.com/gdpr-ccpa).
+
+## Why we need your data
+
+We collect your personal data in order to:
+
+- Gather feedback to improve our services.
+- Respond to any feedback you send us, if you’ve asked us to.
+
+## What we do with your data
+
+We will share your data if we are required to do so by law - for example, by court order, or to prevent fraud or other crime.
+
+We will not:
+
+- Sell or rent your data to third parties.
+- Share your data with third parties for their marketing purposes.
+
+## Linked content & services
+
+If you follow a link to a service or website, that is not directly part of this https://open-web-advocacy.org website, you will be subject to the privacy terms of that service
+or website instead of the terms laid out here.
+
+### Commonly linked services
+
+Below is a non-exhaustive list of services we knowingly link to within our site, along with that service's privacy terms:
+
+- Discord - [Privacy Policy](https://discord.com/privacy)
+- Twitter - [Privacy Policy](https://twitter.com/en/privacy)
+
+## Children’s privacy protection
+
+Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain data about anyone under the age of 13.
+
+## Contact us or make a complaint
+
+Contact us via [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org) if you:
+
+- Have a question about anything in this privacy notice.
+- Think that your personal data has been misused or mishandled.
+
+If you have any concerns about our use of your personal information, you can make a complaint to us at the above email address or contact the local privacy authority for your region.
+
+## Changes to this policy
+
+We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.
+
+Last updated 31 March 2022


### PR DESCRIPTION
## Summary of Changes

This adds some initial content for the privacy page.
I somewhat used the [gov.uk privacy page](https://www.gov.uk/help/privacy-notice) as a rough template, Altering to the current state of the site while being careful not to place any additional responsibility burdens upon the group managers/owners.

The main intent here is to have enough to go live with, which can then be adapted in the future as required. 