### PR TITLE
Created new "paper" layout for walled gardens (and similar future papers) and updated TOC to use auto-generated header links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,8 +41,8 @@ module.exports = config => {
   // Pass through css
   config.addPassthroughCopy('./src/css');
 
-  // Pass through papers
-  config.addPassthroughCopy('./src/papers');
+  // Pass through files
+  config.addPassthroughCopy('./src/files');
 
   // Set custom markdown library
   config.setLibrary('md', buildMarkdownLibrary());

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 // Eleventy Plugins
 const rssPlugin = require('@11ty/eleventy-plugin-rss');
+const tocPlugin = require('eleventy-plugin-toc');
 
 // Markdown Libraries
 const markdownIt = require('markdown-it');
@@ -8,6 +9,7 @@ const markdownItAnchor = require('markdown-it-anchor');
 // Filters
 const dateFilter = require('./src/filters/date-filter.js');
 const w3DateFilter = require('./src/filters/w3-date-filter.js');
+const cleanTocFilter = require('./src/filters/clean-toc-filter.js');
 
 // Utils
 const sortByDisplayOrder = require('./src/utils/sort-by-display-order.js');
@@ -16,9 +18,14 @@ module.exports = config => {
   // Add filters
   config.addFilter('dateFilter', dateFilter);
   config.addFilter('w3DateFilter', w3DateFilter);
+  config.addFilter('cleanTocFilter', cleanTocFilter);
 
   // Plugins
   config.addPlugin(rssPlugin);
+  config.addPlugin(tocPlugin, {
+    tags: ['h2'],
+    ul: true,
+  });
 
   // Returns a collection of blog posts in reverse date order
   config.addCollection('blog', collection => {
@@ -33,6 +40,9 @@ module.exports = config => {
 
   // Pass through css
   config.addPassthroughCopy('./src/css');
+
+  // Pass through papers
+  config.addPassthroughCopy('./src/papers');
 
   // Set custom markdown library
   config.setLibrary('md', buildMarkdownLibrary());

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@11ty/eleventy-plugin-rss": "^1.1.2",
+        "eleventy-plugin-toc": "^1.1.5",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "moment": "^2.29.1"
@@ -460,6 +461,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -586,6 +592,41 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dependencies": {
         "is-regex": "^1.0.3"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "dependencies": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "dependencies": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -760,6 +801,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -841,12 +908,12 @@
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       },
       "funding": {
@@ -865,9 +932,9 @@
       ]
     },
     "node_modules/domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -879,9 +946,9 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -952,6 +1019,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eleventy-plugin-toc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-toc/-/eleventy-plugin-toc-1.1.5.tgz",
+      "integrity": "sha512-Fo5AZZSBH8CKvz0axJQA9nmnTFOflAMFrngaKER4rOz3C6oDwqxK8N+kNFepmIsieTPkrH+iREWLJ+/9j5JjUg==",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.10"
       }
     },
     "node_modules/emoji-regex": {
@@ -2198,6 +2273,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nunjucks": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
@@ -2311,6 +2397,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
     },
     "node_modules/parseqs": {
       "version": "0.0.6",
@@ -3271,6 +3370,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
@@ -3853,6 +3957,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3961,6 +4070,32 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
         "is-regex": "^1.0.3"
+      }
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "requires": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "requires": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
       }
     },
     "chokidar": {
@@ -4109,6 +4244,23 @@
         "vary": "^1"
       }
     },
+    "css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -4169,12 +4321,12 @@
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
@@ -4184,17 +4336,17 @@
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "requires": {
         "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -4246,6 +4398,14 @@
       "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
       "requires": {
         "jake": "^10.6.1"
+      }
+    },
+    "eleventy-plugin-toc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-toc/-/eleventy-plugin-toc-1.1.5.tgz",
+      "integrity": "sha512-Fo5AZZSBH8CKvz0axJQA9nmnTFOflAMFrngaKER4rOz3C6oDwqxK8N+kNFepmIsieTPkrH+iREWLJ+/9j5JjUg==",
+      "requires": {
+        "cheerio": "^1.0.0-rc.10"
       }
     },
     "emoji-regex": {
@@ -5172,6 +5332,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
     "nunjucks": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
@@ -5249,6 +5417,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "requires": {
+        "parse5": "^6.0.1"
+      }
     },
     "parseqs": {
       "version": "0.0.6",
@@ -6022,6 +6203,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "ua-parser-js": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@11ty/eleventy": "^1.0.0",
     "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-plugin-rss": "^1.1.2",
+    "eleventy-plugin-toc": "^1.1.5",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.4.1",
     "moment": "^2.29.1"

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -43,12 +43,12 @@
       <div class="inner-wrapper">
         <main tabindex="-1" id="main-content" class="inner">
           {% block content %}{% endblock %}
-          {% if isWG %}
+          {% if 'paper.njk' in layout %}
           {% else %}
             {% set postListItems = collections.blog %}
           {% endif %}
         </main>
-        {% if isWG %}
+        {% if 'paper.njk' in layout %}
         {% else %}
           {% include "partials/aside.njk" %}
         {% endif %}

--- a/src/_includes/layouts/paper.njk
+++ b/src/_includes/layouts/paper.njk
@@ -16,7 +16,7 @@
 
     {% if paperName %}
       <p class="download">You can also download the
-        <a href="/papers/{{ paperName }}.pdf">PDF version</a> [{{ paperSize}}]
+        <a href="/files/{{ paperName }}.pdf">PDF version</a> [{{ paperSize}}]
       </p>
     {% endif %}
   </div>

--- a/src/_includes/layouts/paper.njk
+++ b/src/_includes/layouts/paper.njk
@@ -1,0 +1,49 @@
+{% extends "layouts/base.njk" %}
+
+{% block content %}
+
+<article class="h-entry [ post ] [ flow ]">
+  <h1 class="p-name">{{ title }}</h1>
+  <div class="article-data">
+    {% if subtitle %}
+      <p class="baseline">{{ subtitle }}</p>
+    {% endif %}
+
+    <p class="p-author">
+      By <strong>Open Web Advocacy</strong>
+      <a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a>
+    </p>
+
+    {% if paperName %}
+      <p class="download">You can also download the
+        <a href="/papers/{{ paperName }}.pdf">PDF version</a> [{{ paperSize}}]
+      </p>
+    {% endif %}
+  </div>
+
+  <div class="grid3-1">
+
+    <div class="toc flow">
+
+      <details>
+        <summary>
+
+          <h2>1. Table of Contents</h2>
+
+        </summary>
+
+        <div class="flow">
+
+          {{ content | toc | cleanTocFilter | safe }}
+
+        </div>
+      </details>
+
+    </div>
+
+    <div class="content flow">
+      {{ content | safe }}
+    </div>
+  </div>
+</article>
+{% endblock %}

--- a/src/filters/clean-toc-filter.js
+++ b/src/filters/clean-toc-filter.js
@@ -1,0 +1,3 @@
+module.exports = value => {
+  return value.replace(/\>#/g, '>');
+};

--- a/src/pages/walled-gardens.md
+++ b/src/pages/walled-gardens.md
@@ -1,61 +1,14 @@
 ---
 title: 'Bringing Competition to Walled Gardens'
 permalink: '/walled-gardens-report/'
-layout: 'layouts/page.njk'
+layout: 'layouts/paper.njk'
 metaDesc: 'The full Bringing Competition to Walled Gardens report, published by Open Web Advocacy.'
-isWG: true
+subtitle: 'Third Party Browsers & Web Apps - VERSION 1.0'
+paperName: 'OWA - Bringing Competition to Walled Gardens - v1.0'
+paperSize: '9.2MB'
 ---
 
-<div class="article-data">
-  <p class="baseline">Third Party Browsers & Web Apps - VERSION 1.0</p>
-
-  <p class="p-author">
-    By <strong>Open Web Advocacy</strong>
-    <a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a>
-  </p>
-
-  <p class="download">You can also download the
-    <a href="https://open-web-advocacy.org/OWA - Bringing Competition to Walled Gardens - v1.0.pdf">PDF version</a> [8.9Mb]
-  </p>
-</div>
-
-<div class="grid3-1">
-
-<div class="toc flow">
-
-<details>
-<summary>
-
-## 1. Table of Contents
-
-</summary>
-
-<div class="flow">
-
-  <ul>
-    <li><a href="#sec02">Preface</a></li>
-    <li><a href="#sec03">Introduction</a></li>
-    <li><a href="#sec04">Effective competition?</a></li>
-    <li><a href="#sec05">Apple is Holding Back the Open Web</a></li>
-    <li><a href="#sec06">Negative Consequences for Consumers and Businesses</a></li>
-    <li><a href="#sec07">Apple's Incentives</a></li>
-    <li><a href="#sec08">Arguments Against Third Party Browsers</a></li>
-    <li><a href="#sec09">The Web Can Be Capable</a></li>
-    <li><a href="#sec10">The Future of the Web</a></li>
-    <li><a href="#sec11">Potential Regulatory Solutions</a></li>
-    <li><a href="#sec12">Bright Future for Competition</a></li>
-    <li><a href="#sec13">Further Reading</a></li>
-    <li><a href="#sec14">References</a></li>
-  </ul>
-
-</div>
-</details>
-
-</div>
-
-<div class="content flow">
-
-## <span id="sec02">2. Preface</span>
+## 2. Preface
 
 *To the Safari/Webkit Team*,
 
@@ -75,7 +28,7 @@ It is our hope that with this competition Apple will come to realize the great i
 
 **Thank-you for your hard work and for everything you’ve given us**, we hope you will continue to fight for a better open-web.
 
-## <span id="sec03">3. Introduction</span>
+## 3. Introduction
 
 The entire future of the **consumer application industry** is being heavily limited by Apple’s ban of third party browsers. These actions prevent cross-compatibility between devices, and create significant barriers for new market entrants. For businesses and consumers, it greatly increases costs and enables Apple to lock them into their closed ecosystem. This reduces competition for both browsers and applications, and shifts the cycle of investment and funding from an open and free platform to proprietary closed platforms, driving up prices for consumers and developers.
 
@@ -145,7 +98,7 @@ To the end user a well written Web App should be indistinguishable from a native
 
 **“Browser Vendor”** - The entity that makes the browser.
 
-## <span id="sec04">4. Effective Competition?</span>
+## 4. Effective Competition?
 
 > “Businesses that face effective competition dare not raise prices, or cut down on quality standards, for fear of losing customers to their competitors (and so losing money)” <br> [Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
 
@@ -164,7 +117,7 @@ Even Apple executives appear to be aware only their stranglehold on iOS installa
 > "Neither is on the store because they don't have to be. They can be on Mac and distribute to users without sharing the revenue with us" <br> [Philip Schiller - Apple Upper Management - On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
 
 
-## <span id="sec05">5. Apple is Holding Back the Open Web</span>
+## 5. Apple is Holding Back the Open Web
 
 > "Instead, Apple is inhibiting this future Internet. And it does so via tolls, controls, and technologies that not only deny what made and still makes the open web so powerful, but also prevents competition, and prioritize Apple’s own profits." <br>[Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)
 
@@ -956,7 +909,7 @@ Using IAB (In App Browsers) to deny users choice is a very complex topic. [This 
 It is our opinion that mass market operating systems and major applications should as much as possible provide users with the means of selecting a default browser (complete with its engine) and respect it. Additionally they should avoid using dark patterns or misleading interfaces to favour their own browser.
 
 
-## <span id="sec06">6. Negative Consequences for Consumers and Businesses</span>
+## 6. Negative Consequences for Consumers and Businesses
 
 It’s worth taking a moment to discuss why holding back the Web as an application platform, banning the rival browsers and having the iOS App Store be the only viable development platform on iOS is causing real harm to both consumers and businesses.
 
@@ -1020,7 +973,7 @@ One of the published emails allegedly sent by Apple's legal representatives -- d
 
 > "In Sweatshop HD’s case, what is in fact a tasteful commentary aiming to raise awareness of modern-day manufacturing commissions through bright, addictive gameplay mechanics — in other words, an artistic statement — is being banned because Apple seemingly doesn’t want that awareness being raised." <br> [John Brownlee - Cult of Mac](https://www.cultofmac.com/220790/why-apples-reason-for-kicking-a-sweatshop-game-out-of-the-app-store-is-total-hypocrisy/)
 
-## <span id="sec07">7. Apple's Incentives</span>
+## 7. Apple's Incentives
 
 
 ### 7.1. Advantages of the status quo for Apple
@@ -1098,7 +1051,7 @@ It could be argued this is an overly conspiratorial view of how Apple's manageme
 
 > “iMessage on Android would simply serve to remove [an] obstacle to iPhone families giving their kids Android phones ... moving iMessage to Android will hurt us more than help us, this email illustrates why.” <br> [Craig Federighi - Apple's Senior Vice President of Software Engineering](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)
 
-## <span id="sec08">8. Arguments Against Third Party Browsers</span>
+## 8. Arguments Against Third Party Browsers
 
 To our knowledge Apple has never published a detailed defense on why they feel justified in banning all rival third party browsers from iOS. That said, the following three sections contain arguments that others have made on Apple's behalf.
 
@@ -1268,7 +1221,7 @@ Apple is wildly inconsistent in how it approaches privacy on Native and on the W
 Apple's commitment to privacy on the web is admirable but the uneven enforcement between the iOS App Store where they command a 15-30% tax and the Web where they have none **implies that it is simply a tactical tool to block competition.**
 
 
-## <span id="sec09">9. The Web Can Be Capable</span>
+## 9. The Web Can Be Capable
 
 > “The fact that web apps aren’t able to fully compete with iOS apps **is an Apple problem, not a web problem**” <br> [Richard MacManus - NewsStack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation/)
 
@@ -1310,7 +1263,7 @@ Given how large Photoshop documents can be, Photoshop needs the ability to dynam
 Photoshop’s reputation as a demanding application demonstrates that nearly any sort of program can be delivered today as a Web App on a capable browser. Given the speed of progress in the best browsers, it’s hard to imagine that the gap between Native and Web in terms of performance/capability will not continue to shrink.
 
 
-## <span id="sec10">10. The Future of the Web</span>
+## 10. The Future of the Web
 
 If effective competition was restored to the mobile web then the advantages to users are:
 
@@ -1411,7 +1364,7 @@ Example of iOS permission settings screen:
 ![A view of the iOS permission settings screen for WeChat showing toggles for many iOS features](/images/walled-gardens/39_ios-permission-settings.png)
 
 
-## <span id="sec11">11. Potential Regulatory Solutions</span>
+## 11. Potential Regulatory Solutions
 
 To bring effective competition to both browsers on iOS and to allow Web Apps to effectively compete with the App Store (as Apple has suggested they can), regulation should mandate opening up iOS to true third-party browsers, complete with their own engines.
 
@@ -1554,7 +1507,7 @@ These proposed regulations should be subject to an open comment period to allow 
 <sup>2</sup> A browser engine (also known as a layout engine or rendering engine) is a core software component of every major web browser. The primary job of a browser engine is to transform HTML documents and other resources of a web page into an interactive visual representation on a user's device.
 
 
-## <span id="sec12">12. Bright Future for Competition</span>
+## 12. Bright Future for Competition
 
 If third party browsers were allowed, with full access to all the APIs that Apple gives Safari, this would provide Apple the incentive to keep pace with the other browsers and give consumers a means of voting with their feet by moving to a competing browser if they fail to do so.
 
@@ -1567,7 +1520,7 @@ A ban on third-party browsers benefits Apple and harms users, developers and bus
 **Competition not walled gardens leads to the best outcomes.**
 
 
-## <span id="sec13">13. Further Reading</span>
+## 13. Further Reading
 
 
 ### 13.1. Alex Russell - Browser Choice Must Matter
@@ -1598,7 +1551,7 @@ Bruce Lawson presentation to the UK’s Competition and Markets Authority about 
 Stuart Langridge’s presentation to the UK’s Competition and Markets Authority about various privacy and security aspects on iOS.
 
 
-## <span id="sec14">14. References</span>
+## 14. References
 
 - Thomas Claburn - *The Register* -  <a href="https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/#:~:text=We%20asked%20Apple%20about%20the%20IndexedDB%20bug%20and%20whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition.%20We%20would%20be%20stunned%20if%20it%20chose%20to%20reply" data-title="On Safari Underfunding">On Safari Underfunding</a>
 
@@ -1825,6 +1778,3 @@ New York Times on privacy and native apps tracking</a>
 - Bennett Cyphers - *Electronic Freedom Foundation* -
 <a href="https://www.eff.org/deeplinks/2020/06/apples-response-hey-showcases-whats-most-broken-about-apple-app-store" data-title="On harvesting data via native apps">
 On harvesting data via native apps</a>
-
-  </div>
-</div>


### PR DESCRIPTION
## Summary of Changes

- Added plugin to generate table-of-contents from auto-generated header links.
- Added filter to clean toc plugin output to remove hash characters.
- Created new "paper" layout for papers such as walled-gardens, which extracts some of the metadata to frontmatter and cleans up the original walled-gardens content to not have so much structural HTML mixed in. This new paper layout can then be re-used by other similar papers.
- Renamed 'static' directory to 'papers' and passed this through to the output content so we can link to papers on the site.
- Removed `isWG` frontmatter variable and instead look-up the layout in use instead of use this variable to drive base template changes. 