### PR TITLE
add netlify deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Web Advocacy Website
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/6ca86e2c-f78f-4dee-a51d-6699afe30e2c/deploy-status)](https://app.netlify.com/sites/cool-elf-8eb15a/deploys)
+
 This repository contains the source code for and notes related to the Open Web Advocacy website.
 
 The Open Web Advocacy website resides at [open-web-advocacy.org](https://open-web-advocacy.org).


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Added Netlify deploy status badge to the README
<img width="595" alt="Screen Shot 2022-04-14 at 13 14 10" src="https://user-images.githubusercontent.com/895923/163439976-52c42e5f-dfa1-4816-bb3a-df52503df347.png">