### PR TITLE
chore: fix &ldquo: on a post our-response-cma-interim-report

### DIFF
--- a/src/posts/our-response-cma-interim-report.md
+++ b/src/posts/our-response-cma-interim-report.md
@@ -128,16 +128,16 @@ prevent gaming by Apple.
 
 ## 3. Effective Competition?
 
-> &ldquo:Businesses that face effective competition dare not raise prices, or cut down on quality
+> &ldquo;Businesses that face effective competition dare not raise prices, or cut down on quality
 > standards, for fear of losing customers to their competitors (and so losing money)&rdquo;
 >
 > &mdash; [Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
 
-> &ldquo:For the foreseeable future, iOS will be the dominant access pathway, passport,
+> &ldquo;For the foreseeable future, iOS will be the dominant access pathway, passport,
 > monetizer and platform for not just digital life, but virtual ones. Apple holds this role
 > because it makes best-in-class hardware, offers the best apps, and operates the most
 > lucrative app store.&rdquo;
->    
+>
 > &mdash; [Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)
 
 iOS Safari faces no effective competition as Apple has banned competing engines. These


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->

None.

## Summary of Changes

1. [x] Strings `&ldquo:` are appeared instead `"` at "Our response to the CMA interim report"  

| Before        | After         |
| ------------- |:-------------:|
| <img width="666" alt="CleanShot 2022-06-11 at 10 04 52@2x" src="https://user-images.githubusercontent.com/28534/173166637-048b9e6f-a4e6-418c-a426-cf47caab33d5.png">  |  <img width="685" alt="CleanShot 2022-06-11 at 10 05 17@2x" src="https://user-images.githubusercontent.com/28534/173166658-d2a06d0b-dc1d-4fc5-a38a-683b958ff19a.png"> |
