### PR TITLE
Added page to list contents of files folder

### DIFF
--- a/src/_data/files.js
+++ b/src/_data/files.js
@@ -1,0 +1,34 @@
+const fsPromises = require('node:fs/promises');
+const path = require('path');
+
+
+function formatBytesToSizeString(bytes) {
+  const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const suffixIndex = Math.floor((String(bytes).length - 1) / 3);
+  const scaledBytes = bytes / Math.pow(1000, suffixIndex);
+  const decimals = (scaledBytes > 100 || suffixIndex === 0) ? 0 : 1;
+  return `${scaledBytes.toFixed(decimals)}${suffixes[suffixIndex]}`;
+}
+
+async function fileToDetails(fileDir, fileName) {
+
+  const fullPath = path.join(fileDir, fileName);
+  const details = await fsPromises.stat(fullPath);
+
+  return {
+    name: fileName,
+    size: formatBytesToSizeString(details.size),
+    uri: `/files/${encodeURIComponent(fileName)}`
+  }
+}
+
+module.exports = async function() {
+
+  const filesDir = path.join(__dirname, '../files');
+  const fileNames = await fsPromises.readdir(filesDir);
+  const filePromises = fileNames.map(name => fileToDetails(filesDir, name));
+  const files = await Promise.all(filePromises);
+  files.sort((a, b) => a.name - b.name);
+
+  return files;
+};

--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -29,6 +29,10 @@
     {
       "text": "Glossary",
       "url": "/glossary/"
+    },
+    {
+      "text": "Files",
+      "url": "/files/"
     }
   ]
 }

--- a/src/pages/files.html
+++ b/src/pages/files.html
@@ -1,0 +1,14 @@
+---
+title: 'Files'
+permalink: '/files/'
+metaDesc: 'An index of the documents available on the site'
+layout: 'layouts/page.njk'
+---
+
+<p>Here is a list of files available in this directory of the site:</p>
+
+<ul>
+  {% for file in files %}
+    <li><a href="{{ file.uri }}">{{ file.name }}</a> [{{ file.size }}]</li>
+  {% endfor %}
+</ul


### PR DESCRIPTION
## Summary of Changes

This parses and loads the contents of the 'src/files' directory and makes the file details available as `files` eleventy data which is then used to create an index page for the files directory, at the /files/ uri.
This also adds the new files index page as a footer link for easy access.

[Page preview here](https://deploy-preview-29--owa-production.netlify.app/files/).

### Context

After the recent addition of more files in this directory, I questioned the usefullness of adding an index page, to which Matt replied saying such a page would be great. [Discord Discussion](https://discord.com/channels/945208532930822155/948084147837075477/988764733735845919).

### Notes

The list is sorted by name, but the "Subverting Competition" doc shows first due to a double spacing around the hyphen. I'll look to address that separately (Need to check that the link is not in use).