### PR TITLE
Set socialImage to site.url + site.logo if it's not set

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -2,5 +2,6 @@
   "name": "Open Web Advocacy",
   "url": "https://open-web-advocacy.org",
   "authorName": "Open Web Advocacy",
-  "authorEmail": "contactus@open-web-advocacy.org"
+  "authorEmail": "contactus@open-web-advocacy.org",
+  "logo": "/images/logo-192.png"
 }

--- a/src/_includes/partials/meta-info.njk
+++ b/src/_includes/partials/meta-info.njk
@@ -1,14 +1,15 @@
 {% set pageTitle = title + ' - ' + site.name %}
+{% set socialImage = site.url + site.logo if not socialImage %}
 
 {# We don't want any duplication. This is likely for the homepage #}
-{% if site.name === title %} 
+{% if site.name === title %}
   {% set pageTitle = title %}
 {% endif %}
 
 {% set siteTitle = site.name %}
 {% set currentUrl = site.url + page.url %}
 
-{# If the page’s frontmatter has specific metaTitle and/or metaDesc items, switch 
+{# If the page’s frontmatter has specific metaTitle and/or metaDesc items, switch
   them into the mix #}
 {% if metaTitle %}
   {% set pageTitle = metaTitle %}
@@ -17,7 +18,6 @@
 {% if not metaDesc %}
   {% set metaDesc = summary %}
 {% endif %}
-
 
 <title>{{ pageTitle }}</title>
 <link rel="canonical" href="{{ currentUrl }}" />


### PR DESCRIPTION
## Related Issue

None, this is a hotfix

## Summary of Changes

Sets `socialImage` to `site.url + site.logo` if it's not set yet, making sure every page has a value for `og:image`