### PR TITLE
Press page improvements

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -45,6 +45,22 @@ module.exports = config => {
     return [...collection.getFilteredByGlob('./src/posts/*.md')].reverse();
   });
 
+  // Returns press-links grouped by year (descending): [{ year, entries },...]
+  config.addCollection('press', collection => {
+    const pressData = collection.getAll().filter(item => item.data.press)[0]?.data?.press || [];
+    const yearlyMap = pressData.reduce((acc, item) => {
+      const year = new Date(item.date).getFullYear();
+      if (!acc.has(year)) acc.set(year, []);
+      acc.get(year).push(item);
+      return acc;
+    }, new Map());
+    const yearlyData = Array.from(yearlyMap.entries()).map(([ year, entries ]) => ({
+      year,
+      entries: entries.sort((a, b) => new Date(b.date) - new Date(a.date))
+    })).sort((a, b) => b.year - a.year);
+    return yearlyData;
+  });
+
   // Tell 11ty to use the .eleventyignore and ignore our .gitignore file
   config.setUseGitIgnore(false);
 

--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -13,6 +13,10 @@
       "url": "/blog/"
     },
     {
+      "text": "Press coverage",
+      "url": "/press/"
+    },
+    {
       "text": "Walled Gardens Report",
       "url": "/walled-gardens-report/"
     },

--- a/src/_data/press.json
+++ b/src/_data/press.json
@@ -1,32 +1,46 @@
 [
   {
     "url": "https://appleinsider.com/articles/22/03/01/web-devs-create-advocacy-group-aimed-at-relaxing-ios-browser-restrictions",
-    "title": "Web devs create advocacy group aimed at relaxing iOS browser restrictions"
+    "title": "Web devs create advocacy group aimed at relaxing iOS browser restrictions",
+    "date": "2022-03-02",
+    "publisher": "AppleInsider"
   },
   {
     "url": "https://www.computerworld.com/article/3652348/developers-push-back-against-apple-ban-on-third-party-browsers.amp.html",
-    "title": "Developers push back against Apple 'ban' on third-party browsers"
+    "title": "Developers push back against Apple 'ban' on third-party browsers",
+    "date": "2022-03-02",
+    "publisher": "Computerworld"
   },
   {
     "url": "https://www.theregister.com/2022/02/28/apple_apps_challenge/",
-    "title": "Web devs rally to challenge Apple App Store browser rules"
+    "title": "Web devs rally to challenge Apple App Store browser rules",
+    "date": "2022-02-28",
+    "publisher": "The Register"
   },
   {
     "url": "https://www.macrumors.com/2022/03/02/web-devs-advocacy-group-browser-engines-ios/",
-    "title": "Web Developers Form Advocacy Group to Allow Other Browser Engines on iOS"
+    "title": "Web Developers Form Advocacy Group to Allow Other Browser Engines on iOS",
+    "date": "2022-03-02",
+    "publisher": "MacRumors"
   },
   {
     "url": "https://thenewstack.io/owa-takes-on-apples-browser-ban-for-pwa-parity/",
-    "title": "OWA Takes on Apple’s Browser Ban for PWA Parity"
+    "title": "OWA Takes on Apple’s Browser Ban for PWA Parity",
+    "date": "2022-03-17",
+    "publisher": "The New Stack"
   },
   {
     "url": "https://www.heise.de/news/Browser-Web-Entwickler-fuer-Ende-von-WebKit-Zwang-auf-iPhones-6533101.html",
     "title": "Browser: Web-Entwickler für Ende von WebKit-Zwang auf iPhones",
+    "date": "2022-03-02",
+    "publisher": "Heise",
     "lang": "de"
   },
   {
     "url": "https://ios.developpez.com/actu/331527/Les-developpeurs-Web-se-mobilisent-pour-contester-les-regles-de-navigation-de-l-App-Store-d-Apple-l-Open-Web-Advocacy-s-attaque-au-jardin-clos-d-Apple/",
     "title": "Les développeurs Web se mobilisent pour contester les règles de navigation de l'App Store d'Apple",
+    "date": "2022-03-02",
+    "publisher": "developpez.com",
     "lang": "fr"
   }
 ]

--- a/src/_data/press.json
+++ b/src/_data/press.json
@@ -2,45 +2,39 @@
   {
     "url": "https://appleinsider.com/articles/22/03/01/web-devs-create-advocacy-group-aimed-at-relaxing-ios-browser-restrictions",
     "title": "Web devs create advocacy group aimed at relaxing iOS browser restrictions",
-    "date": "2022-03-02",
-    "publisher": "AppleInsider"
+    "date": "2022-03-02"
   },
   {
     "url": "https://www.computerworld.com/article/3652348/developers-push-back-against-apple-ban-on-third-party-browsers.amp.html",
     "title": "Developers push back against Apple 'ban' on third-party browsers",
-    "date": "2022-03-02",
-    "publisher": "Computerworld"
+    "date": "2022-03-02"
   },
   {
     "url": "https://www.theregister.com/2022/02/28/apple_apps_challenge/",
     "title": "Web devs rally to challenge Apple App Store browser rules",
-    "date": "2022-02-28",
-    "publisher": "The Register"
+    "publisher": "The Register",
+    "date": "2022-02-28"
   },
   {
     "url": "https://www.macrumors.com/2022/03/02/web-devs-advocacy-group-browser-engines-ios/",
     "title": "Web Developers Form Advocacy Group to Allow Other Browser Engines on iOS",
-    "date": "2022-03-02",
-    "publisher": "MacRumors"
+    "date": "2022-03-02"
   },
   {
     "url": "https://thenewstack.io/owa-takes-on-apples-browser-ban-for-pwa-parity/",
     "title": "OWA Takes on Apple’s Browser Ban for PWA Parity",
-    "date": "2022-03-17",
-    "publisher": "The New Stack"
+    "date": "2022-03-17"
   },
   {
     "url": "https://www.heise.de/news/Browser-Web-Entwickler-fuer-Ende-von-WebKit-Zwang-auf-iPhones-6533101.html",
     "title": "Browser: Web-Entwickler für Ende von WebKit-Zwang auf iPhones",
     "date": "2022-03-02",
-    "publisher": "Heise",
     "lang": "de"
   },
   {
     "url": "https://ios.developpez.com/actu/331527/Les-developpeurs-Web-se-mobilisent-pour-contester-les-regles-de-navigation-de-l-App-Store-d-Apple-l-Open-Web-Advocacy-s-attaque-au-jardin-clos-d-Apple/",
     "title": "Les développeurs Web se mobilisent pour contester les règles de navigation de l'App Store d'Apple",
     "date": "2022-03-02",
-    "publisher": "developpez.com",
     "lang": "fr"
   }
 ]

--- a/src/_data/press.json
+++ b/src/_data/press.json
@@ -1,0 +1,32 @@
+[
+  {
+    "url": "https://appleinsider.com/articles/22/03/01/web-devs-create-advocacy-group-aimed-at-relaxing-ios-browser-restrictions",
+    "title": "Web devs create advocacy group aimed at relaxing iOS browser restrictions"
+  },
+  {
+    "url": "https://www.computerworld.com/article/3652348/developers-push-back-against-apple-ban-on-third-party-browsers.amp.html",
+    "title": "Developers push back against Apple 'ban' on third-party browsers"
+  },
+  {
+    "url": "https://www.theregister.com/2022/02/28/apple_apps_challenge/",
+    "title": "Web devs rally to challenge Apple App Store browser rules"
+  },
+  {
+    "url": "https://www.macrumors.com/2022/03/02/web-devs-advocacy-group-browser-engines-ios/",
+    "title": "Web Developers Form Advocacy Group to Allow Other Browser Engines on iOS"
+  },
+  {
+    "url": "https://thenewstack.io/owa-takes-on-apples-browser-ban-for-pwa-parity/",
+    "title": "OWA Takes on Apple’s Browser Ban for PWA Parity"
+  },
+  {
+    "url": "https://www.heise.de/news/Browser-Web-Entwickler-fuer-Ende-von-WebKit-Zwang-auf-iPhones-6533101.html",
+    "title": "Browser: Web-Entwickler für Ende von WebKit-Zwang auf iPhones",
+    "lang": "de"
+  },
+  {
+    "url": "https://ios.developpez.com/actu/331527/Les-developpeurs-Web-se-mobilisent-pour-contester-les-regles-de-navigation-de-l-App-Store-d-Apple-l-Open-Web-Advocacy-s-attaque-au-jardin-clos-d-Apple/",
+    "title": "Les développeurs Web se mobilisent pour contester les règles de navigation de l'App Store d'Apple",
+    "lang": "fr"
+  }
+]

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -941,12 +941,16 @@ ul.press-list {
   margin: 2rem 0;
 }
 
-ul.press-list li {
+ul.press-list > li {
   display: flex;
   gap: 1rem;
 }
 
-ul.press-list li::before {
+ul.press-list .press-entry .press-date {
+  font-size: small;
+}
+
+ul.press-list > li::before {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -961,17 +965,17 @@ ul.press-list li::before {
   border-radius: 100%;
 }
 
-ul.press-list [lang="fr"]::before {
+ul.press-list > li[lang="fr"]::before {
   content: "FR";
   background-color: #369;
 }
 
-ul.press-list [lang="de"]::before {
+ul.press-list > li[lang="de"]::before {
   content: "DE";
   background-color: #B26C03;
 }
 
-ul.press-list [lang="it"]::before {
+ul.press-list > li[lang="it"]::before {
   content: "IT";
   background-color: var(--highlight-color);
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -946,7 +946,7 @@ ul.press-list > li {
   gap: 1rem;
 }
 
-ul.press-list .press-entry .press-date {
+ul.press-list .press-entry .press-details {
   font-size: small;
 }
 

--- a/src/filters/hostname-filter.js
+++ b/src/filters/hostname-filter.js
@@ -1,0 +1,8 @@
+module.exports = url => {
+  var url = new URL(url);
+  var hostname = url.hostname;
+  if (hostname.startsWith('www.')) {
+    hostname = hostname.slice(4);
+  }
+  return hostname;
+};

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -8,27 +8,11 @@ layout: 'layouts/page.njk'
 <p>Here are links to the press coverage OWA has received thus far:</p>
 
 <ul class="press-list">
-  <li><a href="https://appleinsider.com/articles/22/03/01/web-devs-create-advocacy-group-aimed-at-relaxing-ios-browser-restrictions">
-    Web devs create advocacy group aimed at relaxing iOS browser restrictions</a>
-  </li>
-  <li><a href="https://www.computerworld.com/article/3652348/developers-push-back-against-apple-ban-on-third-party-browsers.amp.html">
-    Developers push back against Apple 'ban' on third-party browsers</a>
-  </li>
-  <li><a href="https://www.theregister.com/2022/02/28/apple_apps_challenge/">
-    Web devs rally to challenge Apple App Store browser rules</a>
-  </li>
-  <li><a href="https://www.macrumors.com/2022/03/02/web-devs-advocacy-group-browser-engines-ios/">
-    Web Developers Form Advocacy Group to Allow Other Browser Engines on iOS</a>
-  </li>
-  <li><a href="https://thenewstack.io/owa-takes-on-apples-browser-ban-for-pwa-parity/">
-    OWA Takes on Apple’s Browser Ban for PWA Parity</a>
-  </li>
-  <li lang="de"><a href="https://www.heise.de/news/Browser-Web-Entwickler-fuer-Ende-von-WebKit-Zwang-auf-iPhones-6533101.html">
-    Browser: Web-Entwickler für Ende von WebKit-Zwang auf iPhones</a>
-  </li>
-  <li lang="fr"><a href="https://ios.developpez.com/actu/331527/Les-developpeurs-Web-se-mobilisent-pour-contester-les-regles-de-navigation-de-l-App-Store-d-Apple-l-Open-Web-Advocacy-s-attaque-au-jardin-clos-d-Apple/">
-    Les développeurs Web se mobilisent pour contester les règles de navigation de l'App Store d'Apple</a>
-  </li>
+  {% for entry in press %}
+    <li lang="{{ entry.lang | default('en') }}">
+      <a href="{{ entry.url }}">{{ entry.title }}</a>
+    </li>
+  {% endfor %}
 </ul>
 
 <p><strong>Last updated:</strong> <time datetime="2022-03-17">March 17th, 2022</time></p>

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -52,4 +52,4 @@ layout: 'layouts/page.njk'
 {% endfor %}
 {% endif %}
 
-<p><strong>Last updated:</strong> <time datetime="2022-03-17">March 17th, 2022</time></p>
+<p><strong>Last updated:</strong> <time datetime="2024-02-19">Feb 19th, 2024</time></p>

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -7,17 +7,20 @@ layout: 'layouts/page.njk'
 
 <p>Here are links to the press coverage OWA has received thus far:</p>
 
+{% for yearlyData in collections.press %}
+<h3 id="{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
 <ul class="press-list">
-  {% for entry in press %}
-    <li lang="{{ entry.lang | default('en') }}">
-      <div class="press-entry">
-        <a href="{{ entry.url }}">{{ entry.title }}</a>
-        <div class="press-date">
-          published by {{ entry.publisher }}, <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
-        </div>
+  {% for entry in yearlyData.entries %}
+  <li lang="{{ entry.lang | default('en') }}">
+    <div class="press-entry">
+      <a href="{{ entry.url }}">{{ entry.title }}</a>
+      <div class="press-date">
+        published by {{ entry.publisher }}, <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
       </div>
-    </li>
+    </div>
+  </li>
   {% endfor %}
 </ul>
+{% endfor %}
 
 <p><strong>Last updated:</strong> <time datetime="2022-03-17">March 17th, 2022</time></p>

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -10,7 +10,12 @@ layout: 'layouts/page.njk'
 <ul class="press-list">
   {% for entry in press %}
     <li lang="{{ entry.lang | default('en') }}">
-      <a href="{{ entry.url }}">{{ entry.title }}</a>
+      <div class="press-entry">
+        <a href="{{ entry.url }}">{{ entry.title }}</a>
+        <div class="press-date">
+          published by {{ entry.publisher }}, <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
+        </div>
+      </div>
     </li>
   {% endfor %}
 </ul>

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -5,22 +5,51 @@ metaDesc: 'The Open Web Advocacy on the Press'
 layout: 'layouts/page.njk'
 ---
 
-<p>Here are links to the press coverage OWA has received thus far:</p>
+{% macro pressEntry(entry) %}
+<li lang="{{ entry.lang | default('en') }}">
+  <div class="press-entry">
+    <a href="{{ entry.url }}">{{ entry.title }}</a>
+    <div class="press-details">
+      {% if entry.publisher %}
+      published by "{{ entry.publisher }}"
+      {% else %}
+      published on {{ entry.url | hostnameFilter }}
+      {% endif %}
+      {% if entry.date %}
+      - <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
+      {% endif %}
+    </div>
+  </div>
+</li>
+{% endmacro %}
 
-{% for yearlyData in collections.press %}
-<h3 id="{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+
+{% if collections.links | length > 0 %}
+<h2>Related links</h2>
+{% for yearlyData in collections.links %}
+{% if collections.links | length > 1 %}
+<h3 id="related_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
 <ul class="press-list">
   {% for entry in yearlyData.entries %}
-  <li lang="{{ entry.lang | default('en') }}">
-    <div class="press-entry">
-      <a href="{{ entry.url }}">{{ entry.title }}</a>
-      <div class="press-date">
-        published by {{ entry.publisher }}, <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
-      </div>
-    </div>
-  </li>
+  {{ pressEntry(entry) }}
   {% endfor %}
 </ul>
 {% endfor %}
+{% endif %}
+
+{% if collections.press | length > 0 %}
+<h2>OWA Press mentions</h2>
+{% for yearlyData in collections.press %}
+{% if collections.press | length > 1 %}
+<h3 id="owa_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
+<ul class="press-list">
+  {% for entry in yearlyData.entries %}
+  {{ pressEntry(entry) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endif %}
 
 <p><strong>Last updated:</strong> <time datetime="2022-03-17">March 17th, 2022</time></p>

--- a/src/posts/apple-dma-changes.md
+++ b/src/posts/apple-dma-changes.md
@@ -3,7 +3,7 @@ title: "Apple's plan to allow browser competition dubbed unworkable"
 date: '2024-01-27'
 tags: ['Policy', 'Apple', 'EU']
 author: "James Moore"
-relatedLink:
+relatedLinks:
   - url: https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/
     title: Apple announces changes to iOS, Safari, and the App Store in the European Union
     date: 2024-01-25

--- a/src/posts/apple-dma-changes.md
+++ b/src/posts/apple-dma-changes.md
@@ -3,6 +3,10 @@ title: "Apple's plan to allow browser competition dubbed unworkable"
 date: '2024-01-27'
 tags: ['Policy', 'Apple', 'EU']
 author: "James Moore"
+relatedLink:
+  - url: https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/
+    title: Apple announces changes to iOS, Safari, and the App Store in the European Union
+    date: 2024-01-25
 ---
 
 The #AppleBrowserBan Ends in the EU!

--- a/src/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
+++ b/src/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
@@ -3,6 +3,10 @@ title: "Apple on course to break all Web Apps in EU within 20 days"
 date: '2024-02-15'
 tags: ['Apple', 'EU', 'Safari']
 author: "OWA"
+relatedLinks:
+  - url: https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
+    title: Safari 17.4 Beta Release Notes
+    date: 2024-02-13
 ---
 
 

--- a/src/posts/developers-react-apple-eu-dma-compliance.md
+++ b/src/posts/developers-react-apple-eu-dma-compliance.md
@@ -3,6 +3,11 @@ title: "Web Developers React to Apple’s DMA Compliance Proposal"
 date: '2024-01-31'
 tags: ['Policy', 'Apple', 'EU']
 author: "Frances Berriman"
+relatedLinks:
+  - url: https://wptavern.com/eu-regulatory-success-prompts-open-source-cms-leaders-to-form-alliance
+    title: EU Regulatory Success Prompts Open-Source CMS Leaders to Form Alliance
+    publisher: "WP Tavern"
+    date: 2024-02-16
 ---
 
 {% image

--- a/src/posts/its-official-apple-kills-web-apps-in-the-eu.md
+++ b/src/posts/its-official-apple-kills-web-apps-in-the-eu.md
@@ -3,6 +3,10 @@ title: "It’s Official, Apple Kills Web Apps in the EU"
 date: '2024-02-16'
 tags: ['Apple', 'EU', 'Safari']
 author: "OWA"
+relatedLinks:
+  - url: https://developer.apple.com/support/dma-and-apps-in-the-eu#8
+    title: Why don't users in the EU have access to Home Screen web apps?
+    date: 2024-02-19
 ---
 
 <div class="prom-banner" style="max-width: 30em;">

--- a/src/utils/group-entries-by-year.js
+++ b/src/utils/group-entries-by-year.js
@@ -1,0 +1,13 @@
+module.exports = entries => {
+  const yearlyMap = entries.reduce((acc, item) => {
+    const year = new Date(item.date).getFullYear();
+    if (!acc.has(year)) acc.set(year, []);
+    acc.get(year).push(item);
+    return acc;
+  }, new Map());
+  const yearlyData = Array.from(yearlyMap.entries()).map(([ year, entries ]) => ({
+    year,
+    entries: entries.sort((a, b) => new Date(b.date) - new Date(a.date))
+  })).sort((a, b) => b.year - a.year);
+  return yearlyData;
+}

--- a/src/utils/page-details.js
+++ b/src/utils/page-details.js
@@ -1,0 +1,21 @@
+/**
+ * TODO: this function could be use to load missing data like date, description, etc. if only a url sting was provided.
+ * @param {LinkInfo} link 
+ * @returns Object with url, title and date
+ */
+async function loadPageDetails(link) {
+
+  if (typeof link === "string") {
+    return {
+      url: link,
+      title: link.title | "<<title>> missing",
+      date: link.data | new Date(),
+    }
+  } else {
+    return link;
+  }
+}
+
+module.exports = {
+  loadPageDetails
+}


### PR DESCRIPTION
- [x] Make it easy to add new articles in a data-file, the selection should be done by the core-team and discussed in a pull-request.
- [x] Add the existing /press page to the navigation so it can be reached.
- [x] Extend the existing links, to not only show  articles about the OWA itselfe, but other interesting links that have been referred to in the past.
- [x] Show links ordered by year of publication.
- [ ] Show a little preview-image, timestamp, tags and description instead of a simple link (if I find the time)
- [ ] Add filtering by tags (if I find the time)