### PR TITLE
updated link to press coverage

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -13,10 +13,6 @@
       "url": "/blog/"
     },
     {
-      "text": "Press coverage",
-      "url": "/press/"
-    },
-    {
       "text": "Walled Gardens Report",
       "url": "/walled-gardens-report/"
     },

--- a/src/_includes/partials/aside.njk
+++ b/src/_includes/partials/aside.njk
@@ -10,6 +10,7 @@
       </div>
     {% endif %}
     {% include "partials/promo.njk" %}
+    {% include "partials/press-coverage.njk" %}
   </aside>
 {% endblock %}
 

--- a/src/_includes/partials/press-coverage.njk
+++ b/src/_includes/partials/press-coverage.njk
@@ -1,0 +1,6 @@
+<div class="press-entry">
+  <h3>
+  <a href="/press">OWA Press Coverage</a>
+  </h3>
+  <p>Check out how the press is covering OWA actions.</p>
+</div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -422,10 +422,11 @@ div.promo {
   position: relative;
   padding-top: 1rem;
   margin-top: 2rem;
-  border-top: 2px solid var(--body-text);
+  border-top: 1px solid var(--body-text);
 }
 
 div.promo div.group {
+  --flow-space: 1rem;
   margin: 0;
 }
 
@@ -443,6 +444,17 @@ div.promo p.illustration img {
   box-shadow: 0 0 5px rgb(0 0 0 / 20%);
   transform: rotate(355deg);
 }
+
+aside div.press-entry {
+  --flow-space: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--n-dark);
+}
+
+div.promo h3, aside div.press-entry h3 {
+  font-size: calc(1rem + 0.5vw);
+}
+
 
 /* ---------------------- COMPONENTS -------------------- */
 

--- a/src/pages/press.html
+++ b/src/pages/press.html
@@ -1,5 +1,5 @@
 ---
-title: 'Press'
+title: 'Press Coverage'
 permalink: '/press/'
 metaDesc: 'The Open Web Advocacy on the Press'
 layout: 'layouts/page.njk'
@@ -24,11 +24,11 @@ layout: 'layouts/page.njk'
 {% endmacro %}
 
 
-{% if collections.links | length > 0 %}
-<h2>Related links</h2>
-{% for yearlyData in collections.links %}
-{% if collections.links | length > 1 %}
-<h3 id="related_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% if collections.press | length > 0 %}
+<h2>OWA Press mentions</h2>
+{% for yearlyData in collections.press %}
+{% if collections.press | length > 1 %}
+<h3 id="owa_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
 {% endif %}
 <ul class="press-list">
   {% for entry in yearlyData.entries %}
@@ -38,11 +38,11 @@ layout: 'layouts/page.njk'
 {% endfor %}
 {% endif %}
 
-{% if collections.press | length > 0 %}
-<h2>OWA Press mentions</h2>
-{% for yearlyData in collections.press %}
-{% if collections.press | length > 1 %}
-<h3 id="owa_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% if collections.links | length > 0 %}
+<h2>Related links</h2>
+{% for yearlyData in collections.links %}
+{% if collections.links | length > 1 %}
+<h3 id="related_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
 {% endif %}
 <ul class="press-list">
   {% for entry in yearlyData.entries %}


### PR DESCRIPTION
In press page:
1. Inverted related links with OWA press mentions
2. Modified title to "Press Coverage" instead of just "Press"

Elsewhere: 
1. Removed link to Press Coverage from main navigation
2. Create new partials with press coverage link
3.  Added link to press coverage to the aside block