### PR TITLE
Hotfix: Add contributors/john-ozbay.jpg, update data to point to jpg file

### DIFF
--- a/src/_data/contributors.json
+++ b/src/_data/contributors.json
@@ -202,7 +202,7 @@
     "name": "John Ozbay",
     "website": "https://crypt.ee/",
     "countries": ["Estonia🇪🇪", "Finland🇫🇮"],
-    "avatar": "john-ozbay.webp",
+    "avatar": "john-ozbay.jpg",
     "what": "Maker of weird things and Founder/CEO of Cryptee <a href='https://crypt.ee/'>crypt.ee</a>",
     "twitter": "johnozbay"
   },

--- a/src/images/contributors/john-ozbay.jpg
+++ b/src/images/contributors/john-ozbay.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a53aeacfe633535de9928f45ea7925a41e48161c79542daed1358c1aa90341b
+size 1197


### PR DESCRIPTION
## Summary of Changes

1. [x] Add missing photo of John Ozbay (contributors page)
2. [x] Update data to point to jpg file (instead of webp)