### PR TITLE
Add regex to filter <style> & <script> tags and their contents from excerpt

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,7 +29,7 @@ module.exports = config => {
   config.addFilter('w3DateFilter', w3DateFilter);
   config.addFilter('cleanTocFilter', cleanTocFilter);
   config.addFilter("excerpt", (post) => {
-    const content = post.replace(/(<([^>]+)>)/gi, "");
+    const content = post.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>|<[^>]*>/gi, "");
     return content.substr(0, content.lastIndexOf(" ", 400)) + "...";
   });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->

The CSS inside a `<style>` tag at the beginning of a blog post appears in the post excerpt on the `/news` page.

There is a filter for post excerpts that remove any HTML elements:

```js
// eleventy.js

module.exports = config => {
  // Add filters
  // ...other filters
  
  config.addFilter("excerpt", (post) => {
    const content = post.replace(/(<([^>]+)>)/gi, "");
    return content.substr(0, content.lastIndexOf(" ", 400)) + "...";
  });
  
  // ...more config
  
 }
```

While this works, the CSS inside a `<style>` tag remains in the excerpt.

## Summary of Changes

Added an additional regex to filter `<style>` and `<script>` tags including their contents:

```js
    const content = post.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>|<[^>]*>/gi, "");
```

### Before:

![Screenshot 2024-03-28 114934](https://github.com/OpenWebAdvocacy/website/assets/125431058/2b374f3b-dcab-4f75-ac94-dcb54c214966)

### After:

![Screenshot 2024-03-28 114943](https://github.com/OpenWebAdvocacy/website/assets/125431058/76851ab5-6f6e-4d30-93a5-3d77edb911df)


