### PR TITLE
Correct Canada spelling

### DIFF
--- a/src/_data/contributors.json
+++ b/src/_data/contributors.json
@@ -193,7 +193,7 @@
   },
   {
     "name": "Vincent Morneau",
-    "countries": ["Cananda🇨🇦"],
+    "countries": ["Canada🇨🇦"],
     "avatar": "vincent-morneau.jpg",
     "what": "Oracle, Principal Member of Technical Staff, Mobile and PWA Strategy Lead",
     "twitter": "vincentmorneau"
@@ -231,7 +231,7 @@
   },
   {
     "name": "Benny Powers",
-    "countries": ["Cananda🇨🇦","Israel🇮🇱"],
+    "countries": ["Canada🇨🇦","Israel🇮🇱"],
     "avatar": "benny-powers.png",
     "what": "Principal UX Engineer, Red Hat",
     "twitter": "PowersBenny",


### PR DESCRIPTION
## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->

Corrects the spelling of the word “Canada” in a few places on the [Contributors & Supporters page](https://open-web-advocacy.org/contributors/).
