### PR TITLE
Fix language picker icon not visible on coloured background header

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1376,22 +1376,19 @@ article.apple-dma-review div.toc details {
   display: inline-flex;
   position: absolute;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   top: 1rem;
   left: 1rem;
   color: var(--body-text);
   background-color: var(--body-bg);
-  padding: 0.25em;
+  padding-block: 0.25em;
+  padding-inline: 0.5em;
   cursor: pointer;
 }
 
 .language-picker svg {
   height: 1.25rem;
   width: 1.25rem;
-}
-
-.site-header .language-picker svg {
-  fill: var(--text-inv);
 }
 
 .home-header .language-picker {


### PR DESCRIPTION
## Summary of Changes

1. Fix language picker SVG not being visible on coloured background pages. The svg `fill` was being explicitly set to `var(--text-inv)`, however defaulting to `currentColor` allows it to adopt the button texts colour in different contexts.
2. Slightly adjusted spacing of the language picker for visual balance

### Before & After

<img width="801" alt="image" src="https://github.com/user-attachments/assets/f8fb91c2-f9d9-4701-be62-192840b31cb8">
<img width="805" alt="image" src="https://github.com/user-attachments/assets/ee49beec-9bfe-4446-9cf9-36d1542528af">

<img width="804" alt="image" src="https://github.com/user-attachments/assets/74858cde-7a40-425e-9329-ee4709618f70">
<img width="805" alt="image" src="https://github.com/user-attachments/assets/79d3c850-4134-4bfa-bc1e-1b633e8fdd9e">

<img width="805" alt="image" src="https://github.com/user-attachments/assets/8eb94253-36b8-45bb-8580-1da661ecba5d">
<img width="804" alt="image" src="https://github.com/user-attachments/assets/3589112b-eb4d-4a62-9465-7aff10798030">




