### PR TITLE
Fix small typo in `languages_base.json`

### DIFF
--- a/src/_data/languages_base.json
+++ b/src/_data/languages_base.json
@@ -5,8 +5,8 @@
   ],
   "en": {
     "ariaLabelPaginationlinks": "Pagination links",
-    "ariaLabelPrimaryNav": "Primary navigaton",
-    "ariaLabelSecondaryNav": "Secondary navigaton",
+    "ariaLabelPrimaryNav": "Primary navigation",
+    "ariaLabelSecondaryNav": "Secondary navigation",
     "asideHeading": "Recent updates",
     "asideLinkText": "Read more news",
     "bannerText": "Is Apple DMA compliant? Read the full report!",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
N/A

## Summary of Changes
1. Just fixing small typos: navigaton -> navigation
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->