### PR TITLE
Add script to autogenerate non-translated language files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,38 +6,54 @@ To contribute to code or an existing note in this repository, first create a for
 
 ## Help with website translations
 
-If you're comfortable with code, please follow the instructions below. If you're not comfortable with code but still want to help, reach out to us on [Discord](https://discord.gg/x53hkqrRKx).
+If you're comfortable with code, please follow the instructions below. If you're not comfortable with code but still want to help, reach out to us in the #translation channel of the OWA [Discord](https://discord.gg/x53hkqrRKx).
 
 ### Adding a new language
 
-New languages require translation of the global website content at a minimum. This includes things like banners, header, footer and navigation.  
+#### 1. Translate the global content
 
-Minimum files to include in your PR:
-- `_data/navigation.json`
+Global content is located in two files:
 - `_data/languages_base.json`
+- `_data/navigation.json`
 
-The new language object in these files must include all properties on the `en` object.
+In `_data/languages_base.json`, add the new language to the `supported` array, using the  the [ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
 
-The object key should match the [ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+Duplicate the english object with the new languages translations. 
+
+The new language object in the data files must include all properties on the `en` object.
 
 The url of navigation links should remain in english.
 
-### Adding a translated page
+#### 2. Populate all the pages and posts
 
-If the language has no existing translated pages, please ensure the language has been added to the global files (see above). Translated pages should live in a folder with the [language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) as the name. For example `/src/es/` for Spanish translated pages.
+From the root project directory, run `npm run generate`. 
 
-Find the page you want to translate in the `src/pages` directory. This could be html or markdown. 
+This script will:
+- create a new folder with the new language code
+- create a copy of each page located in `src/pages`
+- create a copy of each post located in `src/post`
+- create a copy of the tag page in `src/robots-meta`
+- update the copied files permalinks to prepend the new language code
+- add `translated: false` to the page's front matter
 
-Copy the page and paste into the relevant language folder. 
+#### 3. Translate pages
 
-The file name of the new language page must be identical to the english version. 
+Translate the copied version of the homepage and any additional pages you are translating.
 
-Translate the new page, including the front matter title and meta description. 
-
-The permalink front matter should be updated to include the language code as a parent folder. For example `permalink: '/get-involved/'` becomes `permalink: /es/get-involved/`.
+Remove the `translated: false` property from the front matter of pages you have translated. This will remove the "not yet translated" banner from the page.
 
 Raise a pull request :tada:
 
+
+### Translating pages for existing language
+
+Each language has a folder corresponding with its [ISO language code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes). 
+
+Files in this folder that are currently in English can be translated directly. 
+
+Once the page is translated, (including the front matter title and meta description), please remove the `translated: false` property. This will remove the "not yet translated" banner from the page.
+
+Raise a pull request :tada:
 
 ### Guidelines
 

--- a/generate-language-files.js
+++ b/generate-language-files.js
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const languagesBasePath = 'src/_data/languages_base.json';
+const languagesBase = JSON.parse(fs.readFileSync(languagesBasePath, 'utf8'));
+const supportedLanguages = languagesBase.supported;
+
+supportedLanguages.forEach(language => {
+  const languageCode = language.code;
+
+  if (languageCode === 'en') {
+    return;
+  }
+
+  const sourceFolders = ['src/pages', 'src/posts', 'src/robot-meta'];
+  const targetFolders = [
+    `src/${languageCode}/pages`,
+    `src/${languageCode}/posts`,
+    `src/${languageCode}/robot-meta`
+  ];
+
+  sourceFolders.forEach((sourceFolder, index) => {
+    const targetFolder = targetFolders[index];
+    const sourcePath = path.join(process.cwd(), sourceFolder);
+    const targetPath = path.join(process.cwd(), targetFolder);
+
+    if (!fs.existsSync(targetPath)) {
+      fs.mkdirSync(targetPath, {recursive: true});
+    }
+
+    let filesCopied = 0;
+    let filesSkipped = 0;
+
+    fs.readdirSync(sourcePath).forEach(file => {
+      const sourceFile = path.join(sourcePath, file);
+      const targetFile = path.join(targetPath, file);
+
+      // Check if the file is .md or .html
+      const ext = path.extname(file);
+      if (ext !== '.md' && ext !== '.html') {
+        filesSkipped++;
+        return;
+      }
+
+      if (fs.lstatSync(sourceFile).isFile()) {
+        if (fs.existsSync(targetFile)) {
+          filesSkipped++;
+          return;
+        }
+
+        const content = fs.readFileSync(sourceFile, 'utf8');
+        const parsed = matter(content);
+        const originalPermalink = parsed.data.permalink;
+
+        if (sourceFolder === 'src/pages' || sourceFolder === 'src/robot-meta') {
+          // Prepend the language code to the existing permalink in the front matter
+          if (originalPermalink) {
+            parsed.data.permalink = `/${languageCode}${parsed.data.permalink}`;
+          }
+          console.log('AFTER parsed.data.permalink', parsed.data.permalink);
+          console.log('AFTER poriginalPermalink', originalPermalink);
+        } else if (sourceFolder === 'src/posts') {
+          // Set the permalink and layout for posts if not explicitly stated
+          const fileNameWithoutExtension = path.basename(file, path.extname(file));
+          if (!parsed.data.permalink) {
+            parsed.data.permalink = `/${languageCode}/blog/${fileNameWithoutExtension}/index.html`;
+          }
+          if (!parsed.data.layout) {
+            parsed.data.layout = 'layouts/post.njk';
+          }
+        }
+
+        parsed.data.translated = false;
+
+        // Write the updated content to the target file
+        const updatedContent = matter.stringify(parsed.content, parsed.data);
+        fs.writeFileSync(targetFile, updatedContent);
+        filesCopied++;
+
+        // Revert the permalink back to the original value
+        parsed.data.permalink = originalPermalink;
+      }
+    });
+
+    console.log(`Files copied from ${sourceFolder} to ${targetFolder}: ${filesCopied}`);
+    console.log(`Files skipped from ${sourceFolder} to ${targetFolder}: ${filesSkipped}`);
+  });
+});

--- a/generate-language-files.js
+++ b/generate-language-files.js
@@ -58,8 +58,6 @@ supportedLanguages.forEach(language => {
           if (originalPermalink) {
             parsed.data.permalink = `/${languageCode}${parsed.data.permalink}`;
           }
-          console.log('AFTER parsed.data.permalink', parsed.data.permalink);
-          console.log('AFTER poriginalPermalink', originalPermalink);
         } else if (sourceFolder === 'src/posts') {
           // Set the permalink and layout for posts if not explicitly stated
           const fileNameWithoutExtension = path.basename(file, path.extname(file));

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "rm -rf ./dist/*",
     "serve": "npm run start",
     "start": "npx @11ty/eleventy --serve --quiet",
+    "generate": "node generate-language-files.js",
     "build": "npm run production",
     "production": "NODE_ENV=production npx @11ty/eleventy",
     "updates": "npx npm-check-updates -i --format group"

--- a/src/es/pages/accessibility.md
+++ b/src/es/pages/accessibility.md
@@ -1,0 +1,28 @@
+---
+title: Accessibility
+permalink: /es/accessibility/
+metaDesc: Learn about the accessibility of the Open Web Advocacy website.
+layout: layouts/page.njk
+translated: false
+---
+
+The Open Web Advocacy is committed to ensuring digital accessibility for people with disabilities.
+We are applying the relevant accessibility standards, and we will do our best to continually improve the user experience
+for everyone.
+
+## Measures to support accessibility
+
+As a team of enthusiastic volunteers, we are focusing our efforts on web standards and semantic HTML.
+
+The tests done during development are:
+
+- checking for general accessibility problems with WAVE (Web Accessibility Evaluation Tool);
+- navigating the site using the keyboard;
+- using NVDA screen reader.
+
+## Feedback
+
+We welcome your feedback on the accessibility of our pages.
+If you encounter any accessibility barriers accessing our content, please let us know by email:
+[contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org). We will do our
+best to address the issue as soon as possible.

--- a/src/es/pages/apple-attempts-killing-webapps.md
+++ b/src/es/pages/apple-attempts-killing-webapps.md
@@ -1,0 +1,45 @@
+---
+title: Immediate Action Needed!
+permalink: /es/apple-attempts-killing-webapps/
+metaDesc: >-
+  Apple has officially announced that they are attempting to kill web apps in
+  the EU, which will have ramifications worldwide
+layout: layouts/page.njk
+translated: false
+---
+
+**Apple has officially announced that they are attempting to kill web apps in the EU, which will have ramifications worldwide.**
+
+## ACT NOW
+
+**We need immediate support from web developers and businesses that operate online in the EU**.  The European Commission needs to hear from YOU to understand the devastating impact Apple’s new ban will have on your livelihoods, businesses and customers.
+
+To facilitate this, [please sign our open letter](https://letter.open-web-advocacy.org/) so that we can understand the scale of the impact and provide it to the European Commission in a single large submission.
+
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+<p><strong>Are you established in the EU and have an Apple Developer Account?</strong></p>
+<p>If you are, we encourage you to write directly to Apple to request preservation of the existing functionality that allows Safari and other iOS browsers to add Web Apps to the home screen, allows them to run in top-level activities (not in tabs), integrates with iOS settings and permissions, enables Push Notifications and homescreen icon badging, allows persistent storage, and to run fullscreen. </p>
+<p><a href="https://developer.apple.com/support/ios-interoperability/">Submit your interoperabilty request to Apple</a></p>
+
+## What’s happening?
+
+Apple have announced a series of changes designed to comply with the European Union’s Digital Markets Act.
+
+Throughout this process, they’ve chosen to maliciously comply as much as possible, resulting in a series of decisions meant to cripple the ability for anyone to compete on their platform outside of their App Store.
+
+You can read more about the changes they’ve made in these two blog posts:
+
+[It’s Official, Apple Kills Web Apps in the EU](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/)
+
+[OWA’s Review of Apple’s DMA Compliance Proposal for the Web](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/)

--- a/src/es/pages/apple-dma-review.html
+++ b/src/es/pages/apple-dma-review.html
@@ -1,0 +1,5695 @@
+---
+title: Apple DMA Review
+permalink: /es/apple-dma-review/
+layout: layouts/paper.njk
+metaDesc: ''
+subtitle: ' Review of Apple''s Compliance Proposal - VERSION 1.0'
+paperName: OWA - DMA - Review of Apple's Compliance Proposal - v1.0
+paperSize: 4.95 MB
+translated: false
+---
+
+<h2 id="introduction">
+  <a class="header-anchor" href="#introduction" aria-hidden="true">#</a>
+  2. Introduction
+</h2>
+
+<p>
+  The Digital Markets Act (DMA) aims to restore contestability, interoperability,
+  choice and fairness back to digital markets in the EU. These fundamental
+  properties of an effectively functioning digital market have been eroded by the
+  extreme power gatekeepers wield via their control of “core platform services”.
+</p>
+<p>
+  The lack of competition on mobile ecosystems is, at its heart, a structural one.
+  Gatekeepers wield vast power due to the security model that these devices are
+  built on. Traditionally, on operating systems such as Windows, macOS and Linux,
+  users can install any application they want, with no interaction from the
+  operating system gatekeeper, either by the business or the end user. Users can
+  then grant these programs the ability to do anything they desire.
+</p>
+<p>
+  Locking down what applications can do, such as restricting which APIs they can
+  access behind user permissions, is not by itself anti-competitive and can bring
+  legitimate security advantages. However, the manner in which it has been
+  implemented on mobile devices is both self-serving and in its current form,
+  significantly damages competition.
+</p>
+<p>
+  This damage surfaces in several forms:
+</p>
+<p>
+  First, the gatekeeper can control what is allowed to be installed on devices
+  they have already sold to consumers, often for a significant profit. They
+  utilize this device-level control to demand a 30% cut of all third-party
+  software that the consumer installs, not on merit, but simply because they
+  control the only mechanisms available to businesses to release that software,
+  and can further block or hinder the consumer from using or acquiring services
+  outside of their app store.
+</p>
+<p>
+  The second is more subtle. In order to deliver their “native” apps to consumers
+  on Android or iOS, developers must create custom applications in specific
+  programming languages for each individual platform. Typically, companies will
+  require separate development teams for each OS. This not only multiplies
+  development and maintenance cost, but puts in place an invisible barrier to
+  interoperability. Even the built up expertise for creating software for a
+  specific platform provides significant lock-in advantages to the platform’s
+  gatekeeper.
+</p>
+<p>
+  Finally, even if a developer has no desire to interact with the gatekeeper, they
+  are forced into a commercial and legally binding relationship with them. This is
+  due to the fact that the gatekeeper inserts itself between the customer and
+  these third party developers. With smartphones now 15 years old, this may seem
+  normal to us now, but imagine if Microsoft demanded that every software provider
+  signed an onerous contract with them or be barred from releasing a product on
+  Windows. What would have been unacceptable, anti-competitive behavior to both
+  consumers, businesses and regulators on desktop, has been tolerated on mobile
+  simply because these computers were considered a “new” category.
+</p>
+<p>
+  Mobile devices are just small computers whose primary input is touch, there is
+  no sacred or magical property that means they have to run on a proprietary app
+  store model. Nothing is stopping mobile computers running on the open model that
+  desktop computers run on, just as there is nothing stopping a desktop computer
+  running the app store model. Inertia and great profits are however powerful
+  forces. Between them, Apple and Google have created a powerful and entrenched
+  duopoly.
+</p>
+<p>
+  Even with the DMA forcing Apple to open up the ecosystem to competition, Apple
+  is still inserting themselves front and center between consumers and app
+  developers. They insist all developers for iOS/iPadOS (including developers who
+  have no intention of using their app store) pay them $100 per year, that they
+  sign the full Apple developer program contract and submit themselves to what is
+  effectively app store review (although nominally locked to security). Worse,
+  they are attaching significant recurring penalty fees to developers who dare to
+  make their software available outside of Apple’s app store. Apple is using every
+  tool at their disposal to dissuade developers from leaving their app store and
+  to undermine the goals of the DMA.
+</p>
+<p>
+  Apple's key excuse to impose this control is security. Apple's argument is, in
+  essence, that only they can be trusted to vet what consumers are allowed to
+  install on their devices. All third parties must submit to their review.
+</p>
+<p>
+  What is needed is a way to securely run interoperable and capable software
+  across all operating systems. Luckily, such a solution already exists and is not
+  only thriving on open desktop platforms but is dominating, and that
+  dominance is growing every year. The solution is of course, the Web and more
+  specifically Web Apps. Today, more than 60% of users' time on desktop is done
+  using web technologies, and that looks set to only grow.
+</p>
+<p>
+  Web Apps have a number of properties that allow them to solve this critical
+  problem. They are run in the security of the browser's sandbox, which <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">even
+    Apple admits is “orders of magnitude more stringent than the sandbox for native
+    iOS apps.”</a>. They are truly interoperable between operating systems. They
+  don't require developers to sign contracts with any of the OS gatekeepers. They
+  are capable of incredible things and 90% of the apps on your phone could be
+  written as one today.
+</p>
+<p>
+  So why aren't they thriving on mobile? The simple answer to this question is
+  lack of browser competition on iOS and active hostility by Apple towards
+  effective Web App support, both by their own browser and by their OS. Apple's
+  own browser faces no competition on iOS, as they have effectively barred the
+  other browsers from competing by prohibiting them from using or modifying their
+  engines, the core part of what allows browser vendors to differentiate in
+  stability, features, security and privacy.
+</p>
+<p>
+  The DMA explicitly sets out to right this wrong by mandating that gatekeepers
+  can no longer enact such a ban:
+</p>
+
+<blockquote>
+  <p>In particular, each browser is built on a web
+    browser engine,
+    which is responsible for key browser functionality such as
+    speed, reliability and web compatibility. When gatekeepers
+    operate and impose web browser engines, they are in a position
+    to determine the functionality and standards that will apply
+    not only to their own web browsers, but also to competing web
+    browsers and, in turn, to &gt;web software applications.
+    Gatekeepers
+    should therefore not use their position to require their
+    dependent business users to use any of the services provided
+    together with, or in support of, core platform services by the
+    gatekeeper itself as part of the provision of services or
+    products by those business users.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital
+        Markets Act - Recital 43</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent stated for this in the DMA is to prevent gatekeepers from dictating
+  the speed, stability, compatibility and feature set of “web software
+  applications”.
+</p>
+<p>
+  Apple has announced new rules that would, at first glance, allow browser vendors
+  to port their real browsers to iOS. However, on closer inspection, this is a
+  mirage. Instead Apple appears intent on making it <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">“as
+    painful as possible” for browser vendors</a> to port their engines to
+  iOS/iPadOS. As we will outline in our paper, Apple's current proposal falls far
+  short of compliance. Apple is not only undermining browser competition on iOS,
+  but appears to be actively attempting to prevent the growth of an entire open
+  and interoperable ecosystem that could feasibly supplant and replace their app
+  store model.
+</p>
+<p>
+  Apple have seen the Web as a threat to their app store as far back as 2011, when
+  Philip Schiller internally sent an email to Eddie Cue titled “HTML5 poses a
+  threat to both Flash and the App Store”.
+</p>
+
+<blockquote>
+  <p>
+    Food for thought: Do we think our 30/70% split will last forever? While I am a
+    staunch supporter of the 30/70% split and keeping it simple and consistent across
+    our stores, I don’t think 30/70 will last unchanged forever. I think someday we will
+    see a challenge from another platform or a web based solution to want to adjust our
+    model.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+        Phil Schiller - Apple Upper Management
+      </a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This attitude appears not to have changed. Faced with the genuine possibility of third-
+  party browsers effectively powering Web Apps, Apple's first instinct appears to have
+  been to <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+    remove Web Apps support entirely with no notice to either businesses or
+    consumers</a>. Luckily, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+    under significant pressure, Apple backed down</a> from this particular
+  stunt at the last moment.
+</p>
+
+<p>
+  Apple is very explicit in its public statement that they initially planned to remove the
+  functionality as the DMA would force them to share it with third-party browsers. Even in
+  their statement backing down, they make it clear they do not intend to allow third-party
+  browsers that use their own engine to be able to install and manage Web Apps. In both
+  statements, Apple cites "security" as the reason for their decisions.
+</p>
+<p>
+  Unfortunately for Apple, it has been unable to prove that Safari or WebKit are actually
+  more secure than its competitors. When obligated by the UK’s Competition and Markets
+  Authority to provide evidence to back up its assertion that WebKit was more secure than
+  Blink or Gecko, Apple failed to do so.
+</p>
+
+<blockquote>
+  <p>... the evidence that we have seen to date does not suggest that there are material
+    differences in the security performance of WebKit and alternative browser engines.
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>Overall, the evidence we have received to date does not suggest that Apple's
+    WebKit restriction allows for quicker and more effective response to security threats
+    for dedicated browser apps on iOS.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Apple's actions not only hurt the Web ecosystem, third-party businesses (be they
+  browser vendors or software developers), but also make their devices worse for their own
+  consumers. By depriving their consumers of the choice and competition that fair and
+  effective browser and Web App competition would bring, they are worsening the
+  functionality, interoperability, stability, security, privacy, and price of services on their
+  devices.
+</p>
+<p>
+  A reasonable person might argue
+  <em>Why would Apple make their own devices worse, surely
+    better devices means more hardware sales?</em> This behavior comes, however, with key
+  advantages for Apple, even if they harm Apple's own consumers.
+</p>
+
+<p>
+  Critically, service revenue is of growing importance for Apple as
+  <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">their hardware sales have
+    peaked and are declining</a>. Apple has not had a “hit” new product for 14 years, namely the
+  iPad, and, if you are being generous, 9 years for the Apple Watch. It does not currently
+  seem likely that Apple’s VR/AR headset
+  <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">will
+    have any significant impact on Apple’s overall
+    hardware sales</a>.
+</p>
+
+<p>
+  The UK regulator cites two incentives: protecting their app store revenue from
+  competition from Web Apps, and protecting their Google search deal from competition
+  from third-party browsers.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple receives significant revenue from Google
+      by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially
+    from high usage
+    of Safari. [...] <strong class="stressed">The WebKit restriction may help to
+      entrench this position</strong> by limiting
+    the scope for other browsers on iOS to differentiate themselves from Safari [...] As
+    a result, it is less likely that users will choose other browsers over Safari, which in
+    turn <strong class="stressed">secures Apple’s revenues from Google</strong>.
+    [...]
+    Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via Apple
+    IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring
+    all browsers on iOS to use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control
+      over the maximum functionality of all browsers on iOS</strong> and, as a consequence,
+    hold up the development and use of web apps. This limits the <strong class="stressed">competitive
+      constraint that web apps pose on native apps</strong>, which in turn protects and benefits
+    Apple’s App Store revenues.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  These two revenue streams are vast, even for a company of Apple’s size. Apple collected
+  <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.">
+    $85 billion USD in App Store fees in 2022</a>,
+  of which it keeps approximately 30%. Apple
+  reportedly receives
+  <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+    $18-20 billion USD</a> a year from their Google Search engine deal,
+  accounting for 14-16 percent of Apple's annual operating profits.
+</p>
+<p>
+  A third and interesting incentive the CMA does not cite, but which the US's Department of
+  Justice does, is that this behavior greatly weakens the interoperability of Apple's devices,
+  making it harder for consumers to switch or multi-home. It also greatly raises the barriers
+  of entry for new mobile operating system entrants by depriving them of a library of
+  interoperable apps.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple has long understood how middleware can help promote
+      competition</strong> and
+    its myriad benefits, including increased innovation and output,
+    <strong class="stressed">by increasing scale and interoperability</strong>.
+    [...]
+    In the context of smartphones, examples of
+    <strong class="stressed">middleware include internet browsers</strong>,
+    internet or cloud-based apps, super apps, and smartwatches, among other products
+    and services.
+    [...]
+    <strong class="stressed">
+      Apple has limited the capabilities of third-party iOS web browsers, including by
+      requiring that they use Apple’s browser engine, WebKit</strong>.
+    [...]
+    Apple has sole discretion to review and approve all apps and app updates.
+    <strong class="stressed">Apple
+      selectively exercises that discretion to its own benefit</strong>, deviating from or changing
+    its guidelines when it suits Apple’s interests and allowing Apple executives to control
+    app reviews and decide whether to approve individual apps or updates. Apple often
+    enforces its App Store rules arbitrarily.
+    <strong class="stressed">And it frequently uses App Store rules and
+      restrictions to penalize and restrict developers that take advantage of
+      technologies that threaten to disrupt, disintermediate, compete with, or erode
+      Apple’s monopoly power</strong>.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+        DOJ Complaint against Apple</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Interoperability via middleware would reduce lock-in for Apple’s devices. Lock-in is a clear
+  reason for Apple to block interoperability, as can be seen in this email exchange where
+  Apple executives dismiss the idea of bringing iMessage to Android.
+</p>
+
+<blockquote>
+  <p>
+    The #1 most difficult [reason] to leave the Apple universe app is iMessage ...
+    iMessage amounts to serious lock-in
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Unnamed Apple Employee</a>
+    </cite>
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>
+    iMessage on Android would simply serve to remove [an] obstacle to iPhone
+    families giving their kids Android phones ... moving iMessage to Android will hurt us
+    more than help us, this email illustrates why.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Craig Federighi - Apple's Senior Vice President of Software Engineering</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>The DMA has the power to fix all of these underlying issues and unleash a powerful,
+  open, interoperable and secure competitor to not only Apple's
+  app store but also Google's. Lack of
+  contestability for mobile app stores and mobile operating systems is
+  a key concern for the DMA that viable Web
+  Apps solve.
+</p>
+
+<p>This will also remove a heavy burden from new entrants into the operating system
+  market; lack of apps. No longer will developers need to develop custom apps
+  for each operating system, any
+  operating system with good web app support and browser competition will support
+  all web apps automatically. Web
+  Apps support operating systems that developers have not even heard of.
+  The impact of allowing them to compete
+  fairly on mobile will be profound.
+</p>
+
+<p>
+  We request the Commission open a proceeding into Apple and investigate what we allege
+  is severe and deliberate non-compliance. The number of ways that Apple is not complying is so myriad that we,
+  recognising that the commision does not have infinite resources to pursue all of them simultaneously, have split
+  them into three tranches of remedies.
+</p>
+<p>Some remedies require time and/or pre-requisite remedies in order to be effective.
+  Remedies in this document are ordered to ensure that either competitive benefits are delivered earlier or to
+  unlock future remedies. In this way, we propose a program of continual improvement in the competitive landscape,
+  delivering wins at every step along the path.
+</p>
+
+<p>While we have attempted to be comprehensive, it is possible, and perhaps even likely,
+  that there will be infringements that we have not included or are not yet aware of.
+</p>
+
+<p>Our proposed remedies include:</p>
+
+<ul>
+  <li>Restricting Apple's API contract for browsers down to strictly necessary,
+    proportionate and justified security measures.</li>
+  <li>Make clear what the security measures are for third party browsers using
+    their own engine by publishing them in a single up-to-date document.</li>
+  <li>Removing any App Store rule that would prevent third party browsers from
+    competing fairly.</li>
+  <li>Allow browser vendors to keep their existing EU consumers when switching
+    to use their own engine.</li>
+  <li>Removing the special placement of Safari.</li>
+  <li>Making Safari uninstallable.</li>
+  <li>Implementing Install Prompts in iOS Safari for Web Apps.</li>
+  <li>Allowing Browser Vendors and Developers to be able to test their browsers
+    and web software outside the EU.</li>
+  <li>Allowing Browsers using their own engine to install and manage Web Apps.</li>
+  <li>Make notarization a fast and automatic process, as on macOS.</li>
+  <li>Allow direct browser installation independently from Apple’s app store.</li>
+  <li>Allow users to switch to different distribution methods of a native
+    app and allow developers to promote that option to the user.</li>
+  <li>Don't break third party browsers for EU residents who are traveling.</li>
+  <li>Opt-Into Rights contract should be removed.</li>
+  <li>Core Technology Fee should be removed.</li>
+  <li>Apple should publish a new more detailed compliance plan.</li>
+</ul>
+
+<p>Apple is obligated under Articles 5(7), 6(3), 6(4) and 6(7) to fix each
+  of the above issues. Apple has failed to achieve effective compliance
+  with these obligations contrary to Article 13(3). Further Apple has
+  taken numerous and significant steps that obstruct and undermine it in
+  contravention of Article 13(4). Apple has introduced conditions and
+  restrictions on DMA-conferred rights that have no legal basis in the
+  DMA and gone far beyond the restrictions that the DMA does allow by
+  introducing rules that have no basis in security or that are not justified,
+  strictly necessary or proportionate.
+</p>
+
+<p>Any intervention that the Commission makes will have global ramifications. Regulators around the world are carefully watching the implementation of the DMA as they plan their own regulatory regimes. Already <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">Japan has become the second jurisdiction in the world to explicitly prohibit banning browser engines</a>. <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">Australia</a>, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">India, Korea and Brazil</a> are all planning on implementing their own versions of the DMA. The UK has just <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">passed the Digital Markets, Competition and Consumers Bill</a> that grants their regulator great power to enforce codes of conduct against tech giants.
+</p>
+
+<p>Successful resolution of these issues have an exceptional chance of becoming de facto global, as no jurisdiction will want to miss out on clear benefits being enjoyed by EU consumers. However, if Apple manages to successfully avoid complying with the DMA, these problems could persist indefinitely.
+</p>
+
+<p>
+  We urge the Commission to enforce the DMA and obligate Apple to allow
+  browsers and Web Apps to compete fairly and effectively on their mobile ecosystem.
+  This will unlock contestability, fairness and interoperability. Companies will then
+  have to compete for users on merit, not via lock-in or control over operating
+  systems. Consumers will benefit from choice, better quality and cheaper software,
+  interoperability, and the genuine ability to multihome across devices and operating
+  systems offered by different companies.
+</p>
+
+<p>
+  These changes can finally fix a mobile ecosystem that has been
+  structurally broken, and artificially hindered, for more than a decade.
+</p>
+
+<h2 id="review">
+  <a class="header-anchor" href="#review" aria-hidden="true">#</a>
+  3. Review
+</h2>
+
+<h3 id="Apples-new-browser-engine-entitlement-contract">
+  <a class="header-anchor" href="#Apples-new-browser-engine-entitlement-contract" aria-hidden="true">#</a>
+  3.1. Apple’s New Browser Engine Entitlement Contract
+</h3>
+
+<h4 id="api-contract-not-restricted-to-only-security">
+  <a class="header-anchor" href="#api-contract-not-restricted-to-only-security" aria-hidden="true">#</a>
+  3.1.1. API Contract not Restricted to Only Security
+</h4>
+
+<p>
+  As part of Apple’s compliance proposal, Apple published a new contract,
+  namely the “Web Browser Engine Entitlement Addendum for Apps in the EU”.
+</p>
+
+<p>
+  This is a contract to be allowed to have the “Alternative Web Browser
+  Engine App (EU)” entitlement profile. To understand what an entitlement is,
+  we can look to Apple’s documentation:
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">An entitlement is a right or privilege that grants
+      an executable particular
+      capabilities</strong>. For example, an app needs the HomeKit Entitlement — along with
+    explicit user consent — to access a user’s home automation network. An app
+    stores its entitlements as key-value pairs embedded in the code signature of
+    its binary executable.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements">
+        Apple Developer Documentation</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  An entitlement is a permission which grants applications the ability
+  to access some specific hardware or software features of the operating
+  system. For example Apple grants the Safari app the ability to access
+  bluetooth via the “com.apple.bluetooth.internal” entitlement.
+</p>
+
+<p>
+  The contract further specifies:
+</p>
+
+<blockquote>
+  <p>
+    &lsquo;Alternative Web Browser Engine APIs&rsquo; means the restricted Application
+    Programming Interfaces (&lsquo;APIs&rsquo;) contained in the Apple Software, which
+    are provided to You under this Addendum for using an Alternative Web Browser Engine.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This therefore means that this contract is Apple’s terms and conditions
+  for access to these APIs. This applies not only to browsers installed
+  from Apple’s app store but also <strong>applies to browsers that are either
+    installed from a different app store or directly from a website</strong>.
+</p>
+
+<p>The DMA states:</p>
+
+<blockquote>
+  <p>
+    Article 6(7) <strong class="stressed">
+      The gatekeeper shall allow providers of services and
+      providers of hardware, free of charge, effective interoperability with,
+      and access for the purposes of interoperability to, the same hardware
+      and software features accessed or controlled via the operating system
+      or virtual assistant listed in the designation decision pursuant to
+      Article 3(9) as are available to services or hardware provided by the
+      gatekeeper</strong>. Furthermore, the gatekeeper shall allow business users
+    and alternative providers of services provided together with, or in
+    support of, core platform services, free of charge, effective
+    interoperability with, and access for the purposes of interoperability
+    to, the same operating system, hardware or software features,
+    regardless of whether those features are part of the operating system,
+    as are available to, or used by, that gatekeeper when providing such
+    services.
+    <strong class="stressed">The gatekeeper shall not be prevented from taking strictly necessary
+      and proportionate measures to ensure that interoperability does not
+      compromise the integrity of the operating system, virtual assistant,
+      hardware or software features provided by the gatekeeper, provided
+      that such measures are duly justified by the gatekeeper.</strong>
+    </p>
+    <p>
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+        Digital Markets Act - Article 6(7)</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This is clearly a strong restriction on which conditions Apple can place
+  on general API access. That is, while 6(7) allows Apple to have a
+  number of strictly necessary, proportionate and justified security
+  conditions to protect the integrity of the operating system, it is
+  not allowed to then add any other conditions it may want.
+</p>
+
+<p>
+  Apple’s contract helpfully separates out which conditions Apple
+  considers to be security requirements in two sections: “You must
+  meet the following security requirements” and “3.1 Security”.
+</p>
+
+<p>
+  Apple should ensure that each and every condition in this contract is:
+</p>
+
+<ul>
+  <li>To protect the integrity of the operating system</li>
+  <li>Strictly necessary</li>
+  <li>Proportionate</li>
+  <li>Duly justified by Apple</li>
+</ul>
+
+<p>
+  <strong>This immediately strikes out all conditions in the contract that
+    are not security conditions - which make up the majority of the contract.</strong>
+</p>
+
+<p>
+  Apple must remove all non-security terms from its browser engine entitlement contract. The contract must only
+  contain terms allowed by Article 6(7) of the DMA. OWA supports the contract spelling out the necessary,
+  proportionate, and justified security rules to protect the integrity of the operating system.
+</p>
+
+<h4 id="article5-7-no-security-exceptions">
+  <a class="header-anchor" href="#article5-7-no-security-exceptions" aria-hidden="true">#</a>
+  3.1.1.1. Article 5(7) - No Security Exceptions
+</h4>
+
+<p>
+  Under Article 5(7), Apple is obligated to allow browser vendors to port their existing browser engines to iOS.
+  Article 5(7) contains no security exceptions.
+</p>
+<p>
+  This means Apple can not seek to prevent or hinder the features and functionality that browser engines can provide
+  by claiming exemptions under security. Article 13(3) and 13(4) in conjunction with 5(7) means that Apple must enable
+  browser vendors to port their browser engines in their entirety, and Apple must provide those engines the access and
+  integration they require to operate.
+</p>
+<p>
+  We would propose that the Commission therefore looks at security rules through this lens and ensure that any
+  security rule that would significantly hinder browser vendors from porting their existing engines should be struck
+  out. Major browser vendors take security extremely seriously and will likely voluntarily accept a number of rules
+  related to patching and promptly fixing vulnerabilities as they already do this for every other operating system.
+</p>
+<p>
+  Thus, any app store or API contract rule that would make it extremely difficult or impossible for a competent
+  browser vendor to port their existing browser (with its engine) to iOS would be in violation of Article 5(7) and
+  Article 13(4).
+</p>
+<p>
+  If we look at the intent of Article 5(7) with respect to browser engines it goes further. The intent is spelt out in
+  this segment of Recital 43:
+</p>
+
+<blockquote>
+  <p>
+    In particular, each browser is built on a web browser engine, which is responsible for key browser functionality
+    such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they
+    are in a position to determine the functionality and standards that will apply not only to their own web browsers,
+    but also to competing web browsers and, in turn, to web software applications.”
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+        Digital Markets Act - Recital 43</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent is to allow third-party browser vendors to contest the functionality, speed and stability of the
+  gatekeepers browser, including in the provision of the functionality of Web Apps.
+</p>
+<p>
+  This means that any app store or API contract rule that would block functionality from a third-party browser would
+  be in violation of Article 5(7) and 13(4). The most that Apple can insist upon is that browser vendors take
+  reasonable steps to mitigate any security issues to at least the baseline level of security for that API (or
+  equivalent APIs) on iOS.
+</p>
+<p>
+  OWA expects that browser vendors should be subject to security requirements, but as previously stated, security
+  should not be used to block the ability of browsers and Web Apps to compete with the gatekeepers native apps and
+  services.
+</p>
+<p>
+  In summary, <strong>security rules (and other app store rules) that violate
+    Article 5(7) should be modified or struck out</strong>.
+</p>
+
+<h3 id="must-not-use-browser-engine-of-operating-system">
+  <a class="header-anchor" href="#must-not-use-browser-engine-of-operating-system" aria-hidden="true">#</a>
+  3.1.2. Must not use the Browser Engine of the Operating System
+</h3>
+
+<p>
+  Due to Apple’s 15 year ban of third-party browser engines, browser vendors will need to gradually phase in their own
+  engines over time using phased roll-outs and multi-variant testing. Deploying an engine to a new operating system is
+  a complex process and has to be done in a slow and methodical manner to identify bugs and performance issues.
+</p>
+<p>
+  As a result, it is essential that all browser vendors be allowed to ship dual engine browsers. That is, browsers
+  that can use both the system provided WKWebView and their own engine within a single binary. Technically the binary
+  would only contain the code for a single engine, the one the browser vendor provides, since the WKWebView is an
+  operating system provided component.
+</p>
+<p>
+  However, Apple has added a rule in their contract to explicitly ban this:
+</p>
+
+<blockquote>
+  <p>
+    Be a separate binary from any Application that uses the system-provided
+    web browser engine
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>To our knowledge there is no reasonable or rational reason to impose this
+  restriction.</p>
+
+<p>It is not entirely clear what this rule means, but the most obvious interpretation is
+  that the browser is not allowed to make use of the WKWebView. Potentially it could mean that the browser is also
+  not able to make use of or call SFSafariViewController (which may have some niche use cases even for browsers that
+  ship their own engine).</p>
+
+<p>The WKWebView is an operating system component, and thus a software feature of iOS
+  covered under Article 6(7). Since Apple has not provided any security justification for this rule, nor do we
+  believe one plausibly exists, this term is in clear contravention of 6(7).</p>
+
+<p>Without explanation we can only guess Apple’s reasons for adding this rule. The
+  most obvious guess is that Apple is simply being malicious by ensuring browser vendors can not update their
+  existing browser app to use their own engine, which will then ensure that those browser vendors will lose all
+  their existing EU customers if they attempt to port their engine over.</p>
+
+<p>It is also possible that this is simply as childish and anticompetitive as “if
+  you want to not be forced to use it, then you're not allowed to use it at all”. Apple has behaved in a
+  similar manner in a number of other instances with their app store and their payment handler.</p>
+
+<p>A significant consequence of this rule is that it makes phasing in the engine over time
+  with A/B testing impossible. A/B testing (also known as split testing or bucket testing) is a methodology for
+  comparing two versions of an app in order to know which performs better. In the case of browsers, there are bugs
+  which only occur rarely i.e for 1/10,000 or 1/100,000 users. In order to pick up these bugs before releasing them
+  on millions of users, browser vendors turn on features for a percentage of users (i.e 1% or .1%) to catch issues.
+  This is a critical part of browser development. </p>
+
+<p>In this case, browser vendors will be toggling users between the WebKit version of
+  their browser and their own engine version of their browser so as to collect sufficient bug data to make their own
+  engine version stable. Such a rule would make this impossible.</p>
+
+<p>This will make it significantly more difficult for browser vendors to port their
+  engines, let alone have a successful product using their own engine which meets or exceeds the quality and
+  adoption of their WebKit WebView-based browser. This is the only real plausible purpose of the rule. Coupled with
+  the complete lack of security or any other justification, this rule would be in violation of Article 5(7), and
+  Article 13(4).</p>
+
+<p>Thus, under Article 5(7), Article 6(7), and Article 13(4) <strong>Apple must
+    allow browser vendors to ship “dual engine” browsers by removing</strong>
+  <q>Be a separate binary from any Application that uses the system-provided
+    web browser engine</q> from their browser engine entitlement contract and not
+  include an equivalent rule in their
+  app store rules.
+</p>
+
+<h3 id="must-be-new-and-separate-app">
+  <a class="header-anchor" href="#must-be-new-and-separate-app" aria-hidden="true">#</a>
+  3.1.3. Must be New and Separate App
+</h3>
+
+<p>Apple has a number of rules making it clear that the Web Browser Engine Entitlement
+  will only be provided in the EU. Additionally, they will force browser vendors to submit a brand new
+  application called an "Alternative Web Browser Engine App (EU)" in the contract.</p>
+
+<blockquote>
+  <p>Your Application must:</p>
+  <ul>
+    <li>Be distributed solely on iOS in the European Union;</li>
+    <li><strong class="stressed">Be a separate binary from any Application that uses the
+        system-provided web browser engine;</strong></li>
+  </ul>
+  <p>
+    ...
+    2.4 The Entitlement Profile is compatible and may only be used with Applications solely distributed within the EU
+    on devices running iOS 17.4 or later
+    ...
+    You are permitted to use the Entitlement Profile only in connection with Your Alternative Web Browser Engine App
+    (EU) developed or distributed under this Addendum and with Apple-branded products"
+  </p>
+  <p><cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Apple’s Browser Engine Entitlement Contract
+      </a>
+    </cite></p>
+</blockquote>
+
+<p>Apple has chosen to restrict browser competition on iOS to the EU. This means under
+  Apple's current proposal all browsers that intend to bring and modify their own engine will need to create a
+  brand new application. Existing users will need to switch to this "new" app or remain siloed on the
+  existing WKWebView version of their browser.</p>
+
+<p>The rule to ship a separate app in the EU does not affect Safari, as the WKWebView is
+  under Apple's sole control, contains Safari's engine and is updated in lockstep with Safari. That is to
+  say: the system provided browser engine is Safari’s engine, hence they are automatically exempt from this
+  rule.</p>
+
+<p>For a third-party browser to make this transition, they would need to ship a new app,
+  and then advertise to the existing users to switch to the new app. The ramifications of this is so severe
+  it’s unlikely any browser vendor would be willing to take this step as it causes serious issues:
+</p>
+
+<ul>
+  <li>Browser vendors would likely lose a significant percentage of
+    their existing users in the transition.</li>
+  <li>Their "real" browser (i.e. the one they ship on every
+    other operating system) will start with zero installs. This means that, even after a period of time, it may
+    still not be eligible for the choice screen as it only displays the top 12 browsers for the country of the user.
+    It would be worth investigating whether imposing the “new and separate app rule” would therefore
+    breach 13(4)’s effective compliance obligation in relation to Apple’s 6(3) choice screen
+    obligations.</li>
+  <li>This introduces considerable friction and complexity into porting
+    users data, login cookies and settings to the new app. This is problematic as:
+    <ul>
+      <li>In some cases user’s data will be lost in the
+        transfer.</li>
+      <li> Significant development work will be required to sync it.</li>
+      <li>It is unclear what to do for users that become and cease to be EU
+        residents,an artificial problem caused by Apple's geolock.</li>
+      <li>Users opting to keep both applications may find their information
+        out of sync across the two.</li>
+      <li>Browsers will likely want to avoid any high-friction method such as
+        requiring the user to sign-in to use browser cloud syncing
+        functionality, if available.</li>
+    </ul>
+  </li>
+  <li>This is likely to lead to significant user confusion and frustration. Many
+    users are completely unaware that they are not using the “real” versions of popular browsers. This
+    is further complicated by Apple’s insistence (previously indefinitely, now for the next 6 months) that
+    browser vendors would not be able to port their browsers to iPad in the EU. Most users are not concerned with
+    what engine their browser uses, rather they are concerned with the features, stability, speed, security and
+    privacy, etc. that different browsers offer relative to each other.
+  </li>
+</ul>
+
+<p>
+  It is unlikely that a browser vendor
+  would do a major advertising campaign for the EU for their updated browser that would inadvertently highlight
+  the shortcomings of their WkWebView based browser to other large markets. While there is a high probability that
+  Apple will be forced to allow browser competition on iOS in most (if not all) jurisdictions in the future, it is
+  equally likely that there will be a multi-year lag. Browser vendors will not wish to lose market share with
+  their WkWebView based browsers in those jurisdictions while they wait for change.
+</p>
+
+<p>All of this is avoided if the browser vendor can simply update their existing
+  application.</p>
+
+<p>Hypothetically, if Apple were to update the technology powering the Apple TV app, they
+  would not force all their users to download and sign into a new app. They would simply silently update the
+  technology under the hood for all users, providing them a better product with no friction or user frustration. To
+  force browser vendors to have to ship a new app simply to update the underlying technology is both unreasonable
+  and anti-competitive. Particularly when allowing browser vendors to use their own engines for their browser is
+  directly compelled via the DMA.</p>
+
+<h4 id="potential-solutions">
+  <a class="header-anchor" href="#potential-solutions" aria-hidden="true">#</a>
+  3.1.3.1. Potential Solutions
+</h4>
+
+<p>There are a three potential solutions open to Apple including:</p>
+
+<ul>
+  <li><strong>Solution A.</strong> Allow Browser Engines Globally</li>
+  <li><strong>Solution B.</strong> Two Binaries for One Bundle ID</li>
+  <li><strong>Solution C.</strong> Global Dual Engine Binary with Toggle</li>
+</ul>
+
+<h5 id="solution-a-allow-browser-engines-globally">
+  <a class="header-anchor" href="#solution-a-allow-browser-engines-globally" aria-hidden="true">#</a>
+  3.1.3.1.1. Solution A - Allow Browser Engines Globally
+</h5>
+
+<p>Apple could allow browsers to compete fairly with their own engines globally. This is
+  the only option that would enable fair competition. <br><br>However we believe this is an unlikely option
+  since:</p>
+<ol>
+  <li>The DMA has no ability to impose extra-jurisdictional remedies, and
+    OWA is unaware of other legal mechanisms that could force this change.</li>
+  <li>Apple’s revenue from Safari is reportedly $20B USD per year,
+    an amount so significant that it’s unlikely Apple would willingly
+    enable competition unless
+    compelled.</li>
+  <li>Enabling browser competition on iOS globally in the provision of
+    features of Web Apps, will increase Web Apps ability to contest the
+    Apple’s app store which is a
+    significant source of revenue for Apple.</li>
+</ol>
+
+<p>The UK’s Competition and Markets Authority noted both of these potential motives
+  for Apple’s rule locking browsers to the WKWebView in their report.</p>
+
+
+<blockquote>
+  <p><strong class="stressed">
+      Apple receives significant revenue from Google by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially from high
+    usage of Safari. Safari has a strong advantage on iOS over other browsers
+    because it is pre-installed and set as
+    the default browser. The WebKit restriction may help to entrench this
+    position by limiting the scope for other
+    browsers on iOS to differentiate themselves from Safari (for example
+    being less able to accelerate the speed of
+    page loading and not being able to display videos in formats not supported
+    by WebKit). As a result, it is less
+    likely that users will choose other browsers over Safari, which in turn
+    secures Apple’s revenues from
+    Google.</p>
+  <p>Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via
+    Apple IAP. Apple therefore benefits from
+    higher usage of native apps on iOS. By requiring all browsers on iOS to
+    use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control over the maximum
+      functionality of all browsers on
+      iOS</strong> and, as a consequence, hold up the development and use of web apps. This
+    limits the <strong class="stressed">competitive constraint that web apps</strong>
+    pose on native apps,
+    which in turn protects and benefits Apple’s App Store revenues.
+  </p>
+
+  <p><cite>
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report&sa=D&source=editors&ust=1718648881316868&usg=AOvVaw0MbJ8M7tsg-0mKyIlffnKV">UK
+        CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite></p>
+</blockquote>
+
+<p>The reason we have included this as an option is that by providing it as the best and
+  most reasonable option from a competition point of view. It gives us a frame of reference for Apple’s other
+  options. The other options, while possibly legal, are still anti-competitive and place competing vendors under
+  significant burden.</p>
+
+<h5 id="solution-b-two-binaries-for-one-bundle-id">
+  <a class="header-anchor" href="#solution-b-two-binaries-for-one-bundle-id" aria-hidden="true">#</a>
+  3.1.3.1.2. Solution B - Two Binaries for One Bundle ID
+</h5>
+
+<p>Allow browser vendors to provide two signed binaries under one application (one bundle
+  id). These two binaries would be:</p>
+
+  <ul>
+    <li><strong>One -</strong> A signed binary which contains the real browser with its
+      own engine to ship to the EU and other jurisdictions that mandate Apple allow
+      browsers be able to choose and
+      modify their engine. This would need to include the ability to do A/B testing
+      with WKWebView outlined <a href="#must-not-use-browser-engine-of-operating-system">above</a>.
+    </li>
+    <li><strong>Two - </strong> A signed binary which contains the version of the
+      browser which is forced to use Apple’s WKWebView which can be shipped
+      in other jurisdictions.<br><br>An
+      update mechanism that can then toggle which binary to deliver based on
+      if the end user is an EU resident. This
+      would likely require some development work on Apple's part to update
+      their distribution mechanism and to
+      ensure that both binaries can continue to access user data.
+    </li>
+  </ul>
+
+  <p>One problem with this solution is the question of what happens when users become or
+    cease to be EU residents. This would necessitate a complex swap over procedure
+    by the browser vendors where local
+    storage data is copied from one version of the browser to another. This could
+    be a significant source of bugs.</p>
+
+  <h5 id="solution-c-global-dual-engine-binary-with-toggle">
+    <a class="header-anchor" href="#solution-c-global-dual-engine-binary-with-toggle" aria-hidden="true">#</a>
+    3.1.3.1.3. Solution C - Global Dual Engine Binary with Toggle
+  </h5>
+
+  <p>Allow browser vendors to ship a single binary globally which contains both the browser
+    vendor's own engine and the WKWebView version. For regulatory jurisdictions that haven’t yet forced
+    Apple to allow competition, the browser would use the WKWebView, and for those who have, the browser would use the
+    browser's own engine. Apple can indicate to the browser app whether they are allowed to use their own
+    engine, and based on that the browser could then decide if they wish to use their own engine. Likely only a
+    small technical change would be required for this solution to work. That is for Apple to provide some mechanism to
+    let browser vendors detect whether they can use their engine or not, as legally required. Aside from that this
+    would likely require no technical changes on Apple’s end, they would simply need to update their contracts
+    to allow it. In the event Apple is unwilling to develop such an API, Apple can simply update their contracts and
+    each browser vendor can detect whether a user is an EU resident to the best of their abilities using their own
+    mechanisms such as IP address.
+  </p>
+
+  <p>
+    The downside to this solution for browser vendors is that they would then be forced to
+    ship an additional 60 MB &nbsp;- 70 MB (OWA’s estimate) to many millions of users who would not be able to
+    use that engine due to Apple’s browser engine restrictions. This would then have an effect on user
+    acquisition and retention rates as well as those users’ data usage.
+  </p>
+
+  <p>We recommend that the Commission reach out to the vendors to ask their opinions, and
+    whether this solution would be feasible, if required to distribute a single global
+    binary.
+  </p>
+
+  <h4 id="c3-summary">
+    <a class="header-anchor" href="#c3-summary" aria-hidden="true">#</a>
+    3.1.3.2. Summary
+  </h4>
+
+  <p>It is not acceptable for Apple to use their mechanics of restricting browser engines to the EU to
+    suppress and undermine browser competition in the EU. If Apple can not be compelled to allow browser competition
+    globally on iOS, they should be compelled to make browser competition on iOS within the
+    EU <strong>at least</strong> minimally viable. The aim should be to allow third party browser
+    vendors to effectively contest Safari’s features, performance, security and privacy on a fair playing field.
+  </p>
+
+  <p>The commission does not need to force Apple to do anything outside of the EU. The
+    commission simply needs to compel Apple to allow browser vendors to update their existing browser apps for EU
+    customers to use their own engine, if Apple wishes to implement a complex solution to geolock that to the EU, that
+    is Apple’s choice, not the Commissions. Solutions A and Solution C are both straightforward ways in which
+    Apple could achieve a fairer result with minimal technical work.</p>
+
+  <h3 id="review-of-security-terms">
+    <a class="header-anchor" href="#review-of-security-terms" aria-hidden="true">#</a>
+    3.1.4. Review of Security Terms
+  </h3>
+
+  <h4 id="reasonable-security-clauses">
+    <a class="header-anchor" href="#reasonable-security-clauses" aria-hidden="true">#</a>
+    3.1.4.1. Reasonable Security Clauses
+  </h4>
+
+  <p>OWA would recommend asking each of the browser vendors their opinions on whether they
+    believe each security clause in Apple’s contract is reasonable or if any modifications should be made. The
+    following security clauses which Apple lists in their contract appear to be reasonable on our first review,
+    however OWA would need additional time to comprehensively analyze each of these conditions.
+  </p>
+
+  <blockquote>
+    <ol>
+      <li><strong class="alone">Secure Development, Supply Chain Monitoring &amp; Best
+          Practices</strong> <q>Commit to secure development processes, including
+          monitoring Your Application’s software supply chain for vulnerabilities, and following best practices
+          around secure software development (such as performing threat modeling on new features under
+          development)</q>;</li>
+      <li><strong class="alone">Vulnerability Submission Portal &amp; Policy</strong>
+        Provide a URL to a published vulnerability disclosure policy that includes contact information for
+        reporting of security vulnerabilities and issues to You by third parties (which may include Apple), what
+        information to provide in a report, and when to expect status updates;</li>
+      <li><strong class="alone">Timely Vulnerability Fixes</strong>
+        Commit
+        to mitigate vulnerabilities that are being exploited within Your Application or the Alternative Web Browser
+        Engine in a timely manner (e.g., 30 days for the simplest classes of vulnerabilities being actively
+        exploited);</li>
+      <li><strong class="alone">Publish Vulnerabilities</strong> Provide a
+        URL to a publicly available webpage (or pages) that provides information on which reported vulnerabilities have
+        been resolved in specific versions of the browser engine and associated Application version if
+        different;</li>
+      <li><strong class="alone">Root Certificate Policies</strong> If Your
+        Alternative Web Browser Engine uses a root certificate store that is not accessed via the iOS SDK, You must make
+        the root certificate policy publicly accessible and the owner of that policy must participate as a browser in
+        the Certification Authority/Browser Forum; </li>
+      <li><strong class="alone">Support Modern TLS</strong> Demonstrate
+        support for modern Transport Layer Security protocols to protect data-in-transit communications when the browser
+        engine is in use</li>
+      <li><strong>Memory Safe Languages OR Memory Safety Features</strong> Use memory-safe programming languages, or
+        features that improve memory safety within other
+        languages, within the Alternative Web Browser Engine at a minimum for all code that processes web
+        content;</li>
+      <li><strong class="alone">Latest Security Mitigations</strong>
+        Adopt
+        the latest security mitigations (for example, Pointer Authentication Codes) that remove classes of
+        vulnerabilities or make it much harder to develop an exploit chain;</li>
+      <li><strong class="alone">Best Security Practices</strong> Follow
+        secure design, and secure coding, best practices;</li>
+      <li><strong class="alone">Process Separation and Validate IPC</strong>
+        Use process separation to limit the effects of exploitation and validate inter-process communication
+        (IPC) within the Alternative Web Browser Engine;</li>
+      <li><strong class="alone">Supply Chain Vulnerability Monitoring </strong>
+        Monitor for vulnerabilities in any third-party software dependencies and the Your Alternative Web
+        Browser Engine App (EU)’s broader software supply chain, migrating to newer versions if a vulnerability
+        impacts Your Alternative Web Browser Engine App (EU);</li>
+      <li><strong>Don’t use Orphaned Software Libraries </strong>
+        Not use frameworks or software libraries that are no longer receiving security
+        updates in response to vulnerabilities.</li>
+    </ol>
+  </blockquote>
+
+  <p>These rules appear reasonable <strong>on the provision that Safari must equally
+      abide by them</strong>. For these rules, the current level of security of Safari and Apple's
+    native app ecosystem should be the benchmark. No browser should be penalized for doing a better job at security
+    than Apple's accepted status quo on iOS. </p>
+
+  <p>Apple attempted to claim to the UK’s CMA that WebKit’s security was
+    superior to that of Gecko and Blink, however the UK regulator found that Apple had no evidence to back up the
+    assertion. In Apple’s next response to the CMA they had dropped this claim.</p>
+
+  <blockquote>
+    <p>
+      ... in Apple's opinion, WebKit offers a better level of security
+      protection than Blink and Gecko.
+    </p>
+    <p>... the evidence that we have seen to date <strong class="stressed">does not
+        suggest</strong> that <strong class="stressed">there are material differences in the security
+        performance of WebKit and alternative browser engines</strong>.</p>
+    <p>Overall, the evidence we have received to date <strong class="stressed">does not
+        suggest that Apple's WebKit restriction allows for quicker and more effective response to security threats
+        for
+        dedicated browser apps on iOS</strong></p>
+    <p><cite><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report&sa=D&source=editors&ust=1718648881323727&usg=AOvVaw1wItvbQ1Je9Q3JkI-67aGA">UK
+          CMA - Interim Report into Mobile Ecosystems</a>
+        <br>(emphasis added)
+      </cite></p>
+  </blockquote>
+
+  <p>Both developers and users are already aware that installing a native app is more
+    dangerous than visiting a website, including if that app has passed a brief human “app review”.
+  </p>
+
+  <blockquote>
+    <p><strong class="stressed">The most dangerous feature that browsers have</strong>
+      are not the device API’s; it <strong class="stressed">
+        is the ability to link to and download native apps</strong>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/&sa=D&source=editors&ust=1718648881324812&usg=AOvVaw2sL7B3anF49FFINzlBGD5Z">
+          Niels Leenheer - HTML5test</a>
+        <br>(emphasis added)
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>Apple strongly relies on app store review as a mechanism to protect users from iOSs weaker
+    sandbox for Native Apps. Apple has placed great trust in “app review”, despite the fact they
+    reportedly only employ a
+    <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/2021/9/3/22654197/apple-app-store-editorial-scams-refunds&sa=D&source=editors&ust=1718648881325405&usg=AOvVaw1LOd-cVMGn8IJrs-XrKV4L">mere
+      500 reviewers</a>. These reviewers are expected to review 100,000+ Native Apps per week,
+    without the benefit of access to source code. While they are assisted by automated tools, each reviewer gets less
+    than 15 minutes to manually tap through apps, a process which is unlikely to be effective at picking up many types
+    of malicious apps.
+  </p>
+
+  <p>It doesn’t even appear to be effective in picking up apps that violate Apple’s payment
+    rules (that grant it a 15-30% stake), something they are likely to want to enforce. In one particularly striking
+    example of app review being ineffective at blocking updates that violate the current rules of the Apple’s
+    app store, Epic managed to <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://appleinsider.com/articles/20/08/13/epic-skirts-apples-30-commission-fee-by-implementing-direct-payments&sa=D&source=editors&ust=1718648881325903&usg=AOvVaw3-ON3mUJ8u47X62grvpCgZ">
+      slip in an entire third party payment solution</a> into their app without it being
+    picked up in review.</p>
+
+  <p>As Apple’s head of fraud <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/%23document/p1&sa=D&source=editors&ust=1718648881326439&usg=AOvVaw0GfUIzG04QW5vA4X2yAY4m">
+      Eric Friedman</a> said regarding review processes: </p>
+
+  <blockquote>
+    <p>please don’t ever believe that they accomplish
+      anything that would deter a sophisticated hacker.
+    </p>
+    <p>I consider them a wetware rate limiting service and nothing more</p>
+
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/%23document/p1&sa=D&source=editors&ust=1718648881327117&usg=AOvVaw1Ec3Iuo5AQkXt6ICujaCiG">
+          Eric Friedman - Apple’s former head of fraud on App Store Review</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>This suggests that while Apple outwardly projects confidence in the value of their app
+    store review some informed insiders view it as worthless. </p>
+
+  <p>Browsers use a far more reliable form of security than brief human review upon update.
+    They lockdown the entire environment that the third party code, that is websites and Web Apps, runs in. This
+    environment is called a sandbox and every action a website takes is tightly controlled. Even Apple acknowledges
+    that browsers sandbox is massively superior to iOS’s sandbox for native apps:</p>
+
+  <blockquote>
+    <p>WebKit’s sandbox profile on iOS is orders of magnitude more
+      stringent than the sandbox for native iOS apps.”</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf&sa=D&source=editors&ust=1718648881328155&usg=AOvVaw2hKr-aSR5tg7Dxtmif_g8G">
+          Apple’s Response to the CMA’s Mobile Ecosystems Market Study Interim Report</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>Thus while we agree that the standard browsers should be held to a higher standard than
+    that of a typical native app, it is critical that any security threat that browsers face be viewed holistically
+    and not in isolation. That is, were the user forced to install a native app to use that functionality, instead of
+    using a website or Web App what would their relative risk be. Would it be significantly better or worse.
+  </p>
+
+  <p>For example, if a browser implements a relatively secure, but not perfect,
+    implementation of WebBluetooth, then its level of security should be compared to the current accepted level of
+    security for native iOS apps that iOS already meets in their own CoreBluetooth implementation, not the
+    hypothetical perfect security that Safari's non-existent WebBluetooth implementation would like to
+    obtain.</p>
+
+  <p>Security is a subtle art and many of these rules are by necessity subjective. For
+    example “best practices” is no doubt a subject of fierce disagreement on certain points. As such,
+    Apple should only be able to focus on points where there is broad agreement in the industry that certain practices
+    are categorically and unambiguously bad.</p>
+
+  <p>Any complaint by Apple based on violation of these rules should be necessary,
+    reasonable, proportionate and justified with extensive evidence by Apple.</p>
+
+  <p>In some cases there may be more than one method to mitigate a threat and browser
+    engines’ very design may dictate how a browser defends against a particular threat. It is important
+    therefore that Apple’s rules do not force browsers to mitigate each threat in specific ways but rather focus
+    on the degree to which each browser has effectively mitigated a threat. In some cases there will be broad
+    agreement between browsers on how to mitigate particular threats, and in those cases the rules can be more
+    specific.</p>
+
+  <p>Apple should be very specific about which rule has been broken and its evidence for why
+    it believes that is the case. Apple’s current app review approach where apps are rejected without citing
+    specific rules or clearly outlining why, is unacceptable here.</p>
+
+  <p>Browser vendors should be consulted on each individual rule to see if they jointly
+    agree that all the conditions are reasonable before settling on the final list.</p>
+
+  <h4 id="problematic-security-clauses">
+    <a class="header-anchor" href="#problematic-security-clauses" aria-hidden="true">#</a>
+    3.1.4.2. Problematic Security Clauses
+  </h4>
+
+  <p>The following security terms in the contract are problematic:</p>
+
+  <h5 id="vulnerabilities-in-browser-apis">
+    <a class="header-anchor" href="#vulnerabilities-in-browser-apis" aria-hidden="true">#</a>
+    3.1.4.2.1. Vulnerabilities in Browser APIs
+  </h5>
+
+  <blockquote>
+    <p>Prioritize resolving reported vulnerabilities with expedience, over new
+      feature development. For example, where the Alternative Web Browser Engine bridges capabilities between the
+      platform’s SDK and web content to enable Web APIs, upon request the developer must remove support for such
+      a
+      Web API if it is identified to present a vulnerability. Most vulnerabilities should be resolved in 30 days, but
+      some may be more complex and may take longer.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881330441&usg=AOvVaw0la_jg3x_eODxXYnvCuoJY">Apple’s
+          Browser Entitlement Contract</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>What Apple is saying here, is that if an API has a vulnerability, no matter how minor
+    and no matter how much effort the browser vendor has taken to mitigate the vulnerability, Apple can demand that
+    they remove the browser API. This is not reasonable, proportionate, strictly necessary and Apple is not offering
+    to justify its decisions. All APIs contain the potential for vulnerabilities. Further, Apple would never accept an
+    equivalent clause for its own apps or browser. </p>
+
+  <p>This is particularly important as the primary reason that the DMA grants browsers the
+    right to use their own browser engine is to prevent gatekeepers (such as Apple) from determining the functionality
+    and standards for third-party browsers. Allowing Apple to ban third-party browsers from offering functionality on
+    flimsy (or non-existent) security justifications would severely undermine this goal.</p>
+
+  <p>This appears to grant Apple broad powers to use unnecessary and disproportionate
+    security measures to block rival browsers from providing functionality that is distinct from Safari, preventing
+    one of the core aims of the act in allowing browser vendors to port their own engines. It is critical that
+    browsers are allowed to bring functionality to enable browsers and Web Apps to compete with the software and
+    services of the gatekeepers including their native app ecosystems. If Apple is allowed to block functionality then
+    it will prevent this competition. Apple should not be able to impose any security rules that would outright
+    preclude browser vendors from porting such functionality, especially when considering that 5(7) does not have any
+    security carve-outs.</p>
+
+  <p>Additionally, in general, under 6(7), security terms which are not strictly necessary
+    or proportionate must be removed or be modified to be in compliance with the act.</p>
+
+  <p>There is always a trade off between security and utility. The safest browser would be
+    one that refuses to open. The key here for browser vendors is to offer as much security as reasonably possible for
+    their chosen level of utility. No browser should be compelled to reduce utility in the name of security if they
+    have taken firm efforts to mitigate risks.</p>
+
+
+  <h5 id="vulnerability-disclosure">
+    <a class="header-anchor" href="#vulnerability-disclosure" aria-hidden="true">#</a>
+    3.1.4.2.2. Vulnerability Disclosure
+  </h5>
+
+  <p>Apple states that all browser vendors must publish a vulnerability disclosure policy
+    and publicly state which reported vulnerabilities have been resolved in specific versions
+    of the browser engine and associated Application version if different.</p>
+
+  <blockquote>
+    <p>Provide a URL to a published vulnerability disclosure policy that includes
+      contact information for reporting of security vulnerabilities and issues to
+      You by third parties (which may
+      include Apple), what information to provide in a report, and when to expect
+      status updates;</p>
+    <p>…</p>
+    <p>Provide a URL to a publicly available webpage (or pages) that provides information
+      on which reported vulnerabilities have been resolved in specific versions of the browser engine and associated
+      Application version if different</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881332611&usg=AOvVaw28a2cC9N1Zn0s6lZmZW2aA">
+          Apple’s Browser Entitlement Contract</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>We believe this is reasonable on the proviso that Apple also abides by it when
+    publishing updates to Safari. Safari should not have any privileged status with regards to which security
+    vulnerabilities it publishes or the manner in which it publishes them. An obligation for competitors to publish
+    security vulnerabilities while exempting Apple from the same obligation would provide a significant unfair
+    competitive advantage to Apple. </p>
+
+  <p>One example of this Apple failing to adequately warn users of a
+    vulnerability or breach is the <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/&sa=D&source=editors&ust=1718648881333936&usg=AOvVaw0orQMFSYrABh-jhIggE7pN">
+      xCodeGhost iOS malware</a>. </p>
+
+  <p>Documents revealed as part of the current trial of Fortnite vs Apple show that in fact
+    128 million users downloaded the more than 2,500 infected apps, about two thirds of these in China. Popular apps
+    such as WeChat, Didi Chuxing, and Angry Birds 2, among others, were infected by XcodeGhost. These are some of the
+    largest native Apps in the world, being the equivalents of Facebook and Uber in China. WeChat, for example, has
+    1.24 billion users.</p>
+
+  <p>Apple discussed contacting users and briefly made an announcement on their China
+    website. Shortly after, it was removed. To our knowledge, Apple never contacted users to inform them of the
+    breach.</p>
+
+  <blockquote>
+    <p><strong class="stressed">this decision to not notify more than 100 million
+        users</strong> about potential security issues seems to <strong class="stressed">
+        have more to
+        do with protecting the platform’s reputation</strong> than helping users stay
+      safe</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/&sa=D&source=editors&ust=1718648881335296&usg=AOvVaw1J_1BGlANU-ml3i4mkB9ej">
+          Kirk McElhearn - Intego</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>The security of iPhones is one of Apple’s key marketing claims.
+    According to
+    <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881335815&usg=AOvVaw2HNrWblPzFpJA9YqG0nbCz">
+      two dozen security researchers</a>, who spoke on the condition of anonymity, Facebook,
+    Microsoft and Google all publicize their bug-bounty programs and take every opportunity to acknowledge and thank
+    those that find bugs and vulnerabilities sharing valuable insights, weaknesses and solutions. In contrast, Apple
+    conducts its programs in secrecy.
+  </p>
+
+  <p>Apple reportedly has a considerable bug backlog:</p>
+
+  <blockquote>
+    <p>You have to have a healthy internal bug fixing mechanism before you can
+      attempt to have a healthy bug vulnerability disclosure program. What do you expect is going to happen if they
+      report a bug that you already knew about but haven’t fixed? Or if they report something that takes you 500
+      days to fix it?</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881336537&usg=AOvVaw1BxLt0pQEOZekxIt3QNpQ5">
+          Moussouris - Helped create Microsoft's Bug Bounty Program</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>It seems like Apple thinks people reporting bugs are annoying and they want
+      to discourage people from doing so</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881337100&usg=AOvVaw2By_5WMhl3ASlln6lPhfGN">
+          Tian Zhang - an iOS software engineer</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>Apple’s closed-off approach hinders its security efforts</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881337618&usg=AOvVaw1OAx2GKYtJQlSip2_0Eq6v">
+          Dave Aitel - co-author of “The Hacker’s Handbook</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>Apple is slow to fix reported bugs and does not always pay hackers what they
+      believe they’re owed. Ultimately, they say, Apple’s insular culture has hurt the program and created
+      a
+      blind spot on security.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881338118&usg=AOvVaw2r1axOx40q9aItYViHoBAz">
+          Reed Albergotti - Washington Post</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>I want to share my frustrating experience participating in Apple Security
+      Bounty program. I've reported four 0-day vulnerabilities this year between March 10 and May 4, as of now
+      three
+      of them are still present in the latest iOS version (15.0) and one was fixed in 14.7, but Apple decided to cover
+      it up and not list it on the security content page. When I confronted them, they apologized, assured me it
+      happened due to a processing issue and promised to list it on the security content page of the next update.
+      There
+      were three releases since then and they broke their promise each time.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://habr.com/en/post/579714/&sa=D&source=editors&ust=1718648881338629&usg=AOvVaw2U0guBzjJqVM3VzRoLBYiN">
+          Denis Tokarev</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>If Apple can avoid full disclosure while compelling other vendors to, Apple may use
+    these disclosures to falsely claim superior security or create a pretense for delisting other browsers from its
+    app store. We recommend keeping this policy with the caveat that it also applies equally to Apple’s own
+    browser.</p>
+    <p>We also believe that non-disclosure agreements, which entirely prohibit security researchers from
+      publishing their findings (once a reasonable number of days has elapsed, for example
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html%23:~:text%3D%2522This%2520bug%2520is%2520subject%2520to%2520a%252090%2520day%2520disclosure%2520deadline.%2520If%2520a%2520fix%2520for%2520this%2520issue%2520is%2520made%2520available%2520to%2520users%2520before%2520the%2520end%2520of%2520the%252090%252Dday%2520deadline%252C%2520this%2520bug%2520report%2520will%2520become%2520public%252030%2520days%2520after%2520the%2520fix%2520was%2520made%2520available.%2520Otherwise%252C%2520this%2520bug%2520report%2520will%2520become%2520public%2520at%2520the%2520deadline.%2522&sa=D&source=editors&ust=1718648881339306&usg=AOvVaw0tcALn0tWSkb8uh8HYZ8hU">
+        Google Project Zero uses the shorter of 90 days or 30 days after patched</a>) after reporting
+      them to a particular browser vendor (such as Apple) should be prohibited, particularly if the browser vendor has
+      declined to fix these exploits. The ultimate aim here is to improve security by removing the ability of parties
+      to
+      hide both fixed and unfixed exploits from the public and tech community. This applies great pressure to increase
+      investment in security.
+    </p>
+
+    <h3 id="lack-of-justification-of-security-terms">
+      <a class="header-anchor" href="#lack-of-justification-of-security-terms" aria-hidden="true">#</a>
+      3.1.5. Lack of Justification of Security Terms (and Non-Security Terms)
+    </h3>
+
+    <blockquote>
+      <p>A gatekeeper can use different means to favour its own or third-party
+        services or products on its operating system, virtual assistant or web browser, to the detriment of the same
+        or
+        similar services that end users could obtain through other third parties.</p>
+      <p><cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881340240&usg=AOvVaw1x3ePSmnN34p8vpZqMHVGJ">
+            Digital Markets Act - Recital 49</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>One potential mechanism for favoring their own services is blocking competitors with
+      unnecessary and disproportionate security measures. As alleged in the USA Department of Justice’s (DOJ)
+      complaint, Apple has a history of using security rules inconsistently to serve their own financial
+      interests.</p>
+
+    <blockquote>
+      <p>In the end, Apple deploys privacy and security justifications as an elastic
+        shield that can stretch or contract to serve Apple’s financial and
+        business interests.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881341096&usg=AOvVaw3ROuLQRUpO40aOjRFCvTAs">
+            DOJ Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Although 5(7) does not contain carve-outs for security measures, we believe that it
+      would be proportional under the act to require browsers to meet security standards providing it doesn’t
+      prevent the browsers from porting their engines, and prevent them from implementing functionality. The language
+      under Article 6(7) of the DMA states that Apple must duly justify any security measures, which Apple should do
+      for
+      5(7).</p>
+
+    <p>Apple has not attempted to provide any justification to any of the rules in their
+      browser entitlement contract or rules found in documents or contracts it pulls in under "Apple
+      Materials''. We believe that Apple should be required to provide very detailed security justifications
+      for
+      each individual rule attached to obtaining this API access; Why is it strictly necessary and proportionate to
+      prevent this access from compromising the integrity of the operating system, hardware or software features
+      provided by Apple as per the wording and intent of the act.</p>
+
+    <p>It is important that Apple publicly publish these justifications so that they can be
+      scrutinized by the browser development and developer community to make sure that Apple is not attempting to use
+      security rules to undermine either the DMA or competition to their benefit, nor to EU consumers and business
+      users' detriment. This will allow the browser development and developer community to provide evidence and
+      feedback as to if each rule is reasonable and whether Apple's explanation as to its necessity and
+      proportionality are credible.</p>
+
+    <p>We support Apple having the ability to remove browsers that are either malicious or
+      consistently fail to meet a reasonable security standard clearly laid out in the rules (i.e patching regularly,
+      fixing vulnerabilities in a timely fashion, etc). However, we believe Apple should need to prove any allegations
+      with evidence and should face consequences for frivolous or unjustified removal of browsers.</p>
+
+    <h3 id="viral-terms">
+      <a class="header-anchor" href="#viral-terms" aria-hidden="true">#</a>
+      3.1.6. Viral Terms
+    </h3>
+
+    <p>Apple appears to conflate other rules and terms into their contract for API access via
+      the term “Apple Materials”. </p>
+
+    <p>It is defined in the contract as:</p>
+
+    <blockquote>
+      <p>&lsquo;Apple Materials&rsquo; means the Documentation, Entitlement
+        Profile, and other materials provided by Apple to You, and which are incorporated by reference into the
+        requirements of this Addendum.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881342877&usg=AOvVaw0Hy8FnBC8A_1g-H0mf1CHX">
+            Apple’s Browser Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is a frustratingly vague term. </p>
+
+    <p>Apple also state in the contract that they can not guarantee the availability,
+      completeness, or accuracy of Apple Materials. Given this term encompasses all potential rules the browser vendor
+      must abide by it is critical that these are available, clear, complete and accurate. Browser vendors (and likely
+      regulators) should be made aware of any plan to update them well in advance. Changes should be then subject to
+      scrutiny by the Commission, browser vendors and third parties such as OWA.</p>
+
+    <p>From their definition, it appears to encompass all documentation related to third-party browser
+      engines, any documentation those documents reference,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881343684&usg=AOvVaw204j-5Q8r67EPfVBmVnEJI">
+        the Apple Developer Program License Agreement</a> and the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/&sa=D&source=editors&ust=1718648881343943&usg=AOvVaw3_VI4MzGo0bfnX-gYJ0CSB">
+        Apple App Store Review Guidelines</a>.
+    </p>
+
+    <p>Further, the contract explicitly states on multiple occasions that signing and abiding by the
+      terms in Apple Developer Program License Agreement is required to use these APIs, indeed this contract is
+      structured as an addendum to the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881344392&usg=AOvVaw19-W8q7lywCR4eMttGNnwD">
+        Apple Developer Program License Agreement</a>.
+    </p>
+
+    <p>These combined documents contain a vast number of non-security terms and are
+      inappropriately referenced in the context of a browser that is not distributed via Apple’s app
+      store.
+    </p>
+
+    <p>As such these viral terms must be removed and Apple should clearly present all security
+      rules that they wish third-party browser vendors to abide by in order to access APIs necessary for building iOS
+      browsers.</p>
+
+    <h3 id="conflated-terms">
+      <a class="header-anchor" href="#conflated-terms" aria-hidden="true">#</a>
+      3.1.7. Conflated Terms
+    </h3>
+
+    <p>Again “Apple Materials” is problematic as it conflates together various
+      concepts that need to be separate.</p>
+
+    <p>It is defined in the contract as:</p>
+
+    <blockquote>
+      <p><span>‘Apple Materials’ means the Documentation, Entitlement
+          Profile, and other materials provided by Apple to You, and which are incorporated by reference into the
+          requirements of this Addendum.</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881345475&usg=AOvVaw3JXUhm1g0QF9LlJHx9uZJi">
+            Apple’s Browser Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Specifically this means Apple Materials includes:</p>
+    <ul>
+      <li>All documentation for the APIs</li>
+      <li>The nature of how these APIs function and whether they exist</li>
+      <li>All rules the browser vendor has to abide by</li>
+      <li>Additional contractual terms</li>
+      <li>Any other document referenced</li>
+    </ul>
+
+    <p>Specifically out of these, the rules which browser vendors need to abide by (which the
+      act mandates can only be security rules) need to be separated out into their own term and in a single document
+      which is available, clear, complete, accurate and up to date.</p>
+
+    <h3 id="hard-to-know-if-in-compliance">
+      <a class="header-anchor" href="#hard-to-know-if-in-compliance" aria-hidden="true">#</a>
+      3.1.8. Hard to Know if in Compliance
+    </h3>
+
+    <p>Even ignoring Apple's insertion of non-security rules into its API contract, the fact that
+      rules could be hidden in any of a vast range of non-explicitly defined documents,
+      that <a href="#viral-terms">by Apple's own admission</a> may be incomplete or
+      inaccurate and which they can change at any time without notification, means that staying in compliance becomes
+      a
+      fraught and unpredictable task for even the most diligent and security conscious of browser vendors. Even
+      browser
+      vendors with security significantly superior to Safari in all aspects could not be confident of being in
+      compliance when the existing rules are unclear and changes in compliance requirements are not telegraphed in
+      advance</p>
+
+    <p>This is clearly not strictly necessary, reasonable or proportionate.</p>
+
+    <h3 id="severe-and-unreasonable-penalties">
+      <a class="header-anchor" href="#severe-and-unreasonable-penalties" aria-hidden="true">#</a>
+      3.1.9. Severe and Unreasonable Penalties
+    </h3>
+
+    <p>Apple's Browser Engine API contract contains the following clause:</p>
+
+    <blockquote>
+      <p>2.9 While in no way limiting Apple’s other rights under
+        this Addendum or the Developer Agreement, or any other
+        remedies at law or equity, <strong>if Apple has reason to believe </strong>
+        You or Your Alternative Web Browser Engine App (EU) have
+        <strong>failed to comply with the requirements</strong> of this <strong>Addendum</strong>
+        or the <strong class="stressed">Developer Agreement</strong>, Apple
+        <strong>reserves the right to
+          revoke to Your access to any or all of the Alternative
+          Web Browser Engine APIs</strong> immediately upon notice to You;
+        require You to remove Your Entitlement Profile from Your
+        Alternative Web Browser Engine Application (EU); <strong>terminate
+          this Addendum; block updates of, hide, or remove Your
+          Alternative Web Browser Engine App (EU) and/or other
+          Applications from the App Store; block Your Applications
+          from distribution on Apple platforms; and/or to suspend or
+          remove You from the Apple Developer Program</strong>.
+      </p>
+      <p><cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881348084&usg=AOvVaw0pX-RMfm6LUKyfV85KK4M2">
+            Apple’s Browser Engine Entitlement Contract</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>That is, if Apple believes (note, Apple is not placing any burden of proof on itself
+      here) that any rule has been broken in either this contract or in the developer agreement then they grant
+      themselves the right to:</p>
+
+    <ul>
+      <li>Revoke access to the APIs</li>
+      <li>Remove the browser engine entitlement from the browser</li>
+      <li>Block updates or remove the browsers</li>
+      <li>Block other applications the browser vendor distributes on Apple
+        platforms</li>
+      <li>Suspend or remove the developer from the Apple developer
+        program</li>
+    </ul>
+
+    <p>Given the inherent vagueness of the rules that Apple is imposing here and Apple's long history
+      of being a <a href="#direct-browser-installation">poor and self-serving judge of the
+        implementation of those rules</a> this is an extremely threatening clause even to browser
+      vendors who are competently doing an appropriate job of <q>protecting the
+        integrity of the operating system, software and hardware of the gatekeeper</q>.</p>
+
+    <p>This is not strictly necessary, proportionate or reasonable.</p>
+
+    <p>While we support Apple's right to revoke access in cases of persistent negligence
+      or significant and provable malice, this clause as it currently stands, will allow Apple to strategically and
+      anti-competitively bully browser vendors over non-existant or minor edge cases.</p>
+
+    <p>For example, as this rule stands, if Mozilla were to violate a non-security rule related to
+      scrolling logic buried in a recently updated document on Apple's components, then under Apple’s
+      contract, they would be able to block and remove Firefox from all Apple platforms including macOS. While we
+      think
+      this exact scenario is unlikely due to the regulatory scrutiny it would bring, it does highlight the power Apple
+      is granting itself though this contract and how it subverts the intent of the DMA that the rules for API access
+      be
+      only security rules which are strictly necessary, proportionate and duly justified for
+      <i><q>protecting the integrity of the operating system, software and hardware of the
+        gatekeeper</q></i>.
+    </p>
+
+
+    <p>We believe this clause should be updated with language that impresses the necessity and
+      proportionality of any response by Apple and place a burden on Apple to justify with evidence any punitive
+      action
+      it might take against any browser vendor.</p>
+
+    <h3 id="requirement-to-use-apple-components">
+      <a class="header-anchor" href="#severe-and-unreasonable-penalties" aria-hidden="true">#</a>
+      3.1.10. Requirement to use Apple Components
+    </h3>
+
+    <p>In Apple's browser engine entitlement contract they appear to obligate browser
+      vendors to use iOS user interface libraries, rather than their own already built into Gecko and Blink.</p>
+
+    <p>In their documentation for BrowserEngineKit they state:</p>
+
+    <blockquote>
+      <p>To correctly render CSS and manipulate the Javascript DOM, your browser app
+        needs to integrate closely with UIKit and customize the way it handles many low-level user interface events.
+        Use
+        view classes in BrowserEngineKit to handle scrolling, drag interactions, and the context menu in your browser
+        app.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/BrowserEngineKit&sa=D&source=editors&ust=1718648881350509&usg=AOvVaw02E5Gy3LV491m305GhM1U8">
+            Apple Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This becomes a rule and not a suggestion due to this clause in the contract:</p>
+
+    <blockquote>
+      <p><strong class="stressed">You agree to use</strong>, only
+        through the use of the Entitlement Profile, <strong class="stressed">
+          an Alternative Web Browser Engine</strong>
+        in Your Alternative Web Browser Engine App (EU) <strong class="stressed">only as expressly
+          permitted</strong> in this Addendum and in the <strong class="stressed">Apple
+          Materials</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881351361&usg=AOvVaw2BVtxLot8HRji-B7mpK-IQ">
+            Apple Browser Engine Entitlement Contract</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>As discussed before, "Apple Materials" is a disconcertingly vague and broad
+      term that in effect means any imperative statement in any documentation referenced from the contract or
+      referenced
+      from those documents in a cascade are considered binding rules.</p>
+
+    <p>This is critical for two reasons. One, it means significant re-architecture of
+      third-party browsers' engines. This is highlighted in this ticket from Google:</p>
+
+    <blockquote>
+      <p>It's not entirely clear, but this seems to imply that existing browser
+        rendering engines must be re-architected to fit the UIKit rendering model. Chromium has a large and
+        sophisticated
+        rendering architecture which is designed to be platform-agnostic, rather than rely on
+        operating-system-specific
+        details such as the OS compositing architecture. As such, complex behaviour like scrolling is implemented
+        nearly
+        identically across all non-iOS Chrome platforms including Windows, MacOS, Android, Linux and ChromeOS. Using
+        an
+        operating-system provided scrolling / compositing architecture is infeasible for Chromium both because of the
+        huge
+        engineering expense and also because it would result in a worse product
+        in some ways.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/OpenWebAdvocacy/OpenWebCompetitionPlatform/issues/11&sa=D&source=editors&ust=1718648881352498&usg=AOvVaw11u68tQPCgUpow9rzneiEB">
+            Rick Byers - Web Platform Area Tech Lead, Chrome - Open Web Competition Platform</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The second, is that it is in the implementation of these very user interface libraries
+      that a not insignificant proportion of browser competition lies.</p>
+
+    <p>Scrolling is a good example. Apple's implementation for scroll on iOS Safari has
+      been riddled with bugs for any Web App that is attempting more 'app-like' layouts, that is ones where
+      part
+      of the page scrolls vertically rather than the entire page scrolling vertically.</p>
+
+    <blockquote>
+      <p>For more than 6 years, one of the biggest issues Web Developers have had to
+        deal with in Safari and other WebKit-based browsers on iOS (and in a lesser extent on macOS), is the inability
+        to
+        reliably block body scroll, or, said in other words, to remove the ability to scroll the current page in
+        certain
+        situations.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/web-platform-tests/interop/issues/84&sa=D&source=editors&ust=1718648881353339&usg=AOvVaw0ppLky7nKRBgIMlhZ1IORp">
+            OWA - Proposed Interop Issue</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple appears unable or unwilling to fix these bugs, despite identical functionality
+      working in almost every other browser for years. This has likely been prolonged by the complete lack of browser
+      competition on iOS to apply pressure to fix these bugs or risk losing market share.</p>
+
+    <p>Finally, Apple is only allowed to apply security rules in their API contract under
+      Article 6(7), but even if they were to move these rules to their app store guidelines, they should still be
+      struck
+      out under Article 5(7), and Article 13(4) for preventing browsers from porting significant and key parts of
+      their
+      engines.</p>
+
+    <p>It is essential that Apple does not constrain browsers from competing and bringing
+      their full rendering stack (the rendering stack is the collection of libraries responsible for converting html,
+      css and JavaScript into the displaying and updating the actual pixels on the screen inside the area controlled
+      by
+      the browser). Browser vendors should have the right, but not the obligation, to use these iOS provided user
+      interface libraries and components as appropriate to their needs.</p>
+
+    <p>This does not require Apple to make any technical changes. They simply have to update
+      their contracts and associated documentation. Apple may state they do not intend to enforce these rules in their
+      contract, but this is a misleading stance. Apple should not assert it has rights that are prohibited by the
+      DMA.</p>
+
+    <h3 id="privacy">
+      <a class="header-anchor" href="#privacy" aria-hidden="true">#</a>
+      3.1.11. Privacy
+    </h3>
+
+    <p>Apple is only allowed to apply strictly necessary, proportionate and duly justified for
+      <q>protecting the integrity of the operating system, software and hardware of the
+        gatekeeper</q> on API access.
+    </p>
+
+    <p>While improving privacy is a laudable goal, we have three concerns with Apple's
+      privacy section in their browser entitlement contract:</p>
+
+    <ol>
+      <li>The browser entitlement contract is the wrong place to include these
+        clauses as the DMA requires this to be limited to strictly necessary, proportionate and justified security
+        related rules. All of these rules, at a minimum, will need to be moved to the app store guidelines.</li>
+      <li>We are concerned that Apple may have weak or unenforced privacy rules for both
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://techcrunch.com/2023/07/25/apple-att-antitrust-france/&sa=D&source=editors&ust=1718648881355020&usg=AOvVaw3roi0e63FwvYxnUtDqMkfr">
+          its own apps</a> and
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/&sa=D&source=editors&ust=1718648881355366&usg=AOvVaw28ayu92dUxylCb2o_ML1og">
+          apps distributed by its app store</a> —
+        But extremely strong rules for browsers and
+        Web Apps. This will create pressure for apps that are based on advertising to be distributed via Apple’s
+        app store instead of the open web, as the former offers expanded access and weaker privacy protection for
+        consumers.
+      </li>
+      <li>Any privacy rule in the app store guidelines must not, in effect, ban any of
+        the existing major browsers from being ported, and thus contravene Article 5(7). Currently this would likely
+        only impact Chrome. Chrome is in the process of phasing out third-party cookies
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/&sa=D&source=editors&ust=1718648881355994&usg=AOvVaw28RITYOAtO7qbGHBDcZ5wI">
+          but has halted this while the UK's Competition and Market Authority reviews this
+          change</a>. The CMA is concerned that the phase out of third-party cookies in Chrome and replacement with
+        privacy sandbox will reduce competition in advertising. Apple must not apply any rule, that combined with this
+        fact, would de facto ban Google from porting its browser to iOS. While as an organization we can see the
+        privacy
+        benefits of the phase out of third-party cookies and support it, it can not be used as a tool to block
+        competitors from iOS. We would also be concerned at any attempt to fragment the functionality of browsers from
+        jurisdiction to jurisdiction.
+      </li>
+    </ol>
+
+    <blockquote>
+      <p>The CMA clarified that raising these concerns does not imply a belief that
+        the Privacy Sandbox changes cannot proceed. However, it signals the necessity for further resolutions before
+        moving forward.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/&sa=D&source=editors&ust=1718648881356948&usg=AOvVaw0RgC9iV-EQnPj9l_YxQvkp">
+            UK’s CMA Raises Concerns, May Delay Google’s Third-Party Cookie Phase-Out</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The CMA’s preliminary view is that Google is likely to have been aware
+        that these announcements, including the setting of a two-year deadline for deprecating TPCs, would adversely
+        affect market participants and reduce competition. For example, studies cited by Google in the announcement of
+        22
+        August 2019 suggested that when advertising is made less relevant by removing TPCs, funding for publishers
+        falls
+        by 52% on average.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62052c52e90e077f7881c975/Google_Sandbox_.pdf&sa=D&source=editors&ust=1718648881357849&usg=AOvVaw1it1Tv2dVz0SXIxu1Ml79e">CMA
+            on Privacy Sandbox</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>We also note that Apple intends to apply privacy rules to apps that are not distributed
+      by their app store but are signed/notarized by them. OWA considers Apple’s proposed notarization system
+      for
+      third party apps to be App Store Review, in all but name. Again while improving privacy is a laudable goal, we
+      are
+      concerned at the power this allows Apple to indiscriminately wield over apps that are not delivered though their
+      app store. This is strictly prohibited by the DMA as the security carve outs in both 6(4) and 6(7) are both
+      fairly
+      narrowly scooped.</p>
+
+    <p>The appropriate way for this issue to be dealt with is not to place this power in Apple's
+      hands. Apple has a long and proven history of bending its own rules to act in its own financial interests even
+      when that weakens or harms user privacy. Apple has also been shown to have
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/&sa=D&source=editors&ust=1718648881358772&usg=AOvVaw11PxJypjtY0q7-3ktT05dg">
+        dubious policies when it comes to their own employees' own privacy</a>. Apple is not a
+      trusted arbiter of privacy.
+    </p>
+
+    <blockquote>
+      <p>
+        In the end, Apple deploys privacy and security justifications as an
+        elastic shield that can stretch or contract to serve Apple’s financial and
+        business interests.
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+            DOJ Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>
+        Apple has a tactical commitment to your privacy, not a moral one. When it comes down to guarding your privacy
+        or losing access to
+        Chinese markets and manufacturing, your privacy is jettisoned without a second thought.
+        <cite>
+          <a href="">
+            Cory Doctorow - Former European director of the Electronic Frontier Foundation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>
+        Tim Cook, Apple’s chief executive, has said the data is safe. But at the data center in Guiyang, which Apple
+        hoped would be completed by next month, and another in the Inner
+        Mongolia region, <strong class="stressed">
+          Apple has largely ceded control to the Chinese government</strong>.
+      </p>
+      <p>
+        Chinese state employees physically manage the computers. Apple abandoned the encryption technology it used
+        elsewhere after China would not allow it. And the digital keys that unlock
+        information on those computers are stored in the data centers they’re meant to secure.
+      </p>
+      <p>[...]</p>
+      <p>
+        Apple has tried to isolate the Chinese servers from the
+        rest of its iCloud network, according to the documents.
+        The Chinese network would be “established, managed, and
+        monitored separately from all other networks, with no
+        means of traversing to other networks out of country.”
+        <strong class="stressed">
+          Two Apple engineers said the measure was to prevent security
+          breaches in China from spreading to the rest of Apple’s
+          data centers</strong>.
+      </p>
+      <p>
+        <strong class="stressed">Apple said that it sequestered the Chinese data centers
+          because they are, in effect, owned by the Chinese
+          government</strong>, and Apple keeps all third parties disconnected
+        from its internal network.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2021/05/17/technology/apple-china-censorship-data.html">
+            New York Times - Censorship, Surveillance and Profits:
+            A Hard Bargain for Apple in China</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Apple’s marketing insists that when it comes to privacy the company is
+        ethical and different, but when it comes to the people actually tasked with building the products that adhere
+        to
+        those standards — these values suddenly and mysteriously disappear.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/&sa=D&source=editors&ust=1718648881362093&usg=AOvVaw2uyJu8xRa8q8abgixbMmF8">
+            Karl Bode - Techdirt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">Privacy is a fundamental human right</strong>.
+        It’s also one of our
+        core values. Which is why we design our products and services to
+        protect it. That’s the kind of innovation we believe in.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/au/privacy/&sa=D&source=editors&ust=1718648881362649&usg=AOvVaw27QiHS-0cyyFD6SVaY4bwR">
+            Apple on Privacy</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>To solve the privacy issues, we would propose three solutions:</p>
+
+    <ol>
+      <li>Stronger privacy laws for the EU that would equally apply to native
+        apps, Web Apps, websites and Apple's own apps.</li>
+      <li>Apple taking steps to actually enforce a number of their privacy
+        rules and abiding by them for their own apps. They could then advertise the privacy advantages of their app
+        store over competitors or direct downloads. </li>
+      <li>Apple should not use any word games to exclude themselves from their own
+        privacy rules. For example Apple often refers to itself as a first party and displays different softer
+        warnings
+        or no warnings for similar behavior when Apple is the one collecting users data for the purposes of
+        advertising.
+        While a small part of its overall business,
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.forbes.com/sites/daviddoty/2023/02/08/apple-the-story-behind-its-new-ad-offerings-to-retailers-restaurants-hotels-other-location-based-businesses/%23:~:text%3DApple%2520seems%2520to%2520be%2520growing,coming%2520up%2520fast%2520if%2520quietly.)&sa=D&source=editors&ust=1718648881363839&usg=AOvVaw1xH0Kgn6tnXDBGTn8ShARq">
+          advertising is a significant and growing chunk of Apple’s revenue</a> coming in at $3.7
+        billion directly in 2021 and an additional $18 billion in 2021 via its search deal with Google.
+      </li>
+    </ol>
+
+    <p>For example
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/privacy/data/en/app-store/&sa=D&source=editors&ust=1718648881364338&usg=AOvVaw22k1INZIs5-X0gXTbukoPo">
+        in this document</a> they state that for their app store, they use users’
+      personal and identifiable data for the purposes of showing adverts. Users can opt-out via a deeply nested menu
+      option via “Settings &gt; [your name] &gt; Media &amp; Purchases &gt; View Account, and then tap to turn
+      off
+      Personalized Recommendations”:
+    </p>
+
+    <blockquote>
+      <p><strong class="stressed">
+          We collect your personal data</strong> so that we can provide you the content
+        you purchase, download, or want to update in the App Store
+        and other Apple online stores, including iTunes Store and Apple Books.</p>
+
+      <p><strong class="stressed">We also use information about your account, purchases, and downloads in the stores
+          to offer advertising</strong> to ensure that ads on the App Store, Apple News, and Stocks,
+        where available, are relevant to you. You have choices with respect to this advertising, as described
+        below.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/privacy/data/en/app-store/&sa=D&source=editors&ust=1718648881365551&usg=AOvVaw3Z6eSuxPgrIRmMljT_jh8E">
+            Apple App Store Data Policy</a>
+        </cite>
+      </p>
+    </blockquote>
+
+
+    <p>This appears to be potentially in breach of the DMA’s data rules that all
+      gatekeepers must abide by. Specifically this Article 5(2) (b):</p>
+
+    <blockquote>
+      <p>
+        2. The gatekeeper shall not do any of the following:
+      </p>
+      <p>
+        . . .
+      </p>
+      <p>
+        (b) <strong class="stressed">combine personal data from</strong> the relevant
+        core platform
+        service with personal data from any further core platform
+        services or <strong class="stressed">from any other services provided by the
+          gatekeeper </strong>
+        or with personal data from third-party services;
+      </p>
+      <p>
+        . . .
+      </p>
+      <p>
+        <strong class="stressed">unless the end user has been presented
+          with the specific choice
+          and has given consent</strong> within the meaning of Article 4, point
+        (11), and Article 7 of Regulation (EU) 2016/679.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Article 5(2)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>In this case Apple is combining data from its app store (a core platform service of Apple) with
+      other services of Apple including Apple News and Apple Stocks in order to perform targeted advertising. Whether
+      this is in breach would likely depend on whether users were prompted and the nature of that consent prompt.
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://9to5mac.com/2021/09/02/apple-personalized-ads-targeting-ios-15/%23:~:text%3DFor%2520iOS%252015%2520users%252C%2520Apple%2520has%2520begun%2520prompting,well%2520as%2520for%2520targeting%2520App%2520Store%2520Search%2520Ads.&sa=D&source=editors&ust=1718648881367362&usg=AOvVaw0QHD1BGfIFgF4PDAWixlMV">
+        Prior to iOS 15</a> users were not prompted and were automatically opted into targeted
+      advertising for Apple’s own apps.
+    </p>
+
+    <p>Apple’s behavior related to targeted advertising on iOS is already
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://techcrunch.com/2023/07/25/apple-att-antitrust-france/&sa=D&source=editors&ust=1718648881367812&usg=AOvVaw3pdDC_5xSqzJpEY25HxEr4">
+        under investigation by the French Competition Authority</a>. They are investigating whether
+      Apple is self preferencing by categorizing its behavior as it relates to advertising as special and thus under
+      different rules to other third parties on iOS.
+    </p>
+
+    <p>Apple’s carefully chosen definition of “tracking” excludes its own
+      behaviors from its privacy rules as they relate to targeted advertising. As Apple is both the operating system
+      and
+      the publisher of multiple Apple default apps, the app store is able to directly show targeted adverts without
+      providing the applied data to a third-party. We believe this is an intentional redefinition of
+      “tracking” to allow Apple to craft rules to allow its own use of targeted advertising whilst
+      disallowing the same behavior in third parties.</p>
+
+    <blockquote>
+      <p><strong class="stressed">Apple does not consider the processing activities
+          it undertakes in terms of personalised advertising (ie use of first-party data from different Apple apps and
+          services) as ‘tracking’</strong>, particularly as it does not link information
+        collected by apps from different companies, and therefore its apps are not required to show the ATT prompt.
+        This
+        is factually correct, given that, as detailed above, Apple uses data it collects from its own services which
+        it
+        operates under a single corporate ownership for personalised advertising purposes.</p>
+      <p></p>
+      <p>6.177 However, as further discussed in Appendix J, based on our consideration of
+        the ICO’s definition of online tracking, which does not distinguish between
+        first-party and third-party data, we consider
+        <strong class="stressed">Apple’s own use of its users'
+          personal data no less consistent with this description of
+          ‘tracking’ than that of third-party developers</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/63f61bc0d3bf7f62e8c34a02/Mobile_Ecosystems_Final_Report_amended_2.pdf&sa=D&source=editors&ust=1718648881369123&usg=AOvVaw3OdnW6YsomlMitiqsEmfVf">
+            CMA Mobile Ecosystems Report</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <h4 id="sharing-of-state">
+      <a class="header-anchor" href="#privacy" aria-hidden="true">#</a>
+      3.1.11.1. Sharing of State
+    </h4>
+
+    <blockquote>
+      <p>Not sync cookies and state between the browser and any other apps, even other
+        apps of the developer</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881369859&usg=AOvVaw1nFEwavFs8YY3BOb4RkjSD">
+            Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This line is problematic as it prohibits functionality that browsers already provide to
+      users. For example, many browsers (including Safari) sync state between a user's mobile browser and their
+      desktop browser. A lack of sync may prohibit other user-facing functionality, such as password autofill and tab
+      syncing.</p>
+
+    <p>As discussed in the previous section, Apple may only have strictly necessary,
+      proportionate and justified security rules in their browser engine API contract, thus this rule would need to be
+      moved to the app store rules. If Apple chooses to introduce this as an app store rule they would need to be more
+      specific and be cautious so as not to block browser vendors from providing useful functionality to users,
+      otherwise they risk violating Article 5(7).</p>
+
+    <h3 id="confidentiality-clause">
+      <a class="header-anchor" href="#confidentiality-clause" aria-hidden="true">#</a>
+      3.1.12. Confidentiality Clause
+    </h3>
+
+    <p>Apple has long had
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.nytimes.com/2008/07/26/business/26nocera.html&sa=D&source=editors&ust=1718648881370845&usg=AOvVaw1Igq1pyLWRhj07bxKrzABd">
+        a culture of secrecy</a>. This includes inserting confidentiality clauses into both its
+      agreements with other companies and with its staff.
+    </p>
+
+    <p>Its initial developer contract contained clauses banning companies publicly
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.wired.com/2008/09/apple-imposes-n/&sa=D&source=editors&ust=1718648881371293&usg=AOvVaw1EDq41V2ZXb1coeaepTfeI">
+        complaining about being rejected from the app store</a>. Rejection letters include a clause that
+      read:
+    </p>
+
+    <blockquote>
+      <p>THE INFORMATION CONTAINED IN THIS MESSAGE IS UNDER
+        NON-DISCLOSURE.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.wired.com/2008/09/apple-imposes-n/&sa=D&source=editors&ust=1718648881371719&usg=AOvVaw2NWYbyQFq_eh2Gj5qE9tPo">
+            Apple Rejection Email</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>They still have a similar clause in their current developer contract:</p>
+
+      <p>You may not issue any press releases or make any other public statements
+        regarding this Agreement, its terms and conditions, or the relationship of the parties without Apple’s
+        express prior written approval, which may be withheld at Apple’s discretion.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/%23ADPLA9:~:text%3D9.4%2520Press%2520Releases,at%2520Apple%25E2%2580%2599s%2520discretion.&sa=D&source=editors&ust=1718648881372433&usg=AOvVaw3kSBkPwm3H-gnhTaYlWNvr">Apple
+            Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Astonishingly, in Apple’s developer contract they state that anything the developer submits
+      to Apple is not confidential including if Apple wishes to publish it, use it to develop competing products or to
+      share this information with Apple’s partners and the app developers competitors. Given app store review is
+      essentially a condition of being on iOS, currently this seems a prime example of
+      the <q>serious imbalances in bargaining power and, consequently, to unfair
+        practices and conditions
+        for business users</q> that recital 4 of the DMA discusses:</p>
+
+    <blockquote>
+      <p>
+        Apple works with many application and software developers
+        and some of their products may be similar to or compete
+        with Your Applications. <strong class="stressed">Apple may also be developing its
+          own similar or competing applications and products or may
+          decide to do so in the future. To avoid potential
+          misunderstandings</strong> and except as otherwise expressly set
+        forth herein, Apple cannot agree, and expressly disclaims,
+        any confidentiality obligations or use restrictions,
+        express or implied, with respect to any information that
+        You may provide in connection with this Agreement or the
+        Program, including but not limited to information about
+        Your Application, Licensed Application Information, and
+        metadata (such disclosures will be referred to as “Licensee
+        Disclosures”). <strong class="stressed">You agree that any such Licensee Disclosures
+          will be non-confidential. Except as otherwise expressly set
+          forth herein, Apple will be free to use and disclose any
+          Licensee Disclosures on an unrestricted basis without
+          notifying or compensating You. You release Apple from all
+          liability and obligations that may arise from the receipt,
+          review, use, or disclosure of any portion of any Licensee
+          Disclosures. Any physical materials You submit to Apple
+          will become Apple property and Apple will have no obligation
+          to return those materials to You or to certify their destruction</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#ADPLA9:~:text=9.4%20Press%20Releases,at%20Apple%E2%80%99s%20discretion.">
+            Apple Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple has inserted the following clause into its browser engine entitlement
+      contract:</p>
+
+    <blockquote>
+      <p>
+        Confidentiality <strong class="stressed">You agree that any non-public information
+          regarding the Alternative Web Browser Engine APIs or
+          Alternative Web Browser Engine (EU) Entitlement Profile
+          shall be considered and treated as “Apple Confidential
+          Information”</strong> in accordance with the terms of Section 9
+        (Confidentiality) of the Developer Agreement. You agree
+        to use such Apple Confidential Information solely for the
+        purpose of exercising Your rights and performing Your
+        obligations under this Addendum and agree not to use such
+        Apple Confidential Information for any other purpose, for
+        Your own or any third party’s benefit, without Apple's
+        prior written consent. <strong class="stressed">You further agree not to disclose
+          or disseminate Apple Confidential Information to anyone
+          other than those of Your employees or contractors who have
+          a need to know and who are bound by a written agreement
+          that prohibited unauthorized use or disclose of the Apple
+          Confidential Information</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+            Apple Browser Engine Entitlement Document</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Besides clearly not being a security measure, this clause directly violates the DMA in
+      another way, In Recital 42 the DMA states:</p>
+
+    <blockquote>
+      <p><strong class="stressed">Any practice that would in any way inhibit or
+          hinder those users in raising their concerns</strong> or in seeking available redress,
+        <strong class="stressed">for instance by means of confidentiality clauses in agreements</strong> or other
+        written terms, should therefore be prohibited. This prohibition should be without
+        prejudice to the right of business users and gatekeepers to lay down in their agreements the terms of use
+        including the use of lawful complaints-handling mechanisms, including any use of alternative dispute
+        resolution
+        mechanisms or of the jurisdiction of specific courts in compliance with respective Union and national law.
+        This
+        should also be without prejudice to the role gatekeepers play in the fight against illegal content
+        online.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881376619&usg=AOvVaw09qM5CLBK1scrAO5SeVllu">
+            DigitalMarkets Act - Recital 42</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The EU courts, the Commission and other EU national authorities do not work for the
+      browser vendors, nor are they required to sign any such non-disclosure agreement (NDA). This contract explicitly
+      states that such sharing of any non-public interactions with courts and regulators in the EU would be a
+      violation
+      of the contract.</p>
+
+    <p>Apple should not attempt to grant itself confidentiality rights that it is already
+      explicitly prohibited from granting by the DMA.</p>
+
+    <p>This combination of an unreasonable and blanket ban on criticizing Apple’s app
+      review process and a clause that Apple can use confidential information submitted to them for the purposes of
+      app
+      store review in any way they see fit, including to compete against the very same app, again points to an
+      imbalance
+      in power between the Apple the gatekeeper and the business users.</p>
+
+    <p>This clause will, at a minimum, need to be updated with a sentence that explicitly
+      explains that browser vendors are permitted to share such information about their interactions with Apple, to
+      regulators and other government enforcement bodies in the EU.</p>
+
+    <p>We would go further and argue it is unreasonable of Apple to hide malicious compliance
+      of the DMA from the broader public via such confidentiality clauses and to obligate business users to release
+      confidential information to Apple nominally for app store review, that Apple can then use for any purpose.
+    </p>
+
+    <p>Should browser vendors wish to talk to the press about Apple (for example) rejecting
+      their browser for frivolous reasons, then they should be able to do so. Blocking public pressure, which
+      facilitates the proper functioning of the DMA via NDAs or confidentiality agreements, should be
+      prohibited.
+    </p>
+
+    <p>Preventing individuals and companies from talking to regulators and courts via
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881378016&usg=AOvVaw1qR2-9G0u3CwpGca40npGr">
+        such illegal NDAs is not hypothetical</a>. In this example Apple subcontractor Thomas Le
+      Bonniec was frightened by his non-disclosure agreement and initially did not come forward with allegations
+      about Siri’s privacy practices.
+    </p>
+
+    <blockquote>
+      <p>It was scary. I thought I may end up broke for the rest of my
+        life,</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881378575&usg=AOvVaw26GlKzqCqo2jyiRZngp545">Apple
+            subcontractor Thomas Le Bonniec</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>is contract threatened unspecified 'monetary damages' if he shared
+        confidential information 'outside of work' — with no
+        exceptions, according to his complaint.
+      </p>
+
+      <p>As a dedicated Siri data analyst, Le Bonniec said he heard conversations he believed
+        violated users’ privacy, including details about sexual preferences, bank account numbers and health
+        problems. He said that the importance of exposing the existence of the recordings outweighed the risks of
+        breaking
+        his agreement, so he went public. After an outcry by consumers, Apple made changes to Siri to address privacy
+        concerns.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881379264&usg=AOvVaw0KLUFh7iqGO2Pb-UY6Q7ZX">
+            Sabrina Willmer, Austin Weinstein and Bloomberg - Tech firms are using NDAs to illegally muzzle
+            whistleblowers</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This clause needs to be removed from the browser engine entitlement contract. Any
+      similar clause in the app store rules should include language making it explicit that complaints to the
+      Commission, EU courts and other EU legal bodies are permitted. In our opinion, it is not enough to simply state
+      elsewhere that they will not enforce such action. The contracts themselves need to be compliant with the DMA.
+      Further, if possible under any section of the DMA or any other applicable EU law, Apple’s confidentiality
+      clauses should be scrutinized to make sure they are necessary, proportionate, fair and reasonable.</p>
+
+    <h3 id="apple-can-change-or-break-any-api-with-no-notice">
+      <a class="header-anchor" href="#apple-can-change-or-break-any-api-with-no-notice" aria-hidden="true">#</a>
+      3.1.13. Apple can Change or Break any API with No Notice
+    </h3>
+
+    <p>In their browser engine entitlement contract Apple states that they can change or break
+      any API with no notice.</p>
+
+    <blockquote>
+      <p>
+        <strong class="stressed">Apple may at any time, and from time to time, with or
+          without prior notice to You, modify, remove</strong>, or reissue
+        the Apple Materials or the <strong class="stressed">Alternative Web Browser Engine
+          APIs, or any part thereof. You understand that any such
+          modifications may require You to change or update Your
+          Alternative Web Browser Engine App (EU) at Your own cost
+          and that features and functionality of such App may cease
+          to function</strong>. Except as required by applicable law, Apple
+        has no express or implied obligation to provide, or
+        continue to provide, the Apple Materials or Alternative
+        Web Browser Engine APIs, and may suspend or discontinue
+        all or any portion of Your access to them at any time
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+            Apple Browser Engine Entitlement Document</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is clearly unreasonable, as the browser vendors need time to update their browser
+      in order to make sure it continues to work despite the API change or removal.</p>
+
+    <p>Next, Apple is obligated to make sure any software or hardware feature that is used, or
+      available on the system, is provided to browser vendors free of charge subject to narrow scope security measures
+      under Article 6(7).</p>
+
+    <p>Apple is also not allowed under Article 5(7) or Article 13(4) to remove or alter any
+      API in such a way that would undermine the effectiveness of Article 5(7) in allowing browser vendors to port
+      their
+      engines to iOS.</p>
+
+    <p>Finally, under Article 13(6) of the DMA, Apple is not allowed to degrade the conditions
+      or quality of any of the core platform services provided to business users or end users who avail themselves of
+      the rights or choices laid down in Articles 5, 6 and 7 in particular Article 5(7) and Article 6(7).</p>
+
+    <h3 id="apple-can-withhold-any-api-from-browser-vendor">
+      <a class="header-anchor" href="#apple-can-withhold-any-api-from-browser-vendor" aria-hidden="true">#</a>
+      3.1.14. Apple can Withhold any API from any Browser Vendor
+    </h3>
+
+    <p>In the same paragraph in Apple’s browser engine entitlement contract Apple
+      states:</p>
+
+    <blockquote>
+      <p>Except as required by applicable law, Apple has no express or implied
+        obligation to provide, or continue to provide, the Apple Materials or Alternative Web Browser Engine APIs, and
+        may
+        suspend or discontinue all or any portion of Your access to them at any time</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881382057&usg=AOvVaw1zBT4Jkl5guHn_VcHC2aUD">
+            Apple Browser Engine Entitlement Document</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>That is, Apple can suspend any API from any individual browser vendor. Apple does not
+      state they need to provide any evidence or rationale for such a suspension.</p>
+
+    <p>Given that this contract is in essence exclusively for the EU, and Apple are even
+      calling the app “Alternative Web Browser Engine (EU)”, and the DMA causes Apple to have an express
+      obligation to provide and continue to provide these APIs to browser vendors subject to narrow scope security
+      measures, Apple should not be attempting to override the DMA by contract. </p>
+
+    <p>As such this paragraph is explicitly inconsistent with the DMA and should be
+      removed.</p>
+
+    <h3 id="apple-can-remove-any-browser-from-its-app-store-at-its-sole-discretion">
+      <a class="header-anchor" href="#apple-can-remove-any-browser-from-its-app-store-at-its-sole-discretion" aria-hidden="true">#</a>
+      3.1.15. Apple can Remove any Browser from its App Store at its Sole Discretion
+    </h3>
+
+    <blockquote>
+      <p>Nothing herein shall imply that Apple will accept Your Alternative Web
+        Browser Engine App (EU) for distribution on the App Store, and You acknowledge and agree that Apple may, in
+        its
+        sole discretion, reject, or cease distributing Your Alternative Web Browser Engine App (EU) for any reason.
+        For
+        clarity, once Your Alternative Web Browser Engine App (EU) has been selected for distribution via the App
+        Store it
+        will be considered a “Licensed Application” under the Developer Agreement”</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881383176&usg=AOvVaw3Iex1cFhrN8bzQx4XFeIG5">
+            Apple Browser Engine Entitlement Document</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple in this clause states that, at its sole discretion, it can reject or remove a
+      browser vendor's app from the app store for any reason.</p>
+
+    <p>Again this is clearly not permissible under the DMA. Apple is required to operate its
+      app store with FRAND (Fair, reasonable and non-discriminatory) conditions under Article 6(12). Further, it is
+      not
+      allowed to restrict browser vendors from using their own engines under Article 5(7). </p>
+
+    <p>Any attempt to construct app store rules to prevent browsers from using their own
+      engine in order to provide improved features, stability, security or privacy relative to Safari would likely be
+      in
+      violation of Article 13(4) for undermining Article 5(7).</p>
+
+    <p>That is, rejecting a browser from Apple’s app store would not be at its sole
+      discretion and it could not do it for any reason. Apple should not try to override the DMA via its contract and
+      this paragraph should be modified to be compliant with the text of the DMA.</p>
+
+    <h3 id="apple-developer-agreement">
+      <a class="header-anchor" href="#apple-developer-agreement" aria-hidden="true">#</a>
+      3.1.16. Apple Developer Agreement
+    </h3>
+
+    <p>While, in the short term, all browser vendors will likely want to be on Apple’s
+      app store, it is not clear if this will remain the case. We would expect that over the long term many browser
+      vendors will switch to direct distribution and no longer provide their apps via the Apple’s app
+      store.</p>
+
+    <p>Many developers do not distribute on Apple’s app store for macOS, as a point of
+      comparison. </p>
+
+    <blockquote>
+      <p>Neither is on the store because they don't have to be. They can be on
+        Mac and distribute to users without sharing the revenue with us</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email&sa=D&source=editors&ust=1718648881384625&usg=AOvVaw0zdhVCxNyW3EcN61LqRxFb">
+            Philip Schiller - Apple Upper Management - On the Mac App Store</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Mere control of the app store review process, <a href="#apple-should-make-notarization-for-directly-downloaded-browsers-automatic">while of dubious and
+        likely negative value in improving browser security</a>, does allow Apple to exert great
+      control by holding up or rejecting app store updates. This exact
+      concern is highlighted in the DOJs case against Apple. This means that the prospect of having users download
+      signed apps directly from the browser vendors website using an automatic notarization system, similar to
+      macOS, is
+      likely quite appealing for browser vendors.</p>
+
+    <blockquote>
+      <p>Apple often enforces its App Store rules arbitrarily. And it frequently uses
+        App Store rules and restrictions to penalize and restrict developers that take advantage of technologies that
+        threaten to disrupt, disintermediate, compete with, or erode
+        Apple’s monopoly power.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881385451&usg=AOvVaw0NuD7QzcvM6XeOBWthjoaF">
+            DOJ - Case 2:24-cv-04055</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>For this reason it is quite concerning that Apple has chosen to make the contract for browser
+      engine APIs an amendment to the "<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881385920&usg=AOvVaw2AHfq04O6ANOFUsShJqUPc">Apple
+        Developer Program License Agreement</a>".</p>
+
+    <p>In the opening paragraphs it states that:</p>
+
+    <blockquote>
+      <p>Applications developed under this Agreement for iOS, iPadOS, macOS, tvOS,
+        visionOS, and watchOS can be distributed: (1) through the App Store, if selected by Apple, (2) on a limited
+        basis
+        for use on Registered Devices (as defined below), and (3) for beta testing through TestFlight. Applications
+        developed for iOS, iPadOS, macOS, and tvOS can additionally be distributed through Custom App Distribution, if
+        selected by Apple. Applications developed for macOS can additionally be separately distributed as described in
+        this Agreement.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881386670&usg=AOvVaw0AUoa_QsCmYsunLIjUQkeu">
+            Apple Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly, the only apps that can be distributed using this agreement outside
+      Apple's app store or Apple's app store guidelines are applications for macOS:</p>
+
+    <p><q>Applications developed for macOS can additionally be separately distributed as
+        described in this Agreement.</q></p>
+
+    <p>The agreement then has an entire section describing the rules for having your app
+      notarized for macOS.</p>
+
+    <blockquote>
+      <p>Apple may revoke Tickets at any time in its sole discretion in the event that
+        Apple has reason to believe, or has reasonable suspicions, that Your Application contains malware or
+        malicious,
+        suspicious or harmful code or components or that Your developer identity signature has been
+        compromised.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/%23ADPLA5.3&sa=D&source=editors&ust=1718648881387589&usg=AOvVaw0jmfy4McZtR9eDikOgbixI">
+            Apple - Notarization for macOS</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is worth taking note that even in the instance where Apple has found that your app
+      contains malware, this clause has lighter implications and is less broad than the one in Apple's contract
+      for
+      browser engine API access for potentially far more minor or dubious infractions. </p>
+
+    <p>While this clause does have the phrase <q>in its sole
+        discretion</q> it does at least make clear the nature of the infringement: That
+      Apple would have reason to believe that app contains malicious code and that the penalty would simply be
+      having
+      that specific app unnotarized.</p>
+
+    <p>Apple is required by the act to allow browser vendors to distribute directly and will
+      only be subject to the strictly necessary, proportionate and justified security measures in 6(4) and 6(7). Thus,
+      either the browser engine entitlement contract should be separate or the Apple Developer Program License
+      Agreement
+      should be updated with language making it clear that apps can be distributed directly and that any rules in the
+      Apple Developer Program License Agreement or associated documents do not apply to them. Instead, only a clearly
+      listed set of security rules would apply.</p>
+
+
+    <h2 id="choice-screens">
+      <a class="header-anchor" href="#choice-screens" aria-hidden="true">#</a>
+      3.2. Choice Screens
+    </h2>
+
+    <blockquote>
+      <p><strong class="stressed">A gatekeeper can use different means to favour its
+          own or third-party services or products on its operating system</strong>, virtual
+        assistant or web
+        browser, <strong class="stressed">to the detriment of the same or similar services that end users could
+          obtain
+          through other third parties</strong>. This can for instance happen where certain software
+        applications or services are pre-installed by a gatekeeper. To enable end user choice, gatekeepers should not
+        prevent end users from un-installing any software applications on their operating system. It should be
+        possible
+        for the gatekeeper to restrict such un-installation only when such software applications are essential to the
+        functioning of the operating system or the device. Gatekeepers should also allow end users to easily change
+        the
+        default settings on the operating system, virtual assistant and web browser
+        <strong class="stressed">when those default settings favour their own software applications and services. This
+          includes prompting a choice
+          screen</strong>, at the moment of the users’ first use of an online search engine, virtual
+        assistant or web browser of the gatekeeper listed in the designation decision, allowing end users to select an
+        alternative default service when the operating system of the gatekeeper directs end users to those online
+        search
+        engine, virtual assistant or web browser and when the virtual assistant or the web browser of the gatekeeper
+        direct the user to the online search engine listed in the designation decision.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881389125&usg=AOvVaw02ut7-IcXih_A2f_9hSSWW">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The act explains that gatekeepers of operating systems can favor their own products by
+      pre-installing them and setting them as the system default. One of the methods used by the act to help combat
+      this
+      self-preferencing is a choice screen for browsers on operating systems where the browser of the gatekeeper has
+      been set as the default.</p>
+
+    <p>No choice screen will ever completely nullify the advantage granted to the gatekeeper
+      by setting the default browser. In order to have maximum impact in minimizing the effect of this
+      self-preferencing, to increase user autonomy and to not introduce new self-preferencing via the choice screen
+      itself, the choice screen must be carefully designed. Apple’s choice screen, while much improved from
+      initial proposals, still has significant issues.</p>
+
+    <p>While this document focuses only on Apple, in most cases we recommend equivalent
+      remedies for Google’s Android.</p>
+
+    <h3 id="browser-should-be-allowed-to-show-more-information-on-choice-screen">
+      <a class="header-anchor" href="#browser-should-be-allowed-to-show-more-information-on-choice-screen" aria-hidden="true">#</a>
+      3.2.1. Browsers should Be Allowed To Show More Information on Choice Screen
+    </h3>
+
+    <p>Currently on iOS the amount of information that browser vendors can show on the choice
+      screen is extremely limited. It is limited to the company's name, browser name and browser logo.</p>
+
+    <figure>
+      <img alt="" src="/images/apple-dma-report/image5.png">
+      <figcaption>Apple’s Browser Choice Screen</figcaption>
+    </figure>
+
+    <p>One of the aims of the act with the choice screen is to allow users to make an informed
+      choice and to limit the degree to which operating system gatekeepers can self-preference their own browser by
+      setting it as the default.</p>
+
+    <p>With this in mind, it seems entirely appropriate that Apple allow browser vendors to
+      display a sentence explaining why users should choose their browser. The layout should be updated to allow the
+      full sentence to be displayed without clicking on any buttons, a more reasonable character limit might be 150
+      characters (about 30 words).</p>
+
+    <p>To do otherwise concentrates power in the hands of major browsers and suppresses
+      smaller entrants from the mobile browser market. </p>
+
+    <h3 id="shouldnt-be locked-to-the-gatekeepers-app-store">
+      <a class="header-anchor" href="#shouldnt-be locked-to-the-gatekeepers-app-store" aria-hidden="true">#</a>
+      3.2.2. Shouldn't be Locked to the Gatekeepers App Store
+    </h3>
+
+    <blockquote>
+      <p><strong class="stressed">To prevent further reinforcing their dependence on
+          the core platform services of gatekeepers, and in order to promote multi-homing, the business users of those
+          gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate</strong> for the purpose of interacting with any end users that those business
+        users have already acquired through core platform services provided by the gatekeeper or through other
+        channels.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881391333&usg=AOvVaw1Y4E-ABY_a-UIZLGwFJz_M">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Multi-homing is where an end user or business user uses multiple core-platform
+      services. For example owning an Android phone and an iOS iPad. It could also be having multiple apps on a phone
+      from different distributors such as different app stores or directly from the business user (i.e. direct
+      download
+      / distribution via the web).</p>
+
+    <p>The act specifically highlights direct distribution, in this case downloading and
+      updating directly from the business users own website, as something business users should have the option of
+      choosing for their users. Should a browser vendor wish to distribute to their users directly via their own
+      website
+      (as opposed to Apple’s app store), they should be able to do so.</p>
+
+    <p>Choice screens aim to nullify the way that operating system gatekeepers self-preference
+      themselves via setting defaults on the operating system. This remedy should not then reinforce the dependence on
+      the core platform services of gatekeepers, in particular their app store.</p>
+
+    <p>There are a number of concerns here:</p>
+
+    <ol>
+      <li>Apple is only counting browsers downloaded from their app stores in
+        the calculation of the 12 most popular browsers. Browsers that are downloaded directly or from another app
+        store need to be included in this count.</li>
+      <li>Browsers that are not available on the gatekeepers app store at all
+        still need to be included.</li>
+      <li>Browser vendors should not be locked to the gatekeepers app store
+        and should be able to opt into distributing directly to users. Given that all of Apple's security checks
+        are built into their browser entitlement contract and notarization process, there is absolutely no plausible
+        reason to introduce scare screens, and doing so would, in our opinion, be a violation of the act.</li>
+    </ol>
+
+    <p>To allow Apple to impose their app store as the sole gateway for downloading browsers
+      via the choice screen or even the default is against the intent of the act.</p>
+
+    <p>These changes are critical to browser competition on mobile operating systems. In the
+      same manner that it would have been ridiculous for Microsoft to tie their choice screen to only browsers on a
+      Microsoft store from which they set the rules and get a 30% cut, it is unreasonable for Apple to tie their
+      choice
+      screen to their app stores along with their rules and their up to 30% cut.</p>
+
+    <p>Without allowing browser vendors chosen via the choice screen to be directly downloaded
+      from the browser vendor themselves, and instead forcing them to use the Apple’s app store, will continue
+      to
+      damage browser competition including:</p>
+
+    <ul>
+      <li>Forcing browser vendors to share 30% of all revenue made via
+        in-app purchases, which would effectively kill various business models or significantly reduce browser revenue
+        (i.e. for purchases of VPNs, or subscriptions to AI assistants).</li>
+      <li>Forcing all browser vendors to accept the gatekeeper’s app
+        store rules and conditions, which are well documented to be unfair and hamper competition.</li>
+      <li>Introduces delays and complexity into planning and releases.</li>
+    </ul>
+
+    <h3 id="should-be-a-background-and-direct-download">
+      <a class="header-anchor" href="#should-be-a-background-and-direct-download" aria-hidden="true">#</a>
+      3.2.3. Should be a Background and Direct Download
+    </h3>
+
+    <p>As discussed in the previous section, taking the user to the app store is an
+      inappropriate flow, it also introduces friction relative to the gatekeepers browser which is
+      preinstalled.
+    </p>
+
+    <p>Instead, the user should simply pick their new default browser from the choice screen
+      and the operating system should download and install the browser in the background. The choice screen should
+      allow
+      the browser vendor to show relevant information about their browser, including pictures and videos that the user
+      can see by clicking on a “see more” arrow icon. </p>
+
+    <p>This design works far better when different browsers are coming from different
+      distribution channels such as directly from the browser vendors website. Both Google and Apple's design
+      currently conflict with this requirement and will need to be reworked.</p>
+
+    <p>Next, Apple appears to have recently added a time to download countdown to the Apple
+      app store page.</p>
+
+    <figure>
+      <img alt="" src="/images/apple-dma-report/image4.png">
+      <figcaption>The Choice Screen when Brave has been selected and
+        the download symbol has
+        been pressed. Note the “cancel” button at the top
+        and the install time widget that Apple has
+        added.</figcaption>
+    </figure>
+
+    <p>We believe that this, in combination with the prominent cancel button, is an attempt by
+      Apple to use the fact they are preinstalled to undermine user autonomy and push users towards Safari.</p>
+
+    <p>Instead of having a countdown, we believe that Apple should simply set that browser as
+      the default browser immediately, continue to the homescreen, and replace Safari on the hotseat with the user
+      selected browser. It will be clear to the user that the browser is downloading, as it will have the standard
+      downloading circle on the hotseat. We believe after this process has been started, it should continue until it
+      has
+      finished. Providing an additional cancel option undermines the choice screen.</p>
+
+    <h3 id="browser-vendors-need-data-on-the-choice-screen-to-measure-performance">
+      <a class="header-anchor" href="#browser-vendors-need-data-on-the-choice-screen-to-measure-performance" aria-hidden="true">#</a>
+      3.2.4. Browser Vendors Need Data on the Choice Screen to Measure Performance
+    </h3>
+
+    <p>Third party browser vendors need access to the number of times their browser was shown
+      and the number of times their browser was picked on the choice screen by end users. This data can be aggregated
+      per country per day. Additionally it would be useful to include additional information, such as the position in
+      the choice screen the browser was shown.</p>
+
+    <p>For example one piece of aggregated data a browser vendor might receive could
+      be:</p>
+
+    <dl>
+      <dt>Country:</dt>
+      <dd>Germany</dd>
+      <dt>Date:</dt>
+      <dd>2024-07-01</dd>
+      <dt>Browser:</dt>
+      <dd>Firefox</dd>
+      <dt>Times Shown:</dt>
+      <dd>1451</dd>
+      <dt>Times Selected:</dt>
+      <dd>435</dd>
+    </dl>
+
+    <p>i.e. 1451 people were shown Firefox across all positions in Germany on 2024-07-01, out
+      of them 435 chose to make Firefox the default browser.</p>
+
+    <p>For the more detailed one that includes position an example would be:</p>
+
+    <dl>
+      <dt>Country:</dt>
+      <dd>Germany</dd>
+      <dt>Date:</dt>
+      <dd>2024-07-01</dd>
+      <dt>Browser:</dt>
+      <dd>Firefox</dd>
+      <dt>Times Shown:</dt>
+      <dd>77</dd>
+      <dt>Times Selected:</dt>
+      <dd>5</dd>
+      <dt>Position:</dt>
+      <dd>12</dd>
+    </dl>
+
+    <p>i.e. 77 people were shown Firefox in the 12th position in Germany on 2024-07-01, out of
+      them 5 chose to make Firefox the default browser.</p>
+
+    <p>This is important to give browser vendors the chance to work out what works in
+      advertising and adding features to their browser, as well as providing data that the remedy is effective.
+    </p>
+
+    <p>Given the data is aggregated and boils down to two numbers per country per day (or 24
+      for the more detailed one), there is no plausible privacy or security reason not to collect or share this data.
+      The only party that benefits from this data not being available is the operating system gatekeeper.</p>
+
+    <p>The operating system gatekeeper benefits in two ways. First, third party browser
+      vendors can not work out what blurb, advertising or features work in encouraging users to switch browsers.
+      Second,
+      the relative effectiveness of the choice screen is obscured.</p>
+
+    <p>Given this data is aggregated and non-confidential in nature, gatekeepers should not be
+      able to prevent browser vendors from publishing it if they choose to.</p>
+
+    <p>Finally, whether or not a remedy is effective is clearly important to the DMA. For
+      example in the event a gatekeeper is believed to have frustrated the objectives of an article, a proceeding can
+      be
+      opened. The gatekeeper can then be obligated to fix the behavior via commitments or be fined. In the event those
+      commitments are not effective the proceeding can be reopened.</p>
+
+    <blockquote>
+      <p>
+        2. The Commission may, upon request or on its own initiative, reopen by decision the relevant proceedings,
+        where:
+      </p>
+      <ul>
+        <li>(a) there has been a material change in any of the facts on which the decision was based;</li>
+        <li>(b) the gatekeeper concerned acts contrary to its commitments;</li>
+        <li>(c) the decision was based on incomplete, incorrect or misleading information provided by the parties;
+        </li>
+        <li><strong class="stressed">(d) the commitments are not effective</strong>.</li>
+      </ul>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Article 25(2)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The objective of Article 6(3) as outlined in Recital 49 is to nullify the
+      self-prefencing advantage gatekeepers grant their own apps via setting them as the default by default.</p>
+
+    <blockquote>
+      <p><strong class="stressed">A gatekeeper can use different means to favour its own or third-party services or
+          products on its operating system, virtual assistant or web browser, to the detriment of the same or similar
+          services that end users could obtain through other third parties.</strong>
+        This can for
+        instance happen where certain software applications or services are pre-installed by a gatekeeper. To enable
+        end
+        user choice, gatekeepers should not prevent end users from un-installing any software applications on their
+        operating system. It should be possible for the gatekeeper to restrict such un-installation only when such
+        software applications are essential to the functioning of the operating system
+        or the device. <strong class="stressed">
+          Gatekeepers should also allow end users to easily change the default settings on the operating
+          system,
+          virtual assistant and web browser when those default settings favour their
+          own software applications and
+          services. This includes prompting a choice
+          screen</strong>, at the moment of the users’ first use of an online search engine, virtual
+        assistant or web browser of the gatekeeper listed in the designation decision, allowing end users to select an
+        alternative default service when the operating system of the gatekeeper directs end users to those online
+        search
+        engine, virtual assistant or web browser and when the virtual assistant or the web browser of the gatekeeper
+        direct the user to the online search engine listed in the designation decision.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881400323&usg=AOvVaw2RhX2Wi6VmmQPP-hy62lGK">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+      </cite></p>
+    </blockquote>
+
+    <p>As such it is of critical importance that data to measure the effectiveness of
+      Apple’s compliance with the remedy is both collected and shared with relevant parties.</p>
+
+    <h3 id="apples-dark-pattern-exacerbated-by-keeping-hotseat">
+      <a class="header-anchor" href="#apples-dark-pattern-exacerbated-by-keeping-hotseat" aria-hidden="true">#</a>
+      3.2.5. Apple's Dark Pattern Exacerbated by Keeping Hotseat
+    </h3>
+
+    <figure>
+      <img alt="Main icons on iOS’s hotseat" src="/images/apple-dma-report/image2.png">
+      <figcaption>The hotseat on iOS’s homescreen</figcaption>
+    </figure>
+
+    <p>The <strong>hotseat</strong> is any of that collection of app
+      locations on the dock on the base of iOS homescreen. They have the advantage of always being shown regardless
+      of
+      which homescreen the user is on. Apple has set Safari to be in the hotseat by default (along with phone,
+      messages
+      and Apple Music), while users can change this setting manually by dragging the item out and another in, Apple
+      has
+      added significant friction by not making this automatic.</p>
+
+    <blockquote>
+      <p>Only about half (52%) of people understand that their default browser is
+        opened when they, for example, click on a link in an email or document.</p>
+      <p>[..]</p>
+      <p>over half (53%) also erroneously believed that their default browser would
+        automatically be pinned to their task-bar.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf&sa=D&source=editors&ust=1718648881401770&usg=AOvVaw2oJwEtl600_gmhSMqomfdn">
+            Mozilla – “Can browser choice screens be effective?” paper</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Being selected as the default browser does not grant the hotseat. This means it is
+      entirely possible, and in fact likely that many existing users who have set a third party browser as their
+      default
+      browser will still have Safari or Chrome on certain versions of Android in the hotseat.</p>
+
+    <p>While this is of concern on both Android and iOS, due to the undermining of the meaning
+      of default browser, an additional concern is introduced on iOS due to how Apple has implemented their choice
+      screen.</p>
+
+    <p>The DMA states this on choice screens:</p>
+
+    <blockquote>
+      <p>
+        This includes <strong class="stressed">prompting a choice screen, at the moment
+          of the users’ first use of an</strong> online
+        search engine, virtual assistant or <strong class="stressed">
+          web browser of the gatekeeper</strong>
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple has interpreted the DMA very directly here and will only show the choice screen
+      upon Safari being clicked, unlike Google which does it immediately upon system software update.</p>
+
+    <p>In Apple’s design, Safari’s interface actually loads and then the choice
+      screen is a full screen overlay over Safari. This has the psychological effect of making the choice screen seem
+      more like an interruption rather than part of the setup of the device. While this was more problematic in
+      Apple’s initial design which included a giant skip button (labeled “not now”) at the bottom
+      (which would essentially choose Safari), this still seems to be a nudge to users to quickly choose a browser and
+      get back to their initial task.</p>
+
+    <blockquote>
+      <p>People are significantly more likely to choose a pre-installed browser as
+        their default when the choice screen is shown at first use of the
+        browser [...] from 11% to 19%</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf&sa=D&source=editors&ust=1718648881404212&usg=AOvVaw0lCGCBNKUDZoKZXQ6z1ES6">
+            Mozilla – “Can browser choice screens be effective?” paper</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple's design then creates the problematic scenario where the choice screen will
+      be shown even if Safari is not the default browser. Apple is clearly aware of this based on the careful phrasing
+      of their speech at the workshop:</p>
+
+    <blockquote>
+      <p>In terms of what's being required here by the DMA
+        our focus is on <strong class="stressed">presenting this choice</strong> even more
+        clearly to consumers <strong class="stressed">the first time you use Safari</strong>.
+        Obviously there are not choices being presented when
+        you use other browsers on iOS. So we are complying
+        <strong class="stressed">from our perspective with the spirit here</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881405837&usg=AOvVaw15yzvVFfwmNVsjNMNwfb2e">
+            Apple representative at DMA Workshop</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Showing the choice screen when Safari is not the default is clearly against the intent
+      of the act and Apple needs to update the choice screen to only show if Safari is the default browser. The
+      default
+      browser not automatically granting the hotseat, significantly compounds and re-enforces this problem. While it
+      is
+      possible for users to manually change this, this style of friction significantly undermines browser competition.
+      Operating system gatekeepers know this and this is precisely why they are so resistant to such a change.
+    </p>
+
+    <p>It should be assumed that because Apple has displayed the choice screen when third
+      party browsers were already set as default, that they would have already gained users for Safari that they would
+      otherwise not have.</p>
+
+    <p>A reasonable remedy here would be to re-run the choice screen for all users that picked
+      Safari upon such an inappropriate choice screen being shown. If Apple does not store that information, it can
+      simply re-run the choice screen for all Safari users.</p>
+
+    <h3 id="periodic-choice-screen">
+      <a class="header-anchor" href="#periodic-choice-screen" aria-hidden="true">#</a>
+      3.2.6. Periodic Choice Screens
+    </h3>
+
+    <p>The act aims to nullify the power operating system gatekeepers grant themselves by
+      setting the defaults on the operating system. In particular, the "default browser" to their own and
+      placing their browser in a prominent location by default.</p>
+
+    <p>A one-off choice screen may have an impact, perhaps even a significant one, but that
+      impact will fade and will not achieve this goal of the act. It therefore seems appropriate that the choice
+      screen
+      is re-shown to users at an appropriate interval. </p>
+
+    <p>We believe then, that the choice screen should be shown whenever users encounter a new
+      reinstallation event, such as purchasing a new phone, restoring from an old phone or a factory reset.</p>
+
+    <p>This allows the choice screen to have a lasting impact. While it will not remove the
+      immense self privilege of the defaults the operating system gatekeeper sets, it will at least make a significant
+      dent. Critical mass is important for browsers as it strongly affects website developers’ interest in
+      supporting them and dictates their funding, which dictates their development budget.</p>
+
+    <p>We believe the act would support the display of choice screen on devices in which the
+      user is either transferring or restoring their settings to that device. As of the time of writing this document
+      (iOS 17.5), this is not implemented by Apple.</p>
+
+    <h2 id="resolved-issues">
+      <a class="header-anchor" href="#resolved-issues" aria-hidden="true">#</a>
+      3.3. Resolved Issues
+    </h2>
+
+    <h3 id="option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default">
+      <a class="header-anchor" href="#option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default" aria-hidden="true">#</a>
+      3.3.1. Option to Change Default Browser Hidden if Gatekeepers
+      Browser is the Default Browser
+    </h3>
+
+    <p>For the first 13 years of iOS it was impossible to change the default browser, it was locked to
+      Safari. Then in iOS 14 (released on 2020-09-06), <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/21444995/ios-14-default-browsers-chrome-edge-firefox-duckduckgo-safari&sa=D&source=editors&ust=1718648881409211&usg=AOvVaw3V5cIS7JNps5dNNbdj3KBG">
+        Apple added the ability to change it</a>. However as part of this update, Apple specifically coded
+      the
+      astonishing brazen dark pattern of hiding the option to change the
+      default browser in Safari
+      settings,<em>if Safari was already default</em>.
+      If Safari was <em>not the
+        default browser</em>, the option to change the default browser became
+      prominently shown.
+    </p>
+
+    <p>In our own testing, we found that, after <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/?comments%3D1&sa=D&source=editors&ust=1718648881410178&usg=AOvVaw3EaC6Q3IiGTl2U-VfiLyLD">significant
+        publicity</a> (<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881410620&usg=AOvVaw3NaISNMXGfU85vff9JLTGM">generated
+        by OWA</a>), Apple has quietly fixed this issue globally in iOS 17.5, which was released
+      on 2024-05-13, long past Apple’s cutoff compliance date for the DMA of 2024-03-07. While we are pleased
+      they
+      have taken the step to fix this without being directly compelled to do so, we felt given the clear intent,
+      brazenness and late compliance, that it was important context worth including. You can see this below.</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image6.png" alt="Safari's settings screen not showing the default browser choice">
+        <img src="/images/apple-dma-report/image8.png" alt="Safari's settings screen showing the default browser choice">
+      </p>
+      <figcaption>
+        Left: When Safari is the default /
+        Right: When Firefox is the default (Note the option to change default
+        browser has appeared)
+      </figcaption>
+    </figure>
+
+    <p>We asked Apple directly about this at the Apple DMA Workshop.
+      You can see our question,<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881411550&usg=AOvVaw1d862rWLxvNdKkiyEhjtLp">their
+        answer, and our analysis of their answer in this article</a>,
+      which was later <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/&sa=D&source=editors&ust=1718648881411844&usg=AOvVaw3EI3nw5miDrcgV7hQPvSyF">covered
+        on ArsTechnica</a>.</p>
+
+    <p>In other browsers on iOS the option is always shown regardless of whether they are the
+      default browser or not.</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image7.png" alt="Firefox's settings screen showing Safari as the default browser choice">
+        <img src="/images/apple-dma-report/image10.png" alt="Firefox's settings screen showing Firefox as the default browser choice">
+      </p>
+      <figcaption>
+        Left: When Safari is the default /
+        Right: When Firefox is the default (always shown on other browsers settings pages)
+      </figcaption>
+    </figure>
+
+    <p>Hiding the option to change the default browser if the gatekeeper's browser is the default was
+      a very clear violation of Article 13(4) as it clearly sought to undermine the users autonomy of choice.
+    </p>
+
+    <h2 id="remedies">
+      <a class="header-anchor" href="#remedies" aria-hidden="true">#</a>
+      4. Remedies
+    </h2>
+
+    <p>Here we propose three tranches of remedies which we believe are both justified and
+      proportionate. Some remedies require time and/or pre-requisite remedies in order to be effective. Remedies in
+      this
+      document are ordered to ensure that either competitive benefits are delivered earlier or to unlock future
+      remedies. In this way, we propose a program of continual improvement in the competitive landscape, delivering
+      wins
+      at every step along the path.</p>
+
+    <h2 id="tranche-1">
+      <a class="header-anchor" href="#tranche-1" aria-hidden="true">#</a>
+      4.1. Tranche 1
+    </h2>
+    <h3 id="browser-engine-entitlement-contract">
+      <a class="header-anchor" href="#browser-engine-entitlement-contract" aria-hidden="true">#</a>
+      4.1.1. Browser Engine Entitlement Contract
+    </h3>
+    <h4 id="remove-non-security-terms">
+      <a class="header-anchor" href="#remove-non-security-terms" aria-hidden="true">#</a>
+      4.1.1.1. Remove Non-Security Terms
+    </h4>
+
+    <p>Apple’s browser engine entitlement contract defines the conditions with which
+      browser vendors must comply with to be granted access by Apple to hardware and software features on iOS. Article
+      6(7) authorizes the gatekeeper to take such measures, but exclusively in order to preserve the security of the
+      operating system.</p>
+
+    <p>However, as discussed in <a href="#Apples-new-browser-engine-entitlement-contract">section
+        3.1</a>, Apple has incorporated into this contract a vast number of rules that do not
+      relate to security. These rules are therefore non-compliant with the DMA, and we recommend that Apple should
+      be
+      compelled to remove them.</p>
+
+    <p><strong>Apple should remove all non-security-related rules from this contract</strong>.</p>
+
+    <h4 id="dual-engine-browser">
+      <a class="header-anchor" href="#dual-engine-browser" aria-hidden="true">#</a>
+      4.1.1.2. Dual Engine Browser
+    </h4>
+
+    <p>Apple will need to remove the following rule from its browser engine entitlement
+      contract, and not add an equivalent rule elsewhere, such as in its app store guidelines:</p>
+
+    <blockquote>
+      <p>2.2 (page 1): “Be a separate binary from any Application that uses the
+        system-provided web browser engine”</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881414677&usg=AOvVaw1HgqKTOZfiAP12OAIK74ue">
+            Apple Browser Engine Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This rule is a significant barrier to browser vendors porting their real browsers to
+      iOS and defacto causes them to lose all their EU users on their existing browser app on iOS.</p>
+
+    <p>We cover this in greater depth in <a href="#must-not-use-browser-engine-of-operating-system">Section
+        3.1.2</a>.</p>
+
+    <h4 id="allow-browser-vendors-to-keep-their-existing-EU-customers">
+      <a class="header-anchor" href="#allow-browser-vendors-to-keep-their-existing-EU-customers" aria-hidden="true">#</a>
+      4.1.1.3. Allow Browser Vendors to keep their existing EU customers
+    </h4>
+
+    <p>Apple has chosen to restrict browser competition on iOS to the EU. Apple’s
+      actions seek to force third-party browser vendors to build, develop, and maintain two versions of their apps for
+      iOS while Apple’s own Safari bears no such costs.</p>
+
+    <p>Apple’s rules appear to force browser vendors to ship a brand new version of
+      their app in the EU, rather than update existing apps to use their own engines. This will cause browser vendors
+      to
+      lose existing customers, as consumers will need to manually download the new browser.</p>
+
+    <p>This complexity and friction is a direct result of Apple’s own anti-competitive
+      actions over the past 15 years. Apple’s insistence that competitors will only be allowed to compete on a
+      level playing field (with their own engines) in the EU is already a high burden, and this rollout plan would
+      levy
+      additional transition costs on competitors. It is reasonable and proportionate that Apple takes steps to
+      mitigate
+      the damage they appear intent on causing. </p>
+
+    <p>Forcing browser vendors to ship two distinct products in Europe will lead to end user
+      confusion and significant harm to these browser vendors. We do not believe that such an approach would be either
+      fair or compliant with the DMA.</p>
+
+    <p>Apple should not be forcing browser vendors to reacquire existing users. Apple will
+      need to implement a solution where browser vendors can use their own engines and keep their existing EU
+      users.</p>
+
+    <p>Specifically, we are seeking the Commission to compel Apple to allow browser vendors to
+      update their apps for EU consumers to their own engines. With this remedy, we are not asking that the Commission
+      compel Apple to make any changes outside the EU. It is between Apple and other global regulators if they add any
+      complex code or logic to restrict browser competition on iOS to the EU.</p>
+
+    <p>Apple has a number of options to comply with this remedy and have the opportunity to
+      suggest other alternatives that may solve the underlying issue. They are:</p>
+
+    <dl>
+      <dt>Solution A.</dt>
+      <dd><a href="#solution-a-allow-browser-engines-globally">Allow Browser Engines Globally</a></dd>
+      <dt>Solution B.</dt>
+      <dd><a href="#solution-b-two-binaries-for-one-bundle-id">Two Binaries for One Bundle ID</a></dd>
+      <dt>Solution C.</dt>
+      <dd><a href="#solution-c-global-dual-engine-binary-with-toggle">Global Dual Engine Binary with Toggle</a></dd>
+    </dl>
+
+    <p>Solution A and C would only require contract changes and the most minimal technical
+      changes.</p>
+
+    <p>We cover this in greater depth in <a href="#must-be-new-and-separate-app">Section
+        3.1.3</a>.</p>
+
+    <h4 id="requirement-to-use-apple-components">
+      <a class="header-anchor" href="#requirement-to-use-apple-components" aria-hidden="true">#</a>
+      4.1.1.4. Requirement to use Apple Components
+    </h4>
+
+    <p>Apple will need to remove any rule or suggestion that browser vendors are obligated to
+      replace parts of their browser engine with particular Apple layout, rendering or user interface components.
+    </p>
+
+    <p>Importantly, browser vendors need the right, but not the obligation, to use these
+      libraries and components.</p>
+
+    <p>We cover this in greater depth in
+      <a href="#requirement-to-use-apple-components">Section 3.1.10</a>.
+    </p>
+
+    <h4 id="remove-viral-terms">
+      <a class="header-anchor" href="#remove-viral-terms" aria-hidden="true">#</a>
+      4.1.1.5. Remove Viral Terms
+    </h4>
+
+    <p>“Apple Materials” is an inappropriately vague term that expands
+      Apple’s Browser Engine Entitlement Contract to include a great many non-security rules. The way it is
+      phrased is that any imperative statement in any document referenced from the contract or referenced from those
+      documents in cascade is a binding rule.</p>
+
+    <p>As this is purely a contract for API access, Apple is required to only have strictly
+      necessary and proportionate rules to protect the integrity of the operating system. Apple is also required to
+      justify all of these rules as being so.</p>
+
+    <p>As such, these viral terms must be removed and Apple should clearly present all
+      security rules that they wish third-party browser vendors to abide by in order to access APIs necessary for
+      building iOS browsers, preferably in a single document.</p>
+
+    <p>Any update to this document should be public and all relevant parties should be alerted
+      to the new proposed changes. Barring exceptional circumstances, changes should be known by browser vendors and
+      outside groups months in advance. </p>
+
+    <p>We cover this in greater depth in <a href="#viral-terms">Section
+        3.1.6</a>.</p>
+
+    <h4 id="security-rules-must-be-clear">
+      <a class="header-anchor" href="#security-rules-must-be-clear" aria-hidden="true">#</a>
+      4.1.1.6. Security Rules must be Clear
+    </h4>
+
+    <p>All security rules for browser vendors must be clear and upfront.</p>
+
+    <p>It is important that browser vendors can be confident they are abiding by all security
+      rules. In the event that Apple wishes to introduce rules that are not strictly necessary, proportionate,
+      justified
+      or that violate Article 5(7) then browser vendors will need time to respond and, if appropriate, notify the
+      Commission.</p>
+
+    <p>Specifically, Apple must publish all security rules for browsers in a single document.
+      Apple must commit to these rules being available, complete and accurate. In the event Apple wishes to update
+      this
+      document, it must notify all parties and give significant advanced warning of the exact changes it is making,
+      and
+      the justification of the necessity and proportionality of said changes. Apple will need to attest to the fact
+      that
+      the updated or new rules do not conflict with Article 5(7).</p>
+
+    <h4 id="justify-all-security-rules">
+      <a class="header-anchor" href="#justify-all-security-rules" aria-hidden="true">#</a>
+      4.1.1.7. Justify All Security Rules
+    </h4>
+
+    <p>We believe that Apple should be required to provide a security justification for each
+      individual rule attached to obtaining the API access required by browsers using their own engine: Why is it
+      strictly necessary and proportionate to prevent this access from compromising the integrity of the operating
+      system, hardware or software features provided by Apple as per the wording and intent of the act.</p>
+
+    <p>Any rule that cannot be justified, or where the justification is inappropriate or
+      insufficient, should be removed or modified.</p>
+
+    <p>We cover this in greater depth in <a href="#lack-of-justification-of-security-terms">Section
+        3.1.5</a>.</p>
+
+    <h4 id="penalties-for-security-rule-violation-must-be-proportionate-and-justified">
+      <a class="header-anchor" href="#penalties-for-security-rule-violation-must-be-proportionate-and-justified" aria-hidden="true">#</a>
+      4.1.1.8. Penalties for Security Rule Violation must be
+      Proportionate and Justified
+    </h4>
+
+    <p>Apple’s current penalties, as described, do not take into account the need for
+      proportionality. </p>
+
+    <p>The phrase “in Apple’s sole discretion” is not consistent with the
+      fact that Apple will need to justify each of its security measures. </p>
+
+    <p>The language of the contract should be updated to make it clear that the penalties will
+      be proportional and that Apple will provide detailed evidence and reasoning to support any penalty it might
+      choose
+      to impose.</p>
+
+    <p>We cover this in greater depth in <a href="#severe-and-unreasonable-penalties">Section
+        3.1.9</a>.</p>
+
+    <h4 id="justify-and-update-non-proportionate-security-terms">
+      <a class="header-anchor" href="#justify-and-update-non-proportionate-security-terms" aria-hidden="true">#</a>
+      4.1.1.9. Justify and Update Non-Proportionate Security
+      Terms
+    </h4>
+
+    <p>Apple has granted itself the ability to force any browser vendor to remove any browser
+      API that contains a vulnerability, no matter how minor and no matter how much effort the browser vendor has
+      taken
+      to mitigate the vulnerability.</p>
+
+    <p>This is particularly important, as the primary reason that the DMA grants browsers the
+      right to use their own browser engine is to prevent gatekeepers (such as Apple) from determining the
+      functionality
+      and standards for third-party browsers. Allowing Apple to ban third-party browsers from offering functionality
+      on
+      unjustified or non-existent security justifications would severely undermine this goal.</p>
+
+    <p>This appears to grant Apple broad powers to use unnecessary and disproportionate
+      security measures to block rival browsers from providing functionality that is distinct from Safari, preventing
+      one of the core aims of the act in allowing browser vendors to port their own engines.</p>
+
+    <p>This clause must be removed or modified to be strictly necessary and proportionate.
+      Apple must be required to provide clear and convincing evidence of necessity and proportionality of any
+      individual
+      execution of such a rule.</p>
+
+    <p>We cover this in greater depth in <a href="#vulnerability-disclosure">Section
+        3.1.4.2.2</a>.</p>
+
+    <h4 id="security-disclosure">
+      <a class="header-anchor" href="#security-disclosure" aria-hidden="true">#</a>
+      4.1.1.10. Security Disclosure
+    </h4>
+
+    <p>Apple has proposed a security disclosure requirement in their browser engine API
+      contract. We welcome this security disclosure policy, provided it applies equally to Safari. Our concern is that
+      if Apple can avoid full disclosure while, at the same time, compelling other vendors to disclose
+      vulnerabilities,
+      Apple may use these disclosures to falsely claim superior security or create a pretense for delisting other
+      browsers from their app store. Our recommendation would be for Apple to keep this policy but to also abide by it
+      for their own browser.</p>
+
+    <p>We cover this in greater depth in <a href="#vulnerability-disclosure">Section
+        3.1.4.2.2</a>.</p>
+
+    <h3 id="safari-and-other-apple-services-get-special-placement">
+      <a class="header-anchor" href="#safari-and-other-apple-services-get-special-placement" aria-hidden="true">#</a>
+      4.1.2. Safari and other Apple Services get Special Placement
+    </h3>
+
+    <p>On the settings page for iOS, pre-installed Apple apps are not placed with the other apps. Instead
+      they are given a special, far more prominent location, in the settings. Other third-party apps are shown in a
+      separate location further down the settings page. This divide suggests to
+      users that these are <em>official</em>apps they <em>should</em> be
+      using (which come pre-installed) and other apps are “alternative apps”.</p>
+
+    <p>These apps include:</p>
+    <ul>
+      <li>Siri</li>
+      <li>Apple App Store</li>
+      <li>Wallet and Apple Pay</li>
+      <li>Mail</li>
+      <li>Contacts</li>
+      <li>Calendar</li>
+      <li>Notes</li>
+      <li>Reminders</li>
+      <li>Freeform</li>
+      <li>Voice Memos</li>
+      <li>Phone</li>
+      <li>Messages</li>
+      <li>FaceTime</li>
+      <li>Safari</li>
+      <li>Stocks</li>
+      <li>Weather</li>
+      <li>Translate</li>
+      <li>Apple Maps</li>
+      <li>Compass</li>
+      <li>Measure</li>
+      <li>Health</li>
+      <li>Journal</li>
+      <li>Apple TV</li>
+      <li>Photos</li>
+      <li>Camera</li>
+      <li>Books</li>
+      <li>Podcasts</li>
+      <li>Game Center</li>
+    </ul>
+
+    <p>It indicates to the user that these apps are special and that, while it may be
+      mechanically possible for some of these apps to be replaced by third party apps, the non-neutral nature of the
+      interface arguably seeks to dissuade users from changing the default.</p>
+
+    <p>In particular the fact that Safari has a separate and elevated position from other
+      browsers is, we believe, in contravention of Article 6(3), Article 13(6) and Recital 70 which state:</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow and technically enable
+          end users to easily change default settings on the operating system</strong>, virtual assistant and
+        web browser of the gatekeeper that direct or steer end users to products or services provided by the
+        gatekeeper.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881425413&usg=AOvVaw3u8K2uJAyJI76O1dKICYkT">
+            Digital Markets Act – Article 6(3)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The gatekeeper shall not degrade the conditions or quality of any of the
+        core platform services provided to business users or end users who avail themselves of the rights or choices
+        laid
+        down in Articles 5, 6 and 7, or make the exercise of those rights or choices
+        unduly difficult, <strong class="stressed">including by offering choices to the end-user in a non-neutral
+          manner, or by subverting end
+          users’ or business users' autonomy, decision-making, or free choice via the structure, design,
+          function
+          or manner of operation of a user interface or a part thereof</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881426274&usg=AOvVaw3zwMSogO3thbJiOCPUer4R">Digital
+            Markets Act – Article 13(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">Gatekeepers should not engage in behaviour that
+          would undermine the effectiveness of the prohibitions and obligations</strong>
+        laid down in
+        this Regulation. Such behaviour <strong class="stressed">includes the design used by the
+          gatekeeper, the presentation of end-user choices in a
+          non-neutral
+          manner</strong>, or using the structure, function or manner of operation of a user interface
+        or a
+        part thereof to <strong class="stressed">subvert or impair user autonomy, decision-making, or
+          choice</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881427078&usg=AOvVaw3S8pwN918Ynpb1Fl4AWJfI">
+            Digital Markets Act – Recital 70</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple should move all of its apps and third party apps into the same location in
+      settings. In the event particular types of apps are of elevated importance such as app store, browser, photos,
+      or
+      backup provider, Apple could additionally place the current default in a special location in a neutral manner.
+    </p>
+
+    <p>This is an example mockup of what that might look like:</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image9.png" alt="Example of list of settings">
+        <img src="/images/apple-dma-report/image12.png" alt="Example of a settings page with a list of defaut browsers">
+      </p>
+      <figcaption>
+        Possible Default Location and Default selection page for browsers
+      </figcaption>
+    </figure>
+
+    <p>The goal of this remedy is to indicate to the user that while these apps are
+      pre-installed by Apple, they are replaceable and have no elevated privileges over other third party apps. This
+      will encourage contestability of these services as per the intent of the act.</p>
+
+    <h3 id="safari-is-not-uninstallable">
+      <a class="header-anchor" href="#safari-is-not-uninstallable" aria-hidden="true">#</a>
+      4.1.3. Safari is Not Uninstallable
+    </h3>
+
+    <p>Apple is obligated under the act to make Safari uninstallable. This is psychologically
+      important as it indicates to users that Safari is just another app on their phone that can be uninstalled and
+      replaced, just like any other non-Apple app.</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow and technically enable
+          end users to easily un-install any software applications on the operating system of the
+          gatekeeper</strong>, without prejudice to the possibility for that gatekeeper to restrict such
+        un-installation in relation
+        to software applications that are essential for the functioning of the operating system or of the device and
+        which
+        cannot technically be offered on a standalone basis by third parties.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881428631&usg=AOvVaw0_HAerqa-EXIImBDFzstjB">Digital
+            Markets Act – Article 6(3)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly, the WKWebView and SFSafariViewController should be treated as system components, and
+      it should not be possible to uninstall them. Both of these components are used in a wide variety of native apps.
+      Many native apps use the WKWebView as a convenient way to render first/second party content and any remedy which
+      would break these apps would be unreasonable, disproportionate and counter-productive. Other apps use
+      SFSafariViewController when the user clicks on an external http/https link and should be allowed to continue to
+      do
+      so, provided <a href="#sfsafariviewcontroller-must-respect-browser-choice">Apple commits to making
+        SFSafariViewController respect the user’s choice of default browser</a>.
+    </p>
+
+    <p>We would also support it not being possible to uninstall the default browser until a
+      new default browser has been selected. An appropriate and neutral error message should be displayed if the user
+      attempts to do so.</p>
+
+    <p>We are uncertain if SFSafariViewController is built on top of Safari or the WKWebView.
+      In the event it is currently built on the WKWebView it is not a blocker to Safari being fully uninstallable.
+    </p>
+
+    <p>In the event it is currently mechanically bound to Safari it will need to be updated to instead
+      not impose a browser engine on end users and business users but rather interoperate with the users chosen
+      default
+      browser <a href="#sfsafariviewcontroller-must-respect-browser-choice">as discussed in 4.2.2</a>.
+      In the (likely rare) instance that the user's chosen default browser does not support interoperating with
+      SFSafariViewController then links can simply open in the user's default browser directly.</p>
+
+    <h3 id="implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers">
+      <a class="header-anchor" href="#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers" aria-hidden="true">#</a>
+      4.1.4. Implement Web App Install Prompts for iOS Safari and WKWebView browsers
+    </h3>
+
+    <p>According to Article 6(6), Gatekeepers, such as Apple, shall not <q>&gt;restrict
+        technically or otherwise the ability of end users to switch between, and subscribe to,
+        different software applications and services that are accessed using the core platform services of the
+        gatekeeper.</q></p>
+
+    <p>iOS and Safari are both implicated in delivering Web Apps, and both are designated core
+      platform services. Via its control of both iOS and Safari, Apple has long denied Web Apps the ability to prompt
+      the user to be installed, adding great friction to the process of installing them. Instead, the option to
+      install
+      a Web App is hidden away in a hard to find “share” menu option. Competing browser vendors were only
+      provided with access to this share menu function last year, and are still denied access to the necessary APIs
+      within WKWebView to implement the ability for websites to enable such user-driven prompts.</p>
+
+    <p>Apple has implemented many pieces of equivalent functionality to install native apps from their
+      own app store via Safari, including but not limited to <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/walled-gardens-report/%23app-clips&sa=D&source=editors&ust=1718648881430288&usg=AOvVaw0jcNHZRQcePrdPl4VAVOof">App
+        Clip Associated Domains</a>&nbsp;and <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/walled-gardens-report/%23smart-app-banners&sa=D&source=editors&ust=1718648881430560&usg=AOvVaw3GwzmrrhVwVIHyKDiupkIt">Smart
+        Banners</a>.</p>
+
+    <p>Due to the manner in which WKWebView-based browsers on iOS are implemented, only Apple
+      can effectively implement install prompts for them, and has steadfastly refused to do so despite consistent
+      developer requests.</p>
+
+    <p>We believe that Apple should be obligated to implement install prompts, including both
+      automatic prompts (akin to Smart Banners) and the ability to programmatically display prompts on a button click
+      from within websites that meet the minimum criteria for installation (e.g., providing a Web App Manifest). Apple
+      should also implement APIs already in use across the web to facilitate control over this behavior
+      (“onbeforeinstallprompt”). onbeforeinstallprompt is the technical term for the current
+      implementation,
+      it is an event that tells developers that it is possible to install the website as a web app, this means they
+      can
+      add a button to the page that will trigger showing the choice to the user. This allows developers to create
+      their
+      own install buttons.</p>
+
+    <blockquote>
+      <p>The beforeinstallprompt event fires when the browser has detected that a
+        website can be installed as a Progressive Web App.</p>
+      <p>There's no guaranteed time this event is fired, but it usually happens on page
+        load.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event&sa=D&source=editors&ust=1718648881431722&usg=AOvVaw2YkhPiSf2KacvbD5nYCk0w">
+            Mozilla Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Given that Apple has withheld this functionality for almost a decade, we believe that
+      Apple should not be able to delay discussions of the specifications as this could take months or even years.
+      Rather, they should implement the current specification as is currently available in other browsers which
+      support
+      the feature. After implementing the functionality, Apple can then propose any updates or upgrades.</p>
+
+    <p>Apple should not be allowed to add additional scare screens or other friction as it is
+      not necessary from a security perspective. The ability to install Web Apps via iOS Safari has been available for
+      almost 15 years without such measures, and Apple has not felt it was necessary to implement such measures. They
+      surely cannot be justified now, particularly after Apple’s strong claims regarding the security of its iOS
+      Web App container.</p>
+
+    <p>Web Apps are protected by the sandbox of the browser, which
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf&sa=D&source=editors&ust=1718648881432640&usg=AOvVaw2S_5bW7AyQ7s3-LOIcnBj-">Apple
+        states</a> is <q>&gt;orders of magnitude more stringent than the
+        sandbox for Native Apps</q>. This is important as it means that Apple does not have any
+      significant unmitigatable security objections to such a change.
+    </p>
+
+
+    <h3 id="app-store-rules-for-browsers-must-be-fair-reasonable-and-non-discriminatory">
+      <a class="header-anchor" href="#app-store-rules-for-browsers-must-be-fair-reasonable-and-non-discriminatory" aria-hidden="true">#</a>
+      4.1.5. App Store Rules for Browsers Must Be Fair, Reasonable, and Non-Discriminatory (FRAND)
+    </h3>
+
+    <p>Apple may be tempted to move proposed non-security rules regarding browsers from its
+      proposed browser engine entitlement contract to the broader app store guidelines, which it includes by reference
+      within the proposed Browser Engine Entitlement Addendum. By phrasing the browser engine contract as an addendum,
+      rather than a stand-alone contract, the terms of the entire “Apple Developer Program License
+      Agreement” is included.</p>
+
+    <p>A number of the rules within the engine entitlement addendum do not appear to be fair
+      or reasonable, including:
+    </p>
+
+    <ul>
+      <li>That the browser must be solely distributed in the EU</li>
+      <li>The browser must be a separate binary from one that uses the systems
+        browser engine</li>
+      <li>Apple may change the rules at any time with no notice</li>
+      <li>Apple makes no guarantees as to the accuracy of the rules</li>
+      <li>Apple can reject browsers for any reason at its sole
+        discretion</li>
+      <li>Apple can remove, suspend, break any API with no notice</li>
+      <li>Any breach of rules, no matter how minor, will allow Apple to block
+        or remove your application from all Apple platforms including macOS</li>
+    </ul>
+
+    <p>Apple should not be allowed to add rules for browsers to the app store guidelines or
+      apple program developer license that are unfair, unreasonable or discriminatory.</p>
+
+    <p>While we recognise that the DMA may not have the ability to compel Apple to allow
+      browsers to compete fairly on iOS globally, the unfairness of keeping this privilege exclusive to Safari (out of
+      browsers which ship their own engine) should be noted. The EU should consider any remedies available to lessen
+      this unfairness.</p>
+
+    <h3 id="app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43">
+      <a class="header-anchor" href="#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43" aria-hidden="true">#</a>
+      4.1.6. App Store Rules for Browsers Must Not Violate Article 5(7) and Recital 43
+    </h3>
+
+    <p>Under Article 5(7), Apple can not impose a browser engine on competing browsers. The
+      aim here outlined in Recital 43 is to prevent gatekeepers (such as Apple) from determining the functionality and
+      standards of rival browsers by imposing a browser engine.</p>
+
+    <p>That is, browser vendors must be free to compete in features, stability, security and
+      privacy. Under Article 13(4) Apple can not construct alternative rules or OS design choices that would undermine
+      and render Article 5(7) ineffective.</p>
+
+    <p>So any rule, including rules moved from Apple’s browser engine entitlement
+      contract into Apple’s app store rules, Apple developer program license contract or rules in documents
+      included by reference must be compliant with Article 5(7).</p>
+
+    <h3 id="testing-for-browser-vendors-and-developers-outside-the-EU">
+      <a class="header-anchor" href="#testing-for-browser-vendors-and-developers-outside-the-EU" aria-hidden="true">#</a>
+      4.1.7. Testing for Browser Vendors and Developers Outside the EU
+    </h3>
+
+    <p>Under Apple’s current proposal, browser vendors and companies that develop
+      websites for the EU, whose development teams are outside the EU, will be unable to test their websites or Web
+      Apps
+      in browsers on iOS that use their own engine - except for Safari. Apple's Safari will be the only browser
+      which uses its own engine that will be available globally.</p>
+
+    <p>Apple's browser engine entitlement contract makes no exception for test devices in
+      its rule that browsers using their own engine (other than Safari) must only be available (on iOS) in the EU.
+      Apple’s technical restrictions, launched as part of iOS 17.4, further indicate hostility towards
+      reasonable
+      exceptions for development and testing, with the OS using multiple mechanisms to geofence access to EU-specific
+      behavior to devices physically within the EU.</p>
+
+    <p>For Browser Vendors, the contract is less clear. It does reference “Authorized Test
+      Units” but offers no clarification. In practice, Apple appears to have a policy that all test units for
+      browser vendors must be physically located&nbsp;in the EU.
+    </p>
+
+    <blockquote>
+      <p>The Register has learned from those involved in the browser trade that
+        <strong class="stressed">
+          Apple has limited the development and testing of third-party browser engines to devices
+          physically located in the EU</strong>. That requirement adds an additional barrier to anyone
+        planning to develop and support a browser with an alternative engine in the EU.It effectively geofences
+        the development team. Browser-makers whose dev teams are located in the US will only be able to work on
+        simulators. While some testing can be done in a simulator, there's no substitute for testing on device
+        –
+        which means developers will have to work within Apple's prescribed
+        geographical boundary.
+      </p>
+      <p>‘The contract terms are bonkers and almost no vendor I'm
+        aware of will agree to them,’ lamented one industry veteran familiar with the making of browsers in
+        response
+        to an inquiry from The Register.</p>
+      <p>‘Even folks that may have signed something to be able to prototype can't
+        ship under the constraints Apple's trying to impose. They're so broad and sweeping as to try to duck
+        most
+        of the DMA by contract … which is certainly bold.’</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theregister.com/2024/05/17/apple_browser_eu/&sa=D&source=editors&ust=1718648881436388&usg=AOvVaw355MUPvT3HT1_MhipFl1sv">
+            Thomas Claburn – The Register</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Great story showing how it's clear Apple isn't serious about browser
+        engine competition in Europe.</p>
+      <p>We've got a blink build running well on the simulator but still have no idea if
+        it works on device 🤷.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://twitter.com/RickByers/status/1791609238000705824&sa=D&source=editors&ust=1718648881437283&usg=AOvVaw3x2Qhlue9Egb70lEr_E5lk">
+            Rick Byers – Web Platform Area Tech Lead, Chrome</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This places browser vendors and web developers attempting to reach EU customers via the
+      web at a significant disadvantage that Apple and Safari are not subject too. This greatly harms the goals of
+      interoperability and competition that the DMA sets out to allow.</p>
+
+    <p>This will harm EU end users by making these browsers less secure due to the inability
+      for any engineering team, geographically outside of the EU, being able to develop and test their products
+      accurately. Some, perhaps even most, browser vendors hire security experts from all around the world and some
+      security bugs (like JIT bugs) will need a real device to test and debug on. Not only would this put EU users at
+      risk, but it would also unfairly disadvantage the competing browser vendors.</p>
+
+    <p>Is it really reasonable for Apple to in effect force the entire development teams of
+      these mobile browsers to relocate to the EU? Would Apple accept a similar requirement for their own products in
+      another jurisdiction?
+    </p><p>This also prohibits automated on-device tests for browser vendors outside the EU.
+      Again, the end result of this will be poorer quality products as a result of Apple’s unreasonable
+      restriction.</p>
+
+    <p>Finally, of the millions of web developers and businesses outside the EU who serve EU
+      customers, but do not live in the EU, should Apple really be able to make it impossible for them to effectively
+      test their software on competing browsers?</p>
+
+    <p>We had hoped that Apple might reasonably foresee these complications and voluntarily
+      cease this continued anti-competitive behavior and make it possible for developers to test their products
+      outside
+      of the EU. Unfortunately, Apple seems content with making the web less interoperable and more difficult to
+      develop
+      for.</p>
+
+    <p>As the DMA is (likely) unable to compel Apple to allow browser vendors to compete on
+      iOS with their own engines globally, we propose two potential solutions: </p>
+
+    <ol>
+      <li>Relax the requirements on test devices so that browser vendors can
+        at least test their own browsers on test devices outside the EU. This seems an extremely reasonable request
+        and
+        Apple has no reason beyond malice and a belief they can’t legally be forced to do so to not comply with
+        it. If Apple believes it does have legitimate reasons it should publicly publish them so they can be
+        scrutinized. This part of the remedy solves the problem for allowing browser vendors to develop and test their
+        products.In the case that this scenario is actually a mistake on Apple’s part, and is just a lack
+        of foresight on the needs of developers in regards to testing, Apple should issue updated guidance that
+        browser
+        vendor test devices are exempt from this policy.</li>
+      <li>Any developer with an Apple developer account should be able to
+        download the EU versions of browsers globally onto their own iOS devices for the explicit purpose of testing.
+        This will allow them to test their software in these browsers, which is critical in allowing Web App/website
+        developers to compete. Apple should not be allowed to add undue friction, charge a fee, or restrict these
+        browsers in any way that might significantly undermine the extensive manual and automated testing that major
+        web
+        based products undergo. This will allow the millions of web developers that service the EU to test their
+        products.</li>
+    </ol>
+
+    <p>Apple may point to TestFlight as a possible solution, but this is insufficient. There
+      are hard usage caps of 10,000. &nbsp;Given there are 1.1 billion websites worldwide, we would anticipate that
+      the
+      number of developers that need to test for mobile browsers in the EU would be in the millions and likely
+      comparable to the number of developers who download beta versions of Firefox/Chrome/Edge.</p>
+
+    <p>Apple may also point at the xCode simulator as a possible solution, however this is not
+      acceptable, as many bugs will only appear on real devices, and development of user interfaces will often require
+      the developer to be able to interact with the device to test the responsiveness and feel of the interactions.
+      This
+      sort of testing is not possible in the simulator.</p>
+
+    <h3 id="allow-dev-beta-versions-of-browsers-on-non-beta-versions-of-iOS">
+      <a class="header-anchor" href="#allow-dev-beta-versions-of-browsers-on-non-beta-versions-of-iOS" aria-hidden="true">#</a>
+      4.1.8. Allow Dev/Beta Versions of Browsers on Non-Beta Versions of iOS
+    </h3>
+
+    <p>On other operating systems such as macOS, Windows, Linux, and Android, developers can
+      download multiple versions of the same browser including Stable, Beta, Dev, and Canary “channels”.
+      This allows developers of websites and Web Apps to test their products for compatibility and regressions prior
+      to
+      new versions of browsers being made available to consumers. This increases the quality and safety of both Web
+      Apps
+      and browsers.</p>
+
+    <p>Apple’s app store rules contains the following provision:</p>
+
+    <blockquote>
+      <p>2.2 Beta Testing</p>
+      <p>Demos, betas, and trial versions of your app don’t belong on the App Store
+        – use TestFlight instead. Any app submitted for beta distribution via TestFlight should be intended for
+        public distribution and should comply with the App Review Guidelines. Note, however, that apps using
+        TestFlight
+        cannot be distributed to testers in exchange for compensation of any kind, including as a reward for
+        crowd-sourced
+        funding. Significant updates to your beta build should be submitted to TestFlight App Review before being
+        distributed to your testers. To learn more, visit the TestFlight Beta Testing page.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/%23:~:text%3Dyour%2520review%2520notes.-,2.2%2520Beta%2520Testing,your%2520testers.%2520To%2520learn%2520more%252C%2520visit%2520the%2520TestFlight%2520Beta%2520Testing%2520page.,-2.3%2520Accurate%2520Metadata&sa=D&source=editors&ust=1718648881440321&usg=AOvVaw0yaW1C2oK9mQm0UGVD_7bQ">
+            Apple’s app store rules</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Due to this and limits imposed by Apple’s “Test Flight” program it is
+      practically ensured that Beta, Dev, and Canary versions of competing browsers are not widely available. The
+      number
+      of test users required for popular browsers, which are platforms in their own right, is extraordinary among
+      apps.</p>
+
+    <blockquote>
+      <p>TestFlight has a 10,000 user limit, which is a tiny fraction of the beta
+        population for web browsers with large user bases.The limitation becomes a maintenance burden for browser
+        developers: when reaching the limit, old users must be manually removed from the list. The user experience for
+        prerelease testers is more complicated than on other platforms: users must download the separate TestFlight
+        application, sign up for an access code, wait to receive it, and then paste it into the application.
+        Distributing
+        with a public link is not feasible because of the user limit restriction.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/mozilla/platform-tilt/issues/16&sa=D&source=editors&ust=1718648881441108&usg=AOvVaw37Wo0oErhk8W32fPxDFBdj">
+            Mozilla – Platform Tilt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Tying of browsers to OSes used to be commonplace, for example with Internet Explorer
+      and Microsoft Windows, but in the past 15 years this practice has been abandoned by most browser vendors. Apple
+      remains a notable exception, meaning iOS Safari can only be updated when the whole OS updates, and there can
+      only
+      be a single version of the WebView or Safari at any time. This raises costs on developers who may need to
+      procure
+      multiple iOS devices to adequately test.</p>
+
+    <p>Given that the purpose of the DMA is to allow rivals to compete to provide better
+      functionality, stability, and security, Apple should not be able to restrict browser vendors via app store rules
+      from providing Beta, Dev and Canary versions of their products provided they are clearly labeled and marketed as
+      such. Specifically, it should amend the rule to make an exemption for browsers.</p>
+
+    <p>Such competition will improve browser testing on iOS and may push Apple to make
+      long-needed improvements to provide equivalent functionality for Safari.</p>
+
+    <p>This change will not require any technical changes on Apple’s end nor will it
+      require the EU to make any extra-territorial requests. This simply requires Apple to update its contracts and
+      app
+      store rules to allow this critical use case.</p>
+
+    <h3 id="browser-choice-screen-on-ios">
+      <a class="header-anchor" href="#browser-choice-screen-on-ios" aria-hidden="true">#</a>
+      4.1.9. Browser Choice Screen on iOS
+    </h3>
+
+    <p>In order to comply with both the letter and intent of the Digital Markets Acts Article
+      6(3) and to make that compliance effective we believe that Apple should make the following changes:</p>
+
+    <ul>
+      <li>Allow browsers to show a single line of text explaining why
+        users should pick their browser on the choice screen directly. This line should be allowed to be at least up
+        to
+        150 characters long.</li>
+      <li>The browser choice screen should not be locked to or entrench Apple
+        app store. Both the browsers available and the calculation of the top 12 should include browsers downloaded
+        either directly or from other app stores. Browser vendors should be able to opt to provide their browsers
+        directly to users.</li>
+      <li>Once the user has chosen their browser, the selection flow should
+        continue to the home screen and download the chosen browser in the background, allowing the user to continue
+        their task. Making the user wait with a prominent cancel button undermines the autonomy of users.
+      </li>
+      <li>Apple should share aggregate statistics with browsers vendors about
+        the performance of their browser on the choice screen. This should be daily and automatic. Importantly this
+        needs to include enough detail to allow browser vendors to calculate the percentage of the times it is chosen,
+        per country, per day. Browser vendors should be free to publicly publish this data if they so choose.
+      </li>
+      <li>Being set as the default browser should grant the chosen browser the
+        <em>hotseat</em>. Under no circumstances should the choice screen show if
+        Safari is not already the default browser. Apple should re-show the choice screen to all users that
+        currently
+        have Safari as their default, and that the choice screen was inappropriately shown too, if they do not have
+        this
+        data it should be reshown to all users with Safari as the default.
+      </li>
+      <li>The choice screen should be shown whenever users encounter a new
+        reinstallation event, such as purchasing a new phone,
+        restoring from an old phone or a factory reset</li>
+    </ul>
+
+    <p>We cover this in greater depth in <a href="#choice-screens">Section
+        3.2 </a>.</p>
+
+    <h2 id="tranche-2">
+      <a class="header-anchor" href="#tranche-2" aria-hidden="true">#</a>
+      4.2. Tranche 2
+    </h2>
+
+    <p>Tranche 2 interventions are not less important than those proposed for Tranche 1 (or
+      for Tranche 3), but are instead proposed in a staged order to ensure that progress is made consistently.
+    </p>
+
+    <h3 id="web-app-installation-and-management-for-third-party-browsers">
+      <a class="header-anchor" href="#web-app-installation-and-management-for-third-party-browsers" aria-hidden="true">#</a>
+      4.2.1. Web App Installation and Management for third-party Browsers
+    </h3>
+
+    <blockquote>
+      <p>We all rely on browsers to use the internet on our phones, and the engines
+        that make them work have a huge bearing on what we can see and do. Right now, choice in this space is severely
+        limited and that has real impacts – preventing innovation and reducing competition from web apps. We
+        need to
+        give innovative tech firms, many of which are
+        ambitious start-ups, a fair chance to compete.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming%23:~:text%3DWe%2520all%2520rely,chance%2520to%2520compete.&sa=D&source=editors&ust=1718648881444309&usg=AOvVaw3WID0Rw0VySRuTGIcCaEfq">
+            Andrea Coscelli – Chief Executive of the UK's Competition and Markets Authority</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/&sa=D&source=editors&ust=1718648881444753&usg=AOvVaw10R8jfKTaGmZRSTzoj-pjg">First,
+        Apple claimed that they had to entirely remove Web App functionality</a>&nbsp;to avoid
+      sharing it with third-party browsers using their own engine.</p>
+
+    <blockquote>
+      <p><strong class="stressed">Addressing the complex security and privacy concerns
+          associated with web apps using alternative browser engines would require building an entirely new
+          integration
+          architecture that does not currently exist in iOS</strong> and was not practical to
+        undertake
+        given the other demands of the DMA and the very low user adoption of Home
+        Screen web apps. <strong class="stressed">And so, to comply with the
+          DMA’s requirements, we had to remove the Home Screen web apps
+          feature
+          in the EU</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu%238&sa=D&source=editors&ust=1718648881445389&usg=AOvVaw2l5xSV7Lfd5vKHUtvS0Qx4">
+            Apple’s statement</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>They then, <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/&sa=D&source=editors&ust=1718648881445935&usg=AOvVaw2Ye22bux_X4pKvP6SNOwpB">under
+        significant pressure, reversed that decision</a> and stated that they will keep the
+      current status-quo, implying that access to the underlying APIs required to run Web Apps would be locked to
+      the
+      WebKit implementation and that third-party browsers using their own engine would not be provided sufficient
+      API
+      access to contest it. That is, third-party browsers would continue to be unable to install and manage Web Apps
+      using their own engine.</p>
+
+    <blockquote>
+      <p>This support means Home Screen web apps continue to be built directly on
+        WebKit and its security architecture, and align with the security and privacy model for native apps on
+        iOS.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu%238&sa=D&source=editors&ust=1718648881446492&usg=AOvVaw3a0dPv3GUksfrsvgQZcUpY">
+            Apple’s statement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This stance is in clear contravention of Article 5(7), 6(7) and 13(4). </p>
+
+    <p>It also undermines the Act’s core purpose in prohibiting imposing browser engines outlined
+      in Recital 43, which is to prevent gatekeepers from blocking third-party
+      browsers for implementing features for
+      <strong>“web software applications”</strong>
+    </p>
+
+    <p>Browser vendors require the ability to install, manage, and control Web Apps using
+      their own engines. This is the only way that browser vendors can compete in the provision of functionality,
+      stability, security and privacy for Web Apps.</p>
+
+    <p>As such, Apple must build, update, or provide access to all relevant APIs to install
+      Web Apps to browser vendors with the browser engine entitlement. OWA believes the Commission, and competitors,
+      are
+      owed a full and timely explanation of the implementation plan for these features.</p>
+
+    <h3 id="sfsafariviewcontroller-must-respect-browser-choice">
+      <a class="header-anchor" href="#sfsafariviewcontroller-must-respect-browser-choice" aria-hidden="true">#</a>
+      4.2.2. SFSafariViewController Must Respect Browser Choice
+    </h3>
+
+    <p>SFSafariViewController, Apple’s Remote-Tab In-App Browser (IAB) system continues
+      to self-preference Safari, denying users access to their default browsers when web pages are loaded within
+      third-party apps.</p>
+
+    <p>In order to respect the users choice of default browser as mandated in Article 6(3),
+      and to conform with Article 5(7) which prohibits the imposition of a browser engine on end users and business,
+      Apple must extend SFSafariViewController and provide an operating system API which other browsers can register
+      and
+      interoperate with it to be invoked when users click on links in non-browser apps. This can work in a manner
+      similar to how Android Custom Tabs works. Apple must provide an implementation plan to the Commission and should
+      share its documentation and timeline prior to release, as soon as practicable. OWA suggests this should take
+      less
+      than 6 months, even with Tranche 1 interventions underway as the engineering work is not large.</p>
+
+    <p>Apple may claim that the fact they allow Native Apps to implement their own in-app
+      browser means they are not imposing their browser engine on business users, however, this is an extremely high
+      friction barrier: In order not to use Safari's browser engine and instead use the default browser, these
+      businesses must invest to build their own WebView browser as opposed to simply calling the appropriate OS
+      API.</p>
+
+    <p>Further this also undermines the users choice of default browser by making all native apps that
+      call the system default remote tab browser use Safari instead of the users default browser. This, in turn, will
+      cause friction as Safari will not share user preferences and history with the user’s default browser,
+      resulting in an experience that is dubbed
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://infrequently.org/2022/06/apple-is-not-defending-browser-engine-choice/%23:~:text%3DThis%2520split%2520experience%2520causes%2520a%2520sort%2520of%2520pervasive%2520forgetfulness%252C%2520making%2520the%2520web%2520less%2520useful.&sa=D&source=editors&ust=1718648881448164&usg=AOvVaw2yUzgJK_cRyGGE5fKAqYE2">The
+        Forgetful Web</a>.
+    </p>
+
+    <p>We cover this in detail in our document
+      <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+        “OWA - DMA Interventions – In-App Browsers”
+      </a>
+    </p>
+
+    <h3 id="allow-third-party-browsers-to-ship-their-own-extensions">
+      <a class="header-anchor" href="#allow-third-party-browsers-to-ship-their-own-extensions" aria-hidden="true">#</a>
+      4.2.3. Allow Third-Party Browsers to Ship their Own Extensions
+    </h3>
+
+    <blockquote>
+      <p>Browser extensions are a key part of the web ecosystem and most popular
+        browsers support them. Browser extensions allow developers to add functionality to the browser providing
+        increased
+        utility, usability, and interoperability with applications installed
+        on the system.</p>
+
+      <p>
+        For distribution, popular browsers have established extension catalogs that are
+        available on the open web and curated by the browser vendors. Because extensions have elevated privileges,
+        developers submit them to be approved to ensure safety and compatibility. Browser vendors make their own
+        decisions
+        about the APIs available to extensions. Extensions for each browser are installed and managed within the
+        browser
+        resulting in a common user experience across platforms.</p>
+      <p>Safari supports extensions distributed on the iOS App Store. However, third-party
+        browsers are prevented from offering their own established extension functionality because it would violate
+        section 2.5.2 of the App Store Review Guidelines. To allow third-party browsers to offer the same
+        functionality
+        and be competitive with respect to browser extensibility, the App Store software requirements should be
+        relaxed to
+        permit third-party browsers to use their own extension catalogs. Third-party browsers could then use the
+        existing
+        web-based distribution model (where users can browse and install extensions directly from the browser)
+        allowing
+        for browser extensions to be used on iOS, similarly to other mobile
+        and desktop platforms.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/mozilla/platform-tilt/issues/15&sa=D&source=editors&ust=1718648881449989&usg=AOvVaw0UCIJSbY3WMmagSeZpalhv">
+            Mozilla – Platform Tilt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Currently Apple does not allow, and has no plans to allow, third-party browsers to ship
+      their own extensions. Currently this functionality is exclusive to browsers that rely on the WKWebView and rely
+      on
+      extensions shipped via Apple's app store.</p>
+
+    <p>In order to compete fairly, browsers will need the ability to distribute extensions
+      directly. This is explicitly prohibited by Apple's current app store rules.</p>
+
+    <p>Apple will need to update their browser entitlement contract and app store rules to
+      allow browser vendors to compete in the provision of such functionality. </p>
+
+    <p>Under 5(7), browsers must be allowed to port their extension architecture.</p>
+
+    <h3 id="in-app-browsers-must-respect-browser-choice">
+      <a class="header-anchor" href="#in-app-browsers-must-respect-browser-choice" aria-hidden="true">#</a>
+      4.2.4. In-App Browsers Must Respect Browser Choice
+    </h3>
+
+    <p>Apple has encouraged and overseen an ecosystem of native apps downloaded via
+      Apple’s app store which ignore user choice of default browser on a massive scale.</p>
+
+    <p>In our document
+      <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+        “OWA - DMA Interventions - In-App Browsers”
+      </a>
+      we proposed the following remedies to fix the issue:
+    </p>
+
+    <ol>
+      <li>Designated Core Platform Services should respect the users choice of
+        default browser.</li>
+      <li>App store rules must mandate non-browser apps use the user's
+        chosen default browser for http/https links to third-party websites/Web Apps.</li>
+      <li>Apple must update SFSafariViewController to respect the user's
+        choice of default browser.</li>
+      <li>Third-party businesses must be provided an explicit and effective
+        technical opt-out from non-default in-app browsers.</li>
+      <li>OSes must provide a global user opt-out. Apps must also request
+        explicit permission from users.</li>
+      <li>Google must remove the ability to override the users choice of
+        default browser via Android Custom Tabs. </li>
+    </ol>
+
+    <p>Users' choice of default browser and the consequent competition is only effective
+      if that choice is respected.</p>
+
+    <h3 id="default-browser-dark-patterns-and-prompt-api">
+      <a class="header-anchor" href="#default-browser-dark-patterns-and-prompt-api" aria-hidden="true">#</a>
+      4.2.5. Default Browser Dark Patterns and Prompt API
+    </h3>
+
+    <blockquote>
+      <p>Apple currently introduces friction that impairs user choice of default browser. This
+        is explicitly forbidden in Recital 70, Article 6(3), and Article 13(4).</p>
+
+      <p>Given the substantial economic power of gatekeepers, it is important that
+        the obligations are applied effectively and are not circumvented. To that end, the rules in question should
+        apply
+        to any practice by a gatekeeper, irrespective of its form and irrespective of whether it is of a contractual,
+        commercial, technical or any other nature, insofar as the practice corresponds to the type of practice that is
+        the
+        subject of one of the obligations laid down by this Regulation. Gatekeepers should not engage in behaviour
+        that
+        would undermine the effectiveness of the prohibitions and obligations laid down in this Regulation.
+        <strong class="stressed">Such behaviour includes the design used by the gatekeeper, the presentation of
+          end-user
+          choices in a
+          non-neutral manner, or using the structure, function or manner of operation of a user interface or a part
+          thereof
+          to subvert or impair user autonomy, decision-making, or choice</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881453684&usg=AOvVaw0IZUbPqLtOupM1WwbkJHtS">
+            Digital Markets Act – Recital 70</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple introduces this friction in five ways:</p>
+
+    <ol>
+      <li>Third-party browsers cannot prompt users to change the
+        default
+        via a one-click system prompt.</li>
+      <li>Third-party browsers cannot detect whether they are the
+        default.</li>
+      <li>Safari's settings are prominently positioned on the iOS
+        settings page compared to third-party browsers.</li>
+      <li>Searching for "default" or "default
+        browser" in settings yields no results.</li>
+      <li>There is no centralized location for changing default
+        apps
+        (including browsers) on iOS.</li>
+    </ol>
+
+    <p>Combined, these factors significantly restrict users' free choice
+      in
+      selecting and switching between their choice of browser.</p>
+    <p>In order to be compliant with this specific aspect of the DMA, we
+      believe
+      Apple should make the following changes:</p>
+
+    <ol>
+      <li>Move the option to change default browser out of
+        the
+        browser settings and into a centralized location.</li>
+      <li>Have this option visible, even if Safari is the
+        only
+        currently installed browser.</li>
+      <li>Have this option show up in search if the user
+        searches for "default", "browser" or
+        "default browser".</li>
+      <li>Allow browsers to know if they are the current
+        default
+        browser.</li>
+      <li>Provide a system prompt to browsers (with an
+        option to
+        never ask again, as is usual for all permission prompts) that allows browsers to prompt the user to
+        one-click
+        set it as the new default browser. This is standard on most operating systems.</li>
+    </ol>
+
+    <h3 id="safari-is-locked-to-apple-pay">
+      <a class="header-anchor" href="#safari-is-locked-to-apple-pay" aria-hidden="true">#</a>
+      4.2.6. Safari is Locked to Apple Pay
+    </h3>
+
+    <p>Currently iOS Safari payments are locked to Apple Pay. As Safari is a core platform
+      service it is not allowed to impose a payment service on either end users or business users under Article 5(7).
+      Therefore, Safari must be upgraded to support third-party payment services including allowing them to reach
+      feature parity with Apple Pay.</p>
+
+    <p>This upgrade must also extend to all WKWebView-based browsers on iOS.</p>
+
+    <p>We would like to note that the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.w3.org/TR/payment-request/&sa=D&source=editors&ust=1718648881456112&usg=AOvVaw3QgN_G31XVXxM4o_IqTgDC">specific
+        standardized “PaymentRequest” Web API</a>&nbsp;that Apple is using is
+      actually designed to support multiple payment services and to our knowledge Safari is the only major browser
+      (possibly only browser) that has locked it to a particular payment provider.
+    </p>
+
+    <figure>
+      <img src="/images/apple-dma-report/image1.png" alt="A screencopy of Maciej Stachowiak's comment on Redit">
+    </figure>
+
+    <p>Maciej Stachowiak – Senior Director of Software Engineering at Apple has publicly
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/WebKit/standards-positions/issues/30&sa=D&source=editors&ust=1718648881456668&usg=AOvVaw2Y3F3BdZb8HhrAWRKQMUO2">stated
+        that</a> Apple will <q>only support the ApplePay
+        PaymentRequest
+        method to minimize user confusion and make sure that
+        PaymentRequest API payments always get the same level of
+        security and privacy protection</q>.
+    </p>
+
+    <p>This will need to be fixed in order for Apple to be in compliance with the payment
+      service aspect of Article 5(7).</p>
+
+    <h2 id="tranche-3">
+      <a class="header-anchor" href="#tranche-3" aria-hidden="true">#</a>
+      4.3. Tranche 3
+    </h2>
+
+    <p>Tranche 3 interventions include some of the most impactful, long-term changes, but OWA
+      recognises that they may not be possible within a quarter or two. As such, we suggest the DMA team provide
+      notice
+      of intent to require them early, but work with stakeholders to bring them about in a phased way.</p>
+
+    <h3 id="direct-browser-installation">
+      <a class="header-anchor" href="#direct-browser-installation" aria-hidden="true">#</a>
+      4.3.1. Direct Browser Installation
+    </h3>
+
+    <p>Apple is obligated under the act to allow native apps to be downloaded from a web page.
+      They have allowed, and interpreted it this way, for third-party app stores. The act states that Apple is only
+      allowed to have strictly necessary, proportionate and justified security measures to protect the integrity of
+      the
+      operating system. This means any security measures, such as warnings or scare screens, need to be heavily
+      justified by Apple as strictly necessary.</p>
+
+    <p>There is great fear in the industry that Apple wields app store review as a weapon to
+      punish competitors. This fear appears to be well justified.</p>
+
+
+    <p>On March 5th,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/2024/3/14/24100944/spotify-ios-app-update-eu-apple-dma&sa=D&source=editors&ust=1718648881458141&usg=AOvVaw2ZzgW0BS305ZUxNj9AgR8w">Spotify
+        submitted an update to Apple</a> that puts links to Spotify’s website, along with
+      pricing information for different subscription options, directly in the EU version of its app, without using
+      Apple’s payment system. Despite
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theguardian.com/business/2024/mar/04/eu-fines-apple-18bn-over-app-store-restrictions-on-music-streaming%23:~:text%3DEU%2520fines%2520Apple%2520%25E2%2582%25AC1.8bn%2520over%2520App%2520Store%2520restrictions%2520on%2520music%2520streaming,-This%2520article%2520is%26text%3DApple%2520has%2520been%2520fined%2520%25E2%2582%25AC,streaming%2520services%2520such%2520as%2520Spotify&sa=D&source=editors&ust=1718648881458650&usg=AOvVaw1zOtC2jwLJYwnRdsFCXVcD">being
+        fined 1.8 billion by the EU</a> on this very topic, Apple refused to let the update
+      pass app review even though more than 2 weeks had passed since the update was submitted.
+    </p>
+
+    <blockquote>
+      <p>Moreover, Apple has demonstrated its ability to use its smartphone monopoly
+        to impose fee structures and <strong class="stressed">
+          manipulate app review to inhibit aggrieved parties from
+          taking advantage of regulatory and judicial solutions imposed on Apple</strong>
+        that attempt
+        to narrowly remedy harm from its conduct.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881459226&usg=AOvVaw0Q2nnateLkZN8bu5lbgsMa">DOJ
+            – Case 2:24-cv-04055</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Specifically, Apple sets the conditions for apps it allows on the Apple App
+        Store through its App Store Review Guidelines. Under these guidelines, Apple has sole discretion to review and
+        approve all apps and app updates. Apple selectively exercises that discretion to its own benefit, deviating
+        from
+        or changing its guidelines when it suits Apple’s interests and allowing Apple executives to control app
+        reviews and decide whether to approve individual apps or updates. <strong class="stressed">Apple often
+          enforces
+          its App Store rules arbitrarily. And it frequently uses App Store rules and restrictions to penalize and
+          restrict
+          developers that take advantage of technologies that threaten to disrupt, disintermediate, compete with, or
+          erode
+          Apple’s monopoly power</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881459861&usg=AOvVaw1QDROcM1EIZglnz9UstC43">
+            DOJ – Case 2:24-cv-04055</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>there are endless horror stories around curation of the store. Apps are
+        rejected in arbitrary, capricious, irrational and inconsistent ways, often for breaking completely unwritten
+        rules.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.ben-evans.com/benedictevans/2020/8/18/app-stores&sa=D&source=editors&ust=1718648881460433&usg=AOvVaw1Bn71x5AQJrlI-4xMYhGBl">Benedict
+            Evans – Technology Writer</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>There's a lot of talk about the 30% tax that Apple takes from every app
+        on the App Store. The time tax on their developers to deal with this unfriendly behemoth of a system is just
+        as bad if not worse</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://twitter.com/samj0hn/status/1431001795904561160&sa=D&source=editors&ust=1718648881460912&usg=AOvVaw0YQG4by2ysJkHAkLgltDuL">Samantha
+            John – CEO Hopscotch</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Given that third-party browsers using their own engine already need to comply with
+      extensive security rules in order to be allowed access to the relevant APIs, there is no security justification
+      for any additional scare screens or warnings.</p>
+
+    <p>Currently, only a few browser vendors offer their browser through the macOS app store.
+      It seems plausible that browsers will want to abandon the iOS app store at some point in the future to avoid
+      having to deal with any unreasonable app store guidelines that Apple might impose.</p>
+
+    <p>A key idea in the DMA is that gatekeeper services, such as the Apple’s app store, offered on
+      top of operating system core platform services such as iOS are optional, both for users and businesses.
+      Businesses
+      should be free to distribute directly and users should be free to get software directly from third-party
+      developers. If Apple wishes to retain users and business on their app store they must compete to make it more
+      attractive. As mentioned before, the only leeway they are given by the act to intervene in these direct
+      interactions is via strictly necessary, proportionate and justified security measures to protect the integrity
+      of
+      the operating system.</p>
+
+    <p>This will be beneficial to competition as it will remove a significant source of power
+      Apple has over these browser vendors. However, this future is only possible if the process for installing a
+      browser directly is made frictionless and painless.</p>
+
+    <p>We believe that in order to comply with the DMA, Apple should:
+    </p><ul>
+      <li>Allow browsers to be installed directly from their own
+        websites.</li>
+      <li>Not place any friction or scare screens in the installation
+        process.</li>
+      <li>Not place any rules that aim to inhibit or make more expensive
+        installations that are not via Apple’s app store.</li>
+    </ul>
+
+    <h3 id="allow-users-to-switch-the-distribution-method-of-native-apps">
+      <a class="header-anchor" href="#allow-users-to-switch-the-distribution-method-of-native-apps" aria-hidden="true">#</a>
+      4.3.2. Allow Users to Switch the Distribution Method of Native Apps
+    </h3>
+
+    <p>The DMA obligates gatekeepers to allow business users to promote and choose the
+      distribution channel that they consider most appropriate for the purpose of interacting with any end users;
+      those
+      business users have already acquired core platform services provided by the gatekeeper.</p>
+
+    <p>This means that business users need to be able to switch the distribution channel of
+      individual native apps downloaded by Apple's app store to either direct download or to be managed by another
+      app store.</p>
+
+    <blockquote>
+      <p>In certain cases, for instance through the imposition of contractual terms and
+        conditions, gatekeepers can restrict the ability of business users of their online intermediation services to
+        offer products or services to end users under more favourable conditions, including price, through other
+        online
+        intermediation services or through direct online sales channels. Where such restrictions relate to third-party
+        online intermediation services, they limit inter-platform contestability, which in turn limits choice of
+        alternative online intermediation services for end users. Where such restrictions relate to direct online
+        sales
+        channels, they unfairly limit the freedom of business users to use such channels. To ensure that business
+        users of
+        online intermediation services of gatekeepers can freely choose alternative online intermediation services or
+        direct online sales channels and differentiate the conditions under which they offer their products or
+        services to
+        end users, it should not be accepted that gatekeepers limit business users from choosing to differentiate
+        commercial conditions, including price. Such a restriction should apply to any measure with equivalent effect,
+        such as increased commission rates or de-listing
+        of the offers of business users.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3D(39),of%2520business%2520users.&sa=D&source=editors&ust=1718648881463000&usg=AOvVaw18UQv_k81GLcUs46IcQRvh">Digital
+            Markets Act – Recital 39 </a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>To prevent further reinforcing their dependence on the core platform
+        services of gatekeepers, and in order to promote multi-homing,
+        <strong class="stressed">the business users of
+          those gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate for the purpose of interacting with any end users that those business users have already
+          acquired
+          through core platform services provided by the gatekeeper</strong> or through other
+        channels.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881463665&usg=AOvVaw3jChM1pLkezpnYS_54aAUx">
+            Digital Markets Act – Recital 40</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow business
+          users</strong>, free of charge, <strong class="stressed">to communicate and
+          promote offers,
+          including under different conditions, to end users acquired via its
+          core platform service</strong> or through other channels, and to conclude contracts
+        with those end users, <strong class="stressed">regardless of whether, for that purpose, they use
+          the core platform services of the
+          gatekeeper</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881464536&usg=AOvVaw30v9JNrpHRcZi7Yc_JqqZR">Digital
+            Markets Act – Article 5(4)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Currently the only way of doing this is the extremely awkward process of entirely
+      uninstalling an app (and thus deleting) all its data, then reinstalling it via either the third party app store
+      or
+      directly from the developers website.</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall not restrict technically or
+          otherwise the ability of end users to switch between</strong>, and subscribe to,
+        <strong class="stressed">different software applications and services that are accessed using the core
+          platform services of
+          the
+          gatekeeper</strong>, including as regards the choice of Internet access services for end
+        users.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881465478&usg=AOvVaw2abSXAj0PQYoWnsU_vauD7">Digital
+            Markets Act – Article 6(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>In this case the core platform service would be the operating system iOS which is
+      restricting the ability of users to switch apps between app stores, or being managed directly by the
+      developers.</p>
+
+    <p>Switching which store or developer is controlling a particular app should be
+      straightforward. To not do so is by design of the operating system and its interfaces undermine effective
+      compliance with Recital 39, Recital 40, Article 5(4) and Article 6(6). Apple should build appropriate interfaces
+      to facilitate such a switch.</p>
+
+    <p>This also comes with the advantage that should any individual app store become defunct,
+      there would now be a mechanism to not orphan apps on that app store. It would also apply great pressure on app
+      stores to be reasonable otherwise risk businesses and users switching their existing apps en masse to an
+      alternative. Enabling this competitive pressure would benefit both business and consumers.</p>
+
+    <p>Finally, Apple must allow businesses the right to be able to promote this switch, and
+      its advantages such as price decreases or extra features, to users which have downloaded the app via Apple's
+      app store. There should also be no prohibition via app store rules or contracts on promoting direct download or
+      third party app stores in adverts on other third party apps in Apple's app store. This should also include
+      the
+      case where a business wishes to discontinue offering their app via a particular app store and wishes to promote
+      alternative options for users to switch too.</p>
+
+    <p>Apps will need the ability to detect which source is managing their distribution, i.e
+      which app store or direct download. An API will need to exist which provides this to the app. This is to allow
+      the
+      app to appropriately alter its features, interfaces or displayed prices.</p>
+
+    <p>This change will bring significant advantages for consumers and businesses. It will
+      allow app stores to be more easily contested by third parties and reduce the entrenchment of the existing body
+      of
+      installed apps. This will lead to better prices, more competition and greater choice for consumers.</p>
+
+    <h3 id="direct-install-browsers-should-be-included-in-choice-screens">
+      <a class="header-anchor" href="#direct-install-browsers-should-be-included-in-choice-screens" aria-hidden="true">#</a>
+      4.3.3. Direct Install Browsers Should Be Included In Choice Screens
+    </h3>
+
+    <p>There is no plausible reason for Apple to exclude browsers from choice screens if they are not
+      listed within its app store. Choice screens attempt to remedy the harm from Apple’s historic
+      self-preferencing by setting its browser as the default. The article seeks to prevent gatekeepers that might
+      "favour its own or third-party services or products on its operating
+      system", and so it does not make sense that participation in systems designed to
+      redress harms caused by favoring of their own services and products must then rely on forced participation in
+      them
+      unduly.</p>
+
+    <p>Entrants that choose to entirely avoid Apple's app store should not be penalized
+      for this choice. Thus, browsers that are available for direct download should be eligible to appear on the
+      choice
+      screen.</p>
+
+    <blockquote>
+      <p><strong class="stressed">To prevent further reinforcing their dependence on
+          the core platform services of gatekeepers, and in order to promote multi-homing, the business users of those
+          gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate</strong> for the purpose of interacting with any end users that those business
+        users have already acquired through core platform services provided by the gatekeeper or through other
+        channels.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881467487&usg=AOvVaw1UQA5ne_qECkJfRecRGfXG">Digital
+            Markets Act – Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is important that Apple does not entrench an existing core platform service in the
+      process of satisfying other obligations of the DMA. In the context of both the intent and letter of the DMA,
+      locking all browsers to its app store both mechanically and via its rules does not appear to be
+      compliant.Apple must publish the mechanisms for including a “direct install” version of a
+      browser on the choice screen. Browser vendors should be allowed to distribute both via the AppStore and
+      directly,
+      and be able to opt to have the choice screen connected to their direct install version.</p>
+
+    <h3 id="apple-should-make-notarization-for-directly-downloaded-browsers-automatic">
+      <a class="header-anchor" href="#apple-should-make-notarization-for-directly-downloaded-browsers-automatic" aria-hidden="true">#</a>
+      4.3.4. Apple Should Make Notarization for Directly Downloaded Browsers Automatic
+    </h3>
+
+    <p>Apple has announced that it intends to notarize apps that are not downloaded by its app
+      store but that it will keep this review strictly limited to security.</p>
+
+    <blockquote>
+      <p>Notarization for iOS apps is a baseline review that applies to all apps,
+        regardless of their distribution channel, focused on platform policies for security and privacy and to
+        maintain
+        device integrity. Through a combination of automated checks and human review, Notarization will help ensure
+        apps
+        are free of known malware, viruses, or other security threats, function as promised, and don’t expose
+        users
+        to egregious fraud.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/%23:~:text%3DNotarization%2520for%2520iOS%2520apps%2520is,expose%2520users%2520to%2520egregious%2520fraud.&sa=D&source=editors&ust=1718648881468503&usg=AOvVaw0LVacnSgX1qObVNiqFiS9g">Apple
+            – On Notarization </a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is our opinion that this policy for third-party browsers which are downloaded
+      directly is unproportionate, unnecessary and will in fact worsen security.</p>
+
+    <p>It is important to note that what Apple is proposing is not equivalent to the system
+      Apple has for notarization of macOS software which is a fast and automated process.</p>
+
+    <blockquote>
+      <p>Notarize your macOS software to give users more confidence that the
+        Developer ID-signed software you distribute has been checked by Apple for
+        malicious components. <strong class="stressed">Notarization of macOS
+          software is not App Review</strong>.
+        The Apple notary
+        service is
+        an automated system that scans your software for malicious content, checks for code-signing issues, and
+        returns
+        the results to you quickly. If there are no issues, the notary service generates a ticket for you to staple to
+        your software; the notary service also publishes that ticket online where Gatekeeper can find
+        it.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution&sa=D&source=editors&ust=1718648881469461&usg=AOvVaw2a19uy3X592wknrH83gQY9">Apple
+            – on macOS Notarization</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Were Apple’s proposal simply to apply automatic checks including for code
+      signatures that verify the developer is the same developer with the browser entitlement, that would be perfectly
+      acceptable.</p>
+
+    <p>Apple’s language however makes it clear that this is “app store
+      review” in disguise, although nominally locked to security issues. </p>
+
+    <p>Our concern is that Apple will introduce considerable delay and friction into the
+      process of updating browsers. We are also concerned, given Apple’s known abuse of their Apple app store
+      review process, that if Apple is in a dispute with a third-party browser, they may attempt to use blocking of
+      updates on security ground as a weapon to gain concessions from browser vendors or otherwise wield the fear of
+      such a rejection as a tool to limit third-party browsers to compete.</p>
+
+    <p>“Patch gap” is the amount of time between a vulnerability being discovered
+      and it being patched on consumers devices. It is a critical aspect of security that this gap is as small as
+      possible.</p>
+
+    <p>There is a strong argument that behavior mentioned in the previous two remedies, such as Apple
+      preventing an update to Spotify for two weeks, and the pattern of behavior as
+      outlined in
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881470593&usg=AOvVaw1kmwUiWh-rtCWIBL5x-IUR">the
+        DOJ complaint</a>, means that delays can often be arbitrary and significant.
+    </p>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/distribute/app-review/%23:~:text%3DOn%2520average%252C%252090%2525%2520of%2520submissions%2520are%2520reviewed%2520in%2520less%2520than%252024%25C2%25A0hours.&sa=D&source=editors&ust=1718648881471002&usg=AOvVaw3VVOjJsMjU4C9sG97qu_Cc">Even
+        the 90% in 24 hours for app review</a> that Apple claims it
+      achieves with its app store
+      will
+      significantly worsen patch gap. For reference the macOS notarization
+      process is automated
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow%23:~:text%3DAfter%2520you%2520upload%2520your%2520app%252C%2520the%2520notarization%2520process%2520typically%2520takes%2520less%2520than%2520an%2520hour.&sa=D&source=editors&ust=1718648881471373&usg=AOvVaw3C-TGqnwFX2p2KH6sJXPYv">and
+        takes less than 1 hour</a>.
+    </p>
+
+    <blockquote>
+      <p>Apple suppresses such innovation through a web of contractual restrictions
+        that it selectively enforces through its control of app distribution and its ‘app
+        review’ process</p>
+      <p>[...]</p>
+      <p>Apple often claims these rules and restrictions are necessary to protect user
+        privacy or security, but Apple’s documents tell a different story. In reality, Apple imposes certain
+        restrictions to benefit its bottom line by thwarting direct and disruptive competition for its iPhone platform
+        fees and/or for the importance of the iPhone platform itself.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881472163&usg=AOvVaw3_fbqsCbHlSsjBfYYGSBgn">DOJ
+            Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+    <p>Browser vendors have their own dedicated security teams which have worked for decades to secure
+      their own browsers. <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html&sa=D&source=editors&ust=1718648881472593&usg=AOvVaw2Lt_y4jme5TgZPwxd4_1PU">Apple
+        has a worse track record than Firefox and Chrome</a>&nbsp;when it comes to patch
+      gap.</p>
+
+    <figure>
+      <img src="/images/apple-dma-report/image11.png" alt="Histogram of days from fix landed in public to fix shipped">
+      <figcaption>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.google.com/url?q%3Dhttps://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html%26sa%3DD%26source%3Ddocs%26ust%3D1716007764601184%26usg%3DAOvVaw32MDv4LcTjodz660Hjb1sg&sa=D&source=editors&ust=1718648881473149&usg=AOvVaw0KlDiGM4zL20QQeB0rmC9i">Google
+          Project Zero - Statistics on Patch Gap</a>
+      </figcaption>
+    </figure>
+
+    <p>iOS users remain vulnerable to known bugs in Safari longer than users of alternative browsers on
+      every other OS. This picture is made even clearer by OS update rates. Since Safari requires a full operating
+      system update, further steps (and attendant delay) is introduced in getting patches into user’s hands,
+      than
+      if the browser updated like a “normal app” separate from OS updates (the standard on all other
+      modern
+      OSes). Safari requires the user to update their entire operating system,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.ubackup.com/phone-backup/how-long-does-an-ios-update-take.html%23:~:text%3DUpdating%2520to%2520the%2520latest%2520iOS%2520takes%2520about%252030%2520minutes%2520on%2520average.&sa=D&source=editors&ust=1718648881473638&usg=AOvVaw2stizh6LpxGOKURlp-nGgZ">a
+        process that makes the device unusable for up-to 30 minutes</a>.
+    </p>
+
+    <p>Apple is presumably claiming this right to review under the security provision in 6(4)
+      which states: </p>
+
+    <blockquote>
+      <p>The gatekeeper shall not be prevented from taking, to the extent that they
+        are strictly necessary and proportionate, measures to ensure that third-party software applications or
+        software
+        application stores do not endanger the integrity of the hardware or operating system provided by the
+        gatekeeper,
+        provided that such measures are duly justified by the gatekeeper.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881474304&usg=AOvVaw1FBVxSXRa_HMW6s-eyvUMi">Digital
+            Markets Act – Article 6(4)</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>However, this does mean the security measure, in this case the need to notarize the
+      third-party browsers, needs to:</p>
+
+    <ul>
+      <li>Be strictly necessary</li>
+      <li>Be proportionate</li>
+      <li>Be to prevent browsers from endangering the integrity of the
+        hardware or operating system provided by the gatekeeper</li>
+      <li>Be justified by Apple</li>
+    </ul>
+
+    <p>Given there is a strong argument that Apple will in fact worsen security via this
+      policy, the onus is on Apple to state a convincing argument on how they intend to improve security with this
+      policy, including what additional staffing specifically for third-party browser vendors they are intending on
+      hiring to implement it.</p>
+
+    <p>Apple will need to convincingly show why it is strictly necessary and proportionate for
+      them to enforce this when all the major browser vendors have their own dedicated security teams.</p>
+
+    <p>They will also need to show why simple rules such as patching at a regular cadence or
+      committing to fixing vulnerabilities within a particular time period are not sufficient. For all these rules,
+      Safari should be the benchmark; No browser should be penalized for doing a better job at security than
+      Safari.</p>
+
+    <p>Apple should guarantee that notarization for third-party browsers, with the browser
+      entitlement which are downloaded outside Apple’s app store, is a fast and automatic process. </p>
+
+    <p>Our recommendation is that Apple’s only recourse against third-party browsers
+      with serious security issues, which they refuse to fix in a timely manner or that are compromising the operating
+      system against the interests of the user, is the option to revoke their browser engine entitlement.</p>
+
+    <p>This needs to be paired with strong financial penalties for Apple, in the event it
+      takes such an action without sufficient evidence.</p>
+
+    <p>This setup would remove Apple’s ability to bully browser vendors via threatening
+      to delay updates on bogus security grounds, while still granting the ability to outright remove malicious or
+      incompetent browsers where strictly necessary, reasonable and justified.</p>
+
+    <p>Apple should be subject to a SLA (Service Level Agreement) in return for the
+      ability to impose automated notarization on third parties. It would be our recommendation that the SLA for
+      notarization should be less than an average of 15 minutes with a maximum of 1 hour. It is important that Apple
+      not
+      be left free to abuse the ability to delay app updates. This delay would be solely within Apple’s control
+      and no third party software provider would have the ability to improve upon the speed of Apple’s
+      notarization.</p>
+
+    <p>A key metric directly downloaded browsers and third party app stores will compete on is
+      the ability to provide my timely updates. Allowing Apple the ability to selectively block or make arbitrarily
+      slow
+      (potentially weeks) particular updates with no explanation significantly undermines competition with Apple's
+      app store and grants Apple great power to bully developers who have opted to distribute outside of Apple’s
+      app store.</p>
+
+    <h3 id="apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu">
+      <a class="header-anchor" href="#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu" aria-hidden="true">#</a>
+      4.3.5. Apple Should Not Break Updates for EU Residents Traveling Outside The EU
+    </h3>
+
+    <p>Apple has stated that it will prevent all updates for apps downloaded from third-party
+      app stores that are outside the EU for more than 30 days.</p>
+
+    <p>Apple has not released any explicit statement on what will happen to browsers using their own
+      engine downloaded from Apple’s app store if the user (an EU resident) leaves the EU for greater than 30
+      days. Given <a href="#testing-for-browser-vendors-and-developers-outside-the-EU">Apple is attempting to block even browser
+        vendors from testing on their own test devices outside the EU</a>, it seems likely they
+      will attempt to extend a similar policy to third party browsers which use their own engine even if they are
+      downloaded from Apple’s app store.</p>
+
+    <p>We would like a statement from Apple clarifying that this does not apply to browsers
+      with the browser engine entitlement.</p>
+
+    <blockquote>
+      <p><span>“If you leave the European Union, you can continue to open and use apps that
+          you previously installed from alternative app marketplaces. Alternative app marketplaces can continue updating
+          those apps for up to 30 days after you leave the European Union, and you can continue using alternative app
+          marketplaces to manage previously installed apps. However, you must be in the European Union to install
+          alternative app marketplaces and new apps from alternative app marketplaces.”</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://support.apple.com/en-us/118110%23:~:text%3DIf%2520you%2520leave%2520the%2520European,apps%2520from%2520alternative%2520app%2520marketplaces.&sa=D&source=editors&ust=1718648881477157&usg=AOvVaw2jwLLE_kBl0PIrksiBUvyP">
+            Apple’s statement on breaking updates for EU residents outside the EU for greater than 30 days</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly:</p>
+
+    <ul>
+      <li>This has no exemption for EU residents.</li>
+      <li>This rule will block security updates.</li>
+      <li>Safari is immune to this rule (as it is only available on
+        Apple’s app store)</li>
+      <li>No other gatekeeper has taken such extreme measures to limit the
+        competition the DMA allows to the EU.</li>
+    </ul>
+
+    <p>Apple has not included any arguments in their statement on why EU residents traveling
+      for longer than 30 days cease to be EU residents, nor any discussion on how they will ensure that this policy
+      does
+      not apply to any EU residents.</p>
+
+    <p>Under
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://home-affairs.ec.europa.eu/system/files_en?file%3D2020-09/schengen_brochure_dr3111126_en.pdf&sa=D&source=editors&ust=1718648881478801&usg=AOvVaw1wS3AbOSVuhRr03d8LYEtP">Schengen
+        agreements</a>, EU residents have the legal right to freedom of movement between all 29
+      Schengen countries, and the legal right to stay in each of the 29 countries up to 90 days without the need to
+      apply for a travel visa or permit, as there are no borders between these countries. Importantly, among these
+      29,
+      there are countries like Switzerland, Norway and Iceland, which are not members of the EU. Meaning that, for
+      example, a German citizen can legally visit and stay in their summer cottage in Switzerland for up to 90 days.
+    </p>
+
+    <p>In the same spirit, the EU and the US have mutual visa-free travel agreements, allowing an EU
+      citizen to travel to the US with an
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://esta.cbp.dhs.gov/esta&sa=D&source=editors&ust=1718648881479291&usg=AOvVaw2EYq-tfnXdiyq-5ZvwDHc4">ESTA
+        visa</a> for up to 90 days without losing their status as an EU resident.
+    </p>
+
+    <p>Meaning that, a Swedish citizen can legally visit their parents in Norway for up to 90
+      days, then fly to Iceland and spend an additional 90 days with their siblings, then fly to the US to visit their
+      friends for another 90 days, then spend their summer in Switzerland for up to 90 days, and so can legally stay
+      away from the EU for even a year or more if they wish, whilst continuing to be an EU resident throughout.
+    </p>
+
+    <p>In addition, according to the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://europa.eu/youreurope/citizens/work/taxes/income-taxes-abroad/index_en.htm%23:~:text%3Dyou%2520will%2520usually%2520be%2520considered%2520tax%252Dresident%2520in%2520the%2520country%2520where%2520you%2520spend%2520more%2520than%25206%2520months%2520a%2520year&sa=D&source=editors&ust=1718648881479914&usg=AOvVaw3TK0F7Q_uk3ZOGs-ZvURF7">EU
+        / EEA VAT and taxation law</a>, which includes non-EU countries such as Norway and
+      Iceland, EU residents are only considered tax residents of another member state after 6 months. A rule which
+      is
+      more or less globally harmonized to simplify global taxation of individuals. Meaning that the residents of EU
+      member states are only legally considered tax-residents of another country after having spent 6 months in the
+      destination country.
+    </p>
+
+    <p>This means that for a very large number of EU residents traveling outside the EU, or
+      working outside the EU, Apple’s arbitrary 30-days rule to prevent app updates actually puts EU
+      residents’ cyber-safety and security at great risk. Apps subjected to this policy, in particular browsers,
+      will cease to receive security updates.</p>
+
+    <p>This 30-day policy greatly contradicts Apple’s justification claiming that their
+      biggest priority is the safety of their users, as they could simply remove the arbitrary 30-day rule, or
+      increase
+      it to something more reasonable, such as 6 months to a year or more to accommodate and match the legal rights of
+      EU residents.</p>
+
+    <p>Even if this policy is scoped by Apple to not apply to browsers shipped on their app
+      store, should browsers choose to abandon Apple's app store in the future they will be subject to Apple's
+      decision. Allowing browsers the option to ship outside of Apple's app store is an important option to weaken
+      Apple's ability to dictate to browsers their form and functionality, will allow browsers to reduce the time
+      to
+      deploy security patches and will improve their ability to compete fairly and effectively. The right to choose
+      how
+      to distribute to users is codified in the DMA under Recital 40, Article 5(4) and Article 6(6).</p>
+
+    <blockquote>
+      <p>To prevent further reinforcing their dependence on the core platform
+        services of gatekeepers, and in order to promote multi-homing,
+        <strong class="stressed">the business users of
+          those gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate for the purpose of interacting with any end users that those business users have already acquired
+          through core platform services provided by the gatekeeper</strong> or through other
+        channels.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881481152&usg=AOvVaw0NdHxb9BcUk4CiNjLnaLJf">Digital
+            Markets Act – Recital 40</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow business
+          users</strong>, free of charge, <strong class="stressed">to communicate and promote offers,
+          including under different conditions, to end users acquired via its
+          core platform service</strong> or through other channels, and to
+        conclude contracts with those end users,<strong class="stressed">
+          regardless of whether, for that purpose,
+          they use the core platform services of the
+          gatekeeper</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881481971&usg=AOvVaw35fLxNt4H9CJDwtVAQtFoX">Digital
+            Markets Act – Article 5(4)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The gatekeeper shall not restrict technically or
+        otherwise the ability of end users to switch between, and subscribe to, <span class="c10">different software applications and services that are accessed using the core platform services of
+          the
+          gatekeeper, including as regards the choice of Internet access services for end
+          users.”</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881482817&usg=AOvVaw06_MmwqwZqlPCz3WB0T24j">Digital
+            Markets Act – Article 6(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple should not be able to break important updates (including security updates) for EU residents
+      who are traveling outside the EU. Apple will need to remove or update this policy to be compliant with the
+      DMA.</p>
+
+    <h3 id="h.2szc72q">4.3.6. Opt-In Rights Contract Should Be Removed</h3>
+
+    <p>All businesses serving EU customers should automatically have all of the rights granted
+      to them under the DMA. They should not have to opt-in to those rights under different rules or punitive pricing
+      changes.</p>
+
+    <p>Business users in the act are defined as:</p>
+
+    <blockquote>
+      <p>‘business user’ means any natural or legal person acting in a
+        commercial or professional capacity using core platform services for
+        the purpose of or in the course of
+        providing
+        goods or services to end users</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881483928&usg=AOvVaw3zTjOfqv4HNyMFIkGRac2a">Digital
+            Markets Act</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is a broad definition that currently covers almost every business supplying an app
+      on the iOS app store.</p>
+
+    <p>Apple should not be able to either contract businesses out of their rights under the
+      DMA, or attach a price to those rights. </p>
+
+    <p>This is not how any law functions. For example, Apple can not sell iPhones to consumers
+      at two different prices, one which abides EU's laws on deceptive advertising, and one that does not; The law
+      applies to all of Apple's services and hardware.</p>
+
+    <p>Similarly, Apple should not be able to segment business users into ones for which Apple
+      has to abide by the DMA and another for which they do not have to. Rather, Apple should have to automatically
+      abide by the DMA for all business users operating within the EU, that is every business that supplies
+      applications
+      to EU residents.</p>
+
+    <p>Apple should remove its new "alternative contract" and update its existing
+      contract such that all business users within the EU are automatically moved onto terms compliant with the DMA.
+      All
+      of Apple’s pre-existing contracts which apply to the business interactions between end users and business
+      users in the EU must be updated to comply with the DMA. Business users should not have the choice of being on
+      non-DMA compliant terms. This false choice allows gatekeepers a method of circumventing their responsibilities.
+      &nbsp;</p>
+
+    <h3 id="core-technology-fee-should-be-removed">
+      <a class="header-anchor" href="#core-technology-fee-should-be-removed" aria-hidden="true">#</a>
+      4.3.7. Core Technology Fee Should Be Removed
+    </h3>
+
+    <p>Apple's proposal also includes plans for how they would allow third-party native
+      app stores to compete with their own on iOS. This is directly compelled by the act.</p>
+
+    <p>Apple's proposal seems designed to prevent any free app from ever even considering
+      moving to a third-party native app store on iOS, or being available for direct download from its own
+      website.</p>
+
+    <p>In order to list their app on a third-party app store or on their own website, the app
+      developer must sign an alternative contract allowing them the rights granted under the DMA. However, this
+      alternative contract comes with significantly different pricing.</p>
+
+    <p>If you choose the second contract, Apple will waive some app store fees but will add a
+      new fee called “Core Technology Fee”, summarized as a 50 cent charge per-user per-year, past the
+      first
+      million downloads.</p>
+
+    <p>Critically, and to OWA’s astonishment,<strong>this also includes
+        downloads from the Apple app store</strong>.</p>
+
+    <p>In Apple's own words the fee is: </p>
+
+    <blockquote>
+      <p>The Core Technology Fee (CTF) is an element of the new business terms in the
+        European Union (EU) that reflects the value Apple provides developers through ongoing investments in the
+        tools,
+        technologies, and services that enable them to build and share innovative apps with users around the world.
+        Developers can choose to remain on the App Store’s current business terms or adopt the new business
+        terms
+        for iOS apps in the EU.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/core-technology-fee/&sa=D&source=editors&ust=1718648881486130&usg=AOvVaw1WG5m49ItADLW86-BYUwyg">Apple
+            Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>They also explain:</p>
+
+    <blockquote>
+      <p>The Core Technology Fee (CTF) reflects Apple’s investment in the
+        tools, technology, and services that enable developers to build and share their apps with Apple users.
+        <strong class="stressed">That includes more than 250,000 APIs</strong>, TestFlight, Xcode, and so
+        much more. These tools create a lot of value for developers, whether or not they share their apps on the App
+        Store.
+      </p>
+      <p><strong class="stressed">The CTF only applies to developers who adopt the new terms for alternative
+          distribution and payment processing</strong></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/&sa=D&source=editors&ust=1718648881486892&usg=AOvVaw0tdCGVsupR9pcPd7Meex4m">Apple
+            Documentation</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+
+    <p>That is, Apple explicitly states that the fee covers access to iOS’s APIs.
+    </p>
+
+    <p>The DMA specifically precludes any fee for software or hardware API access:</p>
+
+    <blockquote>
+      <p>Article 6(7) The gatekeeper shall allow providers of services and providers of
+        hardware, <strong class="stressed">free of charge</strong>, effective interoperability with, and
+        access for the purposes of interoperability to, the same hardware and software features accessed or controlled
+        via
+        the operating system or virtual assistant listed in the designation decision pursuant to Article 3(9) as are
+        available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business
+        users and alternative providers of services provided together with, or in support of, core platform services,
+        free
+        of charge, effective interoperability with, and access for the purposes of interoperability to, the same
+        operating
+        system, hardware or software features, regardless of whether those features are part of the operating system,
+        as
+        are available to, or used by, that gatekeeper when providing such services.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881487923&usg=AOvVaw0cEm-CbWqyVu4gQ7ekkjU2">Digital
+            Markets Act</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>“Free of charge” being the key and unambiguous phrase.</p>
+
+    <p>For the remaining items, given that it is not possible (or at least very difficult) to
+      distribute to iOS without Xcode (by Apple’s design), it is not clear how developers could avoid using
+      these
+      tools. Many developers would love the ability to be able to develop for iOS without being forced to use Xcode or
+      TestFlight, as this would allow developing for iOS without requiring an Apple Mac computer. It seems
+      unreasonable
+      to charge for usage of software libraries when you have, by contract and technical setup, prevented developers
+      from using competing libraries.</p>
+
+    <p>Astonishingly, Apple has added wording that you are <strong>unable to switch back
+        to the standard contract</strong> if you are unhappy with the new contract, while still
+      granting themselves the right to change either contract at any time.</p>
+
+    <blockquote>
+      <p>Developers who adopt the new business terms at any time will not be able to
+        switch back to Apple’s existing business terms for their EU apps. Apple will continue to give developers
+        advance notice of changes to our terms, so they can make informed choices about their businesses moving
+        forward.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/%23dev-qa:~:text%3DDevelopers%2520who%2520adopt%2520the%2520new%2520business%2520terms%2520at%2520any%2520time%2520will%2520not%2520be%2520able%2520to%2520switch%2520back%2520to%2520Apple%25E2%2580%2599s%2520existing%2520business%2520terms%2520for%2520their%2520EU%2520apps.%2520Apple%2520will%2520continue%2520to%2520give%2520developers%2520advance%2520notice%2520of%2520changes%2520to%2520our%2520terms%252C%2520so%2520they%2520can%2520make%2520informed%2520choices%2520about%2520their%2520businesses%2520moving%2520forward.&sa=D&source=editors&ust=1718648881489154&usg=AOvVaw1Q2bn7Mave9xGQd8gACzaa">Apple
+            Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Next, it is worth considering how much it would cost for a browser
+      to list on one of these
+      third-party app stores. <a rel="noreferrer" target="_blank" href="https://www.demandsage.com/iphone-user-statistics/">
+        iOS has 1.65 billion users</a>. So that is
+      16.5 million users for each 1% browser market share. If a
+      browser
+      vendor dares to list their app on a third-party store, even once, and
+      <strong>even if no one
+        downloads it</strong> from that third-party store, Apple will bill them <strong>$8.25
+        million per year per 1% market share every year with no recourse</strong> to change back to
+      the previous contract.
+    </p>
+
+    <p>It seems clear this is designed to make it as difficult as possible for free apps to
+      list on third-party app stores, depriving alternative app stores of these apps, and preventing their ability to
+      succeed.</p>
+
+    <p>Apple should remove the Core Technology Fee entirely, and listing on a third-party app store
+      should not be able punitively change additional fees to a business’s
+      apps on the Apple app store in
+      <strong>retaliation</strong> for listing on other app stores on iOS.
+    </p>
+
+    <p>Under pressure Apple has added some exceptions to Core Technology Fee
+      including:</p>
+
+    <ul>
+      <li>Nonprofit organizations</li>
+      <li>Developers who’s apps collectively have less than 1 million
+        users.</li>
+      <li>A phase-in period of 3 years for developers that hit $10 million+
+        revenue</li>
+      <li>Students, hobbyists, and other non-commercial developers with a
+        no-revenue business.</li>
+    </ul>
+
+    <p>The last one is important as it is designed to prevent businesses from listing a free app either
+      directly via their website or third party app stores if they have
+      <strong>any</strong> apps with
+      revenue.
+    </p>
+
+    <p>None of these concessions solve the underlying problem. Apple is attempting to charge
+      fees on interactions between customers and businesses of which they have no part and provide no service beyond
+      that which comes with their operating system by default. These are apps not installed via Apple’s app
+      store
+      on devices that Apple has already sold at incredibly high margins to consumers. This type of behavior is clearly
+      against both the intent and letter of the DMA. </p>
+
+    <p>If Apple wishes to make additional revenue from consumers who purchase their devices in
+      the EU, they need to do it by making their app store and their optional services (Safari, iCloud, Apple TV,
+      Apple
+      Music etc) more attractive. They should not attempt to siphon revenue from consumers and businesses which are
+      opting to not use either for particular apps. </p>
+
+    <p>Further they should not apply punitive pricing to these same apps on their own app
+      store for daring to list outside of it.</p>
+
+    <h4 id="the-fair-price-for-api-access">
+      <a class="header-anchor" href="#the-fair-price-for-api-access" aria-hidden="true">#</a>
+      4.3.7.1. The Fair Price for API Access
+    </h4>
+
+    <p>Even though the DMA explicitly sets the cost of access to these APIs at zero, it is
+      worthwhile discussing what the “fair” price is.</p>
+
+    <h5 id="value-of-ip-in-apis">
+      <a class="header-anchor" href="#value-of-ip-in-apis" aria-hidden="true">#</a>
+      4.3.7.1.1. Value of IP in APIs
+    </h5>
+
+    <p>Clearly Apple does not believe that they have IP rights over the general category of
+      each of these APIs, otherwise with their over billion USD a year legal budget they would have sued other
+      operating
+      systems for violating their IP (eg Windows, Android, Linux etc).</p>
+
+    <p>So the question arises does the IP in Apple's iOS API's actually provide value
+      or is the real value being able to have sufficient access to the operating system hardware and software to
+      provide
+      needed functionality to consumers. It is important to remember that only Apple has control over what APIs are
+      available on iOS and so all of them are by definition made by Apple and likely contain Apple's IP even if
+      they
+      are stock standard and available on every operating system. In a sense it is like Apple is simply charging for
+      the
+      ability to have certain functionality on iOS rather than charging for the value of the IP in those APIs.
+    </p>
+
+    <p>One thought experiment to illustrate this is, to imagine for a particular API that
+      Apple also implemented a replica of Androids equivalent for that API for iOS. &nbsp;Developers are then asked
+      whether and how much more they would be willing to pay for Apple's version of the API containing Apple's
+      IP instead of using the Android APIs. If the answer is zero or low then we believe that the amount Apple should
+      be
+      allowed to charge under should be equally low as this would indicate the the value of the IP in this case was
+      low
+      or zero. </p>
+
+    <h5 id="comparable-licenses">
+      <a class="header-anchor" href="#comparable-licenses" aria-hidden="true">#</a>
+      4.3.7.1.2. Comparable licenses
+    </h5>
+
+    <p>Another avenue for deciding reasonable prices is to look at the comparable licenses
+      charged to other developers. Other operating systems such as Windows, macOS, Linux, ChromeOS and Android all do
+      not charge for access to system APIs. That is the comparable cost of licenses charged to other developers on
+      other
+      platforms is zero.</p>
+
+    <p>It is worth noting that iOS also does not currently charge for API access. Nowhere in
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/&sa=D&source=editors&ust=1718648881492740&usg=AOvVaw2XYSmUlj7BbRVcE5Hg-w73">Apple’s
+        iOS guidelines</a> or in their
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/features/&sa=D&source=editors&ust=1718648881493031&usg=AOvVaw1V4Tqtdr3r51DahsTf07XE">app
+        store features list</a> do they mention that they are waiving API access fees in
+      return for particular conditions or the App Store 15-30% revenue sharing arrangement.
+    </p>
+
+    <h5 id="apple-developer-fee">
+      <a class="header-anchor" href="#apple-developer-fee" aria-hidden="true">#</a>
+      4.3.7.1.3. Apple Developer Fee
+    </h5>
+
+    <p>Apple also charges all developers $100 USD per a year to be part of the developer
+      program. With 34 million registered developers, this is a business worth at least $100m a year to Apple, quite
+      plausibly significantly higher than the budget Apple has for API development for iOS. Apple currently plans to
+      charge this developer fee even to developers that do not distribute via their app store but rather distribute
+      directly or via third party app stores.</p>
+
+    <p>The fact that Apple already derives considerable income directly from developers
+      wishing to distribute an app on their operating system is a significant factor.</p>
+
+    <blockquote>
+      <p>I get it — saying “Spotify pays Apple nothing’ is a much
+        stronger lobbying position than ‘Spotify pays Apple just $99 a year, the same as every other
+        developer’. But only if it is, you know, true. And Apple makes hundreds of millions of dollars a year
+        from
+        charging that fee to developers as standard, which complicates the narrative that the App Store is only funded
+        by
+        commission on sales.</p>
+      <p>I tried asking Apple how they squared this, and a spokesperson repeated the claim
+        that Spotify paid $0 to Apple. When I asked if I could explicitly write that
+        ‘Apple claimed that Spotify
+        is
+        not charged the developer fee’, though, the company stopped replying to my emails. Spotify had no such
+        bashfulness, and confirmed that they pay the fee like all major developers.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theguardian.com/technology/2024/mar/05/techscape-open-source-software-cryptocurrency&sa=D&source=editors&ust=1718648881494238&usg=AOvVaw20Oj1qsGGJeQB3WlrhCgVr">Alex
+            Hern - The Guardian</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple policy personnel are clearly aware of this and have previously directly lied in
+      order to obscure this point.</p>
+
+    <h5 id="why-apple-should-not-be-allowed-to-charge-for-api-access">
+      <a class="header-anchor" href="#why-apple-should-not-be-allowed-to-charge-for-api-access" aria-hidden="true">#</a>
+      4.3.7.1.4. Why Apple Should Not be Allowed to Charge for API Access
+    </h5>
+
+    <p>We believe that charging for access to APIs is deeply problematic for a number of
+    </p>
+    <p>reasons, and may end up being used as a tool to significantly hinder competition by
+      potentially unscrupulous gatekeepers.</p>
+
+    <p>In mandating that such API access must be free, we believe that the authors of the DMA
+      had tremendous foresight into the games that large gatekeepers would play were they granted such a weapon to use
+      against those who would contest their hardware and services.</p>
+
+    <p>They should not be able to charge for the following reasons:</p>
+
+    <ul>
+      <li>Could be a mechanism to hinder competition</li>
+      <li>Gatekeepers effectively can’t charge themselves</li>
+      <li>Face no competitive pressure to lower prices for API access</li>
+      <li>Will lock out smaller players</li>
+      <li>Consumers not the gatekeepers own their devices</li>
+      <li>Difficult to enforce reasonable pricing</li>
+      <li>No benefit to consumers but potential for considerable harm</li>
+      <li>Is not and will not be the gatekeepers’ primary business
+        model</li>
+    </ul>
+
+    <p>Allowing such fees opens the door to Apple and other gatekeepers to charge unreasonable
+      prices and lock out competition and is in our view a strictly worse option than mandating free access to these
+      APIs.</p>
+
+    <h5 id="the-faire-price-is-zero">
+      <a class="header-anchor" href="#the-faire-price-is-zero" aria-hidden="true">#</a>
+      4.3.7.1.5. The Fair Price is Zero
+    </h5>
+
+    <p>Given these APIs have no significant value above what is offered on other operating systems, the
+      fact developers are in fact forced to use them via virtue of it being the only choice on iOS, that developers
+      are
+      already paying Apple $100 USD per year and that allowing Apple to charge for this access will lead to
+      considerable
+      harm for consumers by suppressing the contestability of third party services, the fair price for these APIs is
+      zero.</p>
+
+    <h3 id="apple-should-publish-a-new-more-detailed-compliance-plan">
+      <a class="header-anchor" href="#apple-should-publish-a-new-more-detailed-compliance-plan" aria-hidden="true">#</a>
+      4.3.8. Apple Should Publish a New More Detailed Compliance Plan
+    </h3>
+
+    <p>The act states in Recital 68:</p>
+
+    <blockquote>
+      <p>In addition, a clear and comprehensible non-confidential summary of such
+        information should be made publicly available while taking into account the legitimate interest of gatekeepers
+        in
+        the protection of their business secrets and other confidential information. This non-confidential publication
+        should enable third parties to assess whether the gatekeepers comply with the obligations laid down in this
+        Regulation.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881496493&usg=AOvVaw0RopEp5JWJlI2o6J6HyRCz">Digital
+            Markets Act – Recital 68</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/dma/dma-ncs.pdf&sa=D&source=editors&ust=1718648881496856&usg=AOvVaw0pSO6gijT11fYH94IefoGE">Apple's
+        compliance report</a> is woefully lacking in detail relative to the reports created
+      by the other gatekeepers. Key parts of Apple's compliance plan are not mentioned even in passing, for
+      example
+      phrases such as "Core Technology Fee" or "CTF" do not appear once in the document.</p>
+
+    <p>The lack of detail in Apple's compliance report makes it impossible for
+      <q>third parties to assess whether the gatekeepers comply with the obligations laid down in
+        this
+        Regulation</q>.
+    </p>
+
+    <p>By comparison:</p>
+
+    <dl>
+      <dt>Microsoft</dt>
+      <dd>421 pages</dd>
+      <dt>Google</dt>
+      <dd>271 pages</dd>
+      <dt>Meta</dt>
+      <dd>57</dd>
+      <dt>Bytedance</dt>
+      <dd>52 pages</dd>
+      <dt>Amazon</dt>
+      <dd>32 pages</dd>
+      <dt><strong class="stressed">Apple</strong></dt>
+      <dd><strong class="stressed">12 pages</strong></dd>
+    </dl>
+
+    <p>Without a full and detailed compliance report from Apple, it makes it significantly
+      more difficult for us, or any other party, to analyze their compliance.</p>
+
+    <p>The commission should consider requiring Apple to release a more detailed compliance report where
+      redactions from their existing confidential submission to the Commission are strictly limited to "business
+      secrets and other confidential information". In the event that their confidential submission is lacking
+      sufficient detail they should be forced to rectify it or be fined.
+
+    </p>
+
+    <h2 id="toward-a-brighter-future">
+      <a class="header-anchor" href="#toward-a-brighter-future" aria-hidden="true">#</a>
+      5. Toward A Brighter Future
+    </h2>
+
+    <p>OWA believes that the Web’s unmatched track record of safely providing
+      frictionless access to information and services has demonstrated that it can enable a more vibrant digital
+      ecosystem. The web’s open, interoperable, standards-based nature creates an inclusive environment that
+      fosters competition, delivering the benefits of technology to users more effectively and reliably than any
+      closed
+      ecosystem.</p>
+
+    <p>OWA’s goal is to ensure that browser competition is carried out under fair terms,
+      that user choice in browsers matters, and that web applications are provided equal access and rights necessary
+      to
+      safely contest the market for digital services.</p>
+
+    <p>By standing firm against Apple’s malicious compliance and forcing them to comply with their
+      obligations under the act as intended, the Commission can improve interoperability, contestability, and fairness
+      leading to lower priced and higher quality apps
+      — not only for the EU but for the entire world.</p>
+
+    <p><strong>OWA believes competition, not walled gardens, leads to the brightest future for
+        consumers, businesses, and the digital ecosystem.</strong></p>
+
+    <h2 id="references">
+      <a class="header-anchor" href="#references" aria-hidden="true">#</a>
+      6. References
+    </h2>
+
+    <ul class="references">
+      <li><a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+          The Digital Markets Act</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">
+          MOBILE ECOSYSTEMS MARKET STUDY - APPLE RESPONSE TO INTERIM REPORT</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">
+          Mozilla says Apple’s new
+          browser rules are ‘as painful as possible’ for Firefox</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+          HTML 5 poses a threat to Flash and the App Store</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+          OWA - It’s Official, Apple kills Web Apps in the EU</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+          OWA - Apple Backs Off Killing Web Apps</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+          Mobile ecosystems market study interim report</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">
+          Apple sales fall in nearly all countries</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">
+          No one's talking about the Apple Vision Pro anymore</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis">
+          Apple’s App Store grossed more than $85 billion in 2022</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+          $18B-20B in annual payments from Google to Apple</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+          DOJ Complaint against Apple</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">
+          OWA - Japan ends the #AppleBrowserBan</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">
+          OWA - New Digital Competition Laws for Australia</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">
+          OWA - Open Web Advocacy 2023 in Review</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">
+          OWA - UK passes Digital Markets, Competition and Consumers Bill</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+          Apple says iMessage on Android ‘will hurt us more than help us</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+          Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements">
+          Apple Developer Documentation - Entitlements</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://newosxbook.com/ent.jl?osVer=iOS17&exec=/Applications/MobileSafari.app/MobileSafari#:~:text=com.apple.bluetooth.internal%3A%20true">
+          OS X/iOS Entitlement Database</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/">
+          Hardware and the web: the balance between usefulness, security and privacy</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/9/3/22654197/apple-app-store-editorial-scams-refunds">
+          Eight things Apple could do to prove it actually cares about App Store users</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://appleinsider.com/articles/20/08/13/epic-skirts-apples-30-commission-fee-by-implementing-direct-payments">
+          Epic skirts Apple's 30% commission fee by implementing 'direct
+          ' payments</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/#document/p1">
+          Apple’s head of fraud on “App Store Review”</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/">
+          XcodeGhost Malware Infected 100+ Million iOS Users and Apple Said Nothing</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/">
+          Apple pays hackers six figures to find bugs in its software. Then it sits on
+          their findings</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html#:~:text=%22This%20bug%20is%20subject%20to%20a%2090%20day%20disclosure%20deadline.%20If%20a%20fix%20for%20this%20issue%20is%20made%20available%20to%20users%20before%20the%20end%20of%20the%2090%2Dday%20deadline%2C%20this%20bug%20report%20will%20become%20public%2030%20days%20after%20the%20fix%20was%20made%20available.%20Otherwise%2C%20this%20bug%20report%20will%20become%20public%20at%20the%20deadline.%22">
+          Project Zero team at Google - Vulnerability Disclosure FAQ</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/">
+          Apple Developer Program License Agreement</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/app-store/review/guidelines/">
+          Apple App Review Guidelines</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/BrowserEngineKit">
+          Apple - BrowserEngineKit </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/OpenWebAdvocacy/OpenWebCompetitionPlatform/issues/11">
+          Open Web Competition Platform - Alternate browser engines on iOS must be able to </a>
+        bring their own rendering architecture
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/web-platform-tests/interop/issues/84">
+          Interop - Extend Scrolling to cover Body Scroll Issues
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://techcrunch.com/2023/07/25/apple-att-antitrust-france/">
+          Apple’s app tracking triggers statement of objections from French competition
+          authority</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/">
+          When you ‘Ask app not to track,’ some iPhone apps keep snooping
+          anyway</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/">
+          UK’s CMA Raises Concerns, May Delay Google’s Third-Party Cookie
+          Phase-Out</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62052c52e90e077f7881c975/Google_Sandbox_.pdf">
+          UK’s CMA - Decision to accept commitments offered by Google in
+          relation to its Privacy Sandbox Proposals</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/">
+          Apple's Dedication To Privacy Is Missing When It Comes To Its
+          Workforce, Employees Say</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://twitter.com/doctorow/status/1459914164152016905">
+          Cory Doctorow - Apple has a tactical commitment to your privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2021/05/17/technology/apple-china-censorship-data.html">
+          Censorship, Surveillance and Profits: A Hard Bargain for Apple in China
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.apple.com/au/privacy/">
+          Apple - Privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.forbes.com/sites/daviddoty/2023/02/08/apple-the-story-behind-its-new-ad-offerings-to-retailers-restaurants-hotels-other-location-based-businesses/#:~:text=Apple%20seems%20to%20be%20growing,coming%20up%20fast%20if%20quietly">
+          Apple: The Story Behind Its New Ad Offerings To Retailers, Restaurants, Hotels,
+          Other
+          Location-Based Businesses</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.apple.com/legal/privacy/data/en/app-store/">
+          Apple - App Store &amp; Privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://9to5mac.com/2021/09/02/apple-personalized-ads-targeting-ios-15/#:~:text=For%20iOS%2015%20users%2C%20Apple%20has%20begun%20prompting,well%20as%20for%20targeting%20App%20Store%20Search%20Ads">
+          iOS 15 now prompts users if they want to enable Apple personalized ads, after
+          it was
+          previously on by default</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/63f61bc0d3bf7f62e8c34a02/Mobile_Ecosystems_Final_Report_amended_2.pdf">
+          UK CMA’s &nbsp;- Mobile ecosystems - Market study final report
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2008/07/26/business/26nocera.html">
+          Apple’s Culture of Secrecy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.wired.com/2008/09/apple-imposes-n/">
+          Apple Imposes NDA For App Store Rejections
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/">
+          ‘It’s concerning’: Tech firms are using NDAs to illegally
+          muzzle
+          whistleblowers by threatening to sue them for talking, SEC says</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email">
+          Apple execs discuss why the Mac App Store has not been successful in internal
+          email</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#ADPLA5.3">
+          Apple - &nbsp;Notarized Applications for macOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf">
+          Mozilla - “Can browser choice screens be effective?” paper</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/">
+          OWA - Apple's one weird trick to stop you changing your default browser</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/?comments=1">
+          Report: People are bailing on Safari after DMA makes changing defaults easier</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/walled-gardens-report/#app-clips">
+          OWA - App Clips</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/walled-gardens-report/#smart-app-banners">
+          OWA - Smart App Banners</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event">
+          Mozilla Documentation beforeinstallprompt</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2024/05/17/apple_browser_eu/">
+          Apple says if you want to ship your own iOS browser engine in EU, you need to
+          be there</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://twitter.com/RickByers/status/1791609238000705824">
+          Rick Byers - On how Chrome can’t test their own browser on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/mozilla/platform-tilt/issues/16">
+          Platform Tilt - Beta testing on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming#:~:text=We%20all%20rely,chance%20to%20compete">
+          CMA plans market investigation into mobile browsers and cloud gaming</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/dma-and-apps-in-the-eu#8">
+          Apple - On removing Web App Support</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://infrequently.org/2022/06/apple-is-not-defending-browser-engine-choice/#:~:text=This%20split%20experience%20causes%20a%20sort%20of%20pervasive%20forgetfulness%2C%20making%20the%20web%20less%20useful">
+          Apple Is Not Defending Browser Engine Choice</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+          Digital Markets Act - Interventions In-App Browsers</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/mozilla/platform-tilt/issues/15">
+          Platform Tilt - Browser extension support on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.w3.org/TR/payment-request/">
+          W3C - Payment Request API</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://github.com/WebKit/standards-positions/issues/30">
+          WebKit - standards-positions - Safari will be locked to Apple Pay</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/3/14/24100944/spotify-ios-app-update-eu-apple-dma">
+          Spotify says its iPhone app updates in the EU are getting held up by Apple</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theguardian.com/business/2024/mar/04/eu-fines-apple-18bn-over-app-store-restrictions-on-music-streaming#:~:text=EU%20fines%20Apple%20%E2%82%AC1.8bn%20over%20App%20Store%20restrictions%20on%20music%20streaming,-This%20article%20is&text=Apple%20has%20been%20fined%20%E2%82%AC,streaming%20services%20such%20as%20Spotify">
+          EU fines Apple €1.8bn over App Store restrictions on music streaming</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.ben-evans.com/benedictevans/2020/8/18/app-stores">
+          App stores, trust and anti-trust</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://twitter.com/samj0hn/status/1431001795904561160">
+          Samantha John - CEO Hopscotch on App Store Review</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution">
+          Apple - Notarizing macOS software before distribution</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/distribute/app-review/#:~:text=On%20average%2C%2090%25%20of%20submissions%20are%20reviewed%20in%20less%20than%2024%C2%A0hours">
+          Apple - App Review 90% in less than 24 hours</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow#:~:text=After%20you%20upload%20your%20app%2C%20the%20notarization%20process%20typically%20takes%20less%20than%20an%20hour">
+          Apple - Notarizing macOS software typically less than 1 hour</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html">
+          Google Project Zero - Patch Gap</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.ubackup.com/phone-backup/how-long-does-an-ios-update-take.html#:~:text=Updating%20to%20the%20latest%20iOS%20takes%20about%2030%20minutes%20on%20average">
+          How long does an iOS Update Take - 30 mins</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://support.apple.com/en-us/118110#:~:text=If%20you%20leave%20the%20European,apps%20from%20alternative%20app%20marketplaces">
+          Apple - About alternative app distribution in the European Union</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://home-affairs.ec.europa.eu/system/files_en?file=2020-09/schengen_brochure_dr3111126_en.pdf">
+          The Schengen area</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://esta.cbp.dhs.gov/esta">
+          ESTA - Electronic System for Travel Authorization</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://europa.eu/youreurope/citizens/work/taxes/income-taxes-abroad/index_en.htm#:~:text=you%20will%20usually%20be%20considered%20tax%2Dresident%20in%20the%20country%20where%20you%20spend%20more%20than%206%20months%20a%20year">
+          You will usually be considered tax-resident in the country where you spend more
+          than 6 months a year</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/core-technology-fee/">
+          Apple - Core Technology Fee</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/dma-and-apps-in-the-eu/">
+          Apple - Update on apps distributed in the European Union</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/app-store/features/">
+          Apple - App Store Features</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theguardian.com/technology/2024/mar/05/techscape-open-source-software-cryptocurrency">
+          How much does Spotify really pay Apple?</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.apple.com/legal/dma/dma-ncs.pdf">
+          Apple’s Non-Confidential Summary of DMA Compliance Report</a></li>
+    </ul>
+
+    <h2 id="open-web-advocacy">
+      <a class="header-anchor" href="#open-web-advocacy" aria-hidden="true">#</a>
+      7. Open Web Advocacy
+    </h2>
+
+    <p>Open Web Advocacy is a not-for-profit organization made up of a loose group of
+      software engineers from all over the world, who work for many different companies and have come together
+      to fight
+      for the future of the open web by providing regulators, legislators and policy makers the intricate
+      technical
+      details that they need to understand the major anti-competitive issues in our industry and potential ways
+      to solve
+      them.</p>
+    <p><span>It should be noted that all the authors and reviewers of this document are software
+        engineers and not economists, lawyers or regulatory experts. The aim is to explain the current situation,
+        outline
+        the specific problems, how this affects consumers and suggest potential regulatory remedies. </span></p>
+    <p><span>This is a grassroots effort by software engineers as individuals and not on behalf of
+        their employers or any of the browser vendors. We are available to regulators, legislators and policy
+        makers for presentations/Q&amp;A and we can provide expert technical analysis on topics in this area. </span></p>
+    <p><span>For those who would like to help or join us in fighting for a free and open future for
+        the web, please contact us at:</span></p>
+
+    <dl>
+      <dt>Email</dt>
+      <dd><a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a></dd>
+      <dt>Web/ Web</dt>
+      <dd><a rel="noreferrer" target="_blank" href="http://open-web-advocacy.org">http://open-web-advocacy.org</a></dd>
+      <dt>Mastodon</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://mastodon.social/@owa">@owa@mastodon.social</a></dd>
+      <dt>Twitter / X</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://twitter.com/OpenWebAdvocacy">@OpenWebAdvocacy</a></dd>
+      <dt>LinkedIn</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://www.linkedin.com/company/open-web-advocacy">https://www.linkedin.com/company/open-web-advocacy</a>
+      </dd>
+    </dl>

--- a/src/es/pages/applebrowserban.md
+++ b/src/es/pages/applebrowserban.md
@@ -1,0 +1,19 @@
+---
+title: Apple Browser Ban
+permalink: /es/apple-browser-ban/
+metaDesc: 'Learn more about the #AppleBrowserBan campaign run by Open Web Advocacy.'
+layout: layouts/page.njk
+translated: false
+---
+
+Apple's ban of third party browsers on iOS is deeply anti-competitive, starves the Safari/WebKit team of funding and has stalled innovation for the past 10 years and prevented Web Apps from taking off on mobile.
+
+## What is the Apple browser ban?
+
+You might wonder what we're talking about: Chrome, Firefox and others are available in the Apple AppStore!  All is not what it seems. 
+
+When you download Chrome, Firefox or any other browser that isn't Safari on an Apple device, that browser is forced to use Safari's rendering engine WebKit. Chrome normally uses Chromium, and Firefox Gecko. However, Apple will not allow those browsers to use their own engines. Without the ability to use their own engines, those browsers are unable to bring you their latest and greatest features, and can only go so far as whatever WebKit has added.
+
+This behaviour is anti-competitive, and lessens the web experience for users on Apple devices.
+
+You can read more about this behaviour in our [Walled Garden Report](/walled-gardens-report/), and also show your understanding and support of lifting the Apple browser ban by using the hashtag [#AppleBrowserBan](https://twitter.com/search?q=%23AppleBrowserBan&f=live)

--- a/src/es/pages/blog.md
+++ b/src/es/pages/blog.md
@@ -1,0 +1,30 @@
+---
+title: News
+permalink: /es/blog/
+metaDesc: Check out the most recent blog posts from Open Web Advocacy.
+templateEngineOverride: njk
+translated: false
+---
+{% extends 'layouts/base.njk' %}
+{% block content %}
+<h1 class="post-title">{{ title }}</h1>
+  {% for item in collections.blog %}
+
+
+  <article class="h-entry blog-index">
+    <div class="[ post ] [ flow wrapper ]">
+      <h2 class="post-title"><a href="{{ item.url | locale_url }}" class="post-list__link">{{ item.data.title }}</a></h2>
+      {% set date = item.data.date %}
+      {% set author = item.data.author %}
+      {% set tags = item.data.tags %}
+      {% include "partials/post-meta.njk" %}
+      <div class="post-content flow">
+        {{ item.content | excerpt }} <a href="{{ item.url | locale_url }}">Continue reading</a>
+      </div>
+    </div>
+  </article>
+
+
+   
+  {% endfor %}
+{% endblock %}

--- a/src/es/pages/contributors.html
+++ b/src/es/pages/contributors.html
@@ -1,0 +1,67 @@
+---
+title: Contributors & Supporters
+permalink: /es/contributors/
+metaDesc: Team of contributors to the Open Web Advocacy initiative
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Open Web Advocacy is a not-for-profit organization made up of a loose group of software engineers from all over the world,
+  who work for many different companies who have come together to fight for the future of the open web by providing regulators,
+  legislators and policy makers the intricate technical details that they need to understand the major anti-competitive issues
+  in our industry and potential ways to solve them.</p>
+
+<p>Open Web Advocacy was started in March 2021 by brothers Alex and James Moore. 
+  Early contributors include Stuart Langridge and Bruce Lawson were interviewed for a piece in The Register &ndash;
+  <strong>
+  <a href="https://www.theregister.com/2022/02/28/apple_apps_challenge/">Web devs rally to
+  challenge Apple App Store browser rules</a></strong>,
+  and we have listed coverage on our <a href="{{'/press/' | locale_url}}">press page</a>.
+</p>
+
+<p>A number of our contributers wish to remain private as they are concerned that publicly confronting gatekeepers will cause
+issues with their jobs or businesses.</p>
+
+<p>Please note that contributions by individals do not necessarily reflect an endorsement by their employers.</p>
+
+<ul class="contributors">
+  {% for person in contributors %}
+    <li>
+      <div class="main-data">
+        <p>
+          <img src="/images/contributors/{{ person.avatar }}" alt="" />
+          <strong>
+            {{ person.name }}
+            <span>({{ person.countries | join(',&nbsp;') | safe}})</span>
+          </strong>
+        </p>
+        <p>{{ person.what | safe }}</p>
+      </div>
+      <p class="social">
+        {% if person.github %}<a href="https://github.com/{{ person.github }}">Github</a>{% endif %}
+        {% if person.mastodon and person.github %} / {% endif %}
+        {% if person.mastodon %}<a href="{{ person.mastodon }}">Mastodon</a>{% endif %}
+        {% if person.twitter and (person.github or person.mastodon) %} / {% endif %}
+        {% if person.twitter %}<a href="https://twitter.com/{{ person.twitter }}">Twitter</a>{% endif %}
+        {% if person.linkedIn and (person.github or person.mastodon or person.twitter) %} / {% endif %}
+        {% if person.linkedIn %}<a href="{{ person.linkedIn }}">LinkedIn</a>{% endif %}
+        {% if person.email and (person.github or person.mastodon or person.twitter or person.linkedIn) %} / {% endif %}
+        {% if person.email %}<a href="mailto:{{ person.email }}">Email</a>{% endif %}
+        {% if person.website and (person.github or person.mastodon or person.twitter or person.linkedIn or person.email) %} / {% endif %}
+        {% if person.website %}<a href="{{ person.website }}">Website</a>{% endif %}
+      </p>
+    </li>
+  {% endfor %}
+
+  {% if contributors.length % 2 !== 0%}
+    <li></li>
+  {% endif%}
+</ul>
+
+<p>If you are a contributor or a supporter and wish to be listed above please <a href="mailto:contactus@open-web-advocacy.org">contact us.</a></p>
+
+<p>If you would like to support/contribute you can <a href="{{'/donate' | locale_url}}">donate</a> or join our community on
+  <a href="https://discord.com/invite/x53hkqrRKx">Discord</a> to get more deeply involved. Can't spare the
+  cash or time? Keep up with what we're up to and help spread the word by following us on
+  <a href="https://twitter.com/OpenWebAdvocacy">Twitter</a> and/or <a href="https://mastodon.social/@owa">Mastodon</a>
+  .</p>

--- a/src/es/pages/digital-markets-act.md
+++ b/src/es/pages/digital-markets-act.md
@@ -1,0 +1,13 @@
+---
+title: Digital Markets Act
+permalink: /es/digital-markets-act/
+metaDesc: Learn more about the European Union Digigtal Markets Act
+layout: layouts/page.njk
+translated: false
+---
+
+The Digital Markets Act is a landmark piece of regulation from the European Union.  
+
+The Act aims to ensure that major tech platforms behave in a fair way online, and specifically to the interest of Open Web Advocacy, it ensures that players like Apple, Google and others must make access to the Open Web fairer by allowing a diverse range of browsers to compete. 
+
+You can find out more about the DMA on the [EU's own website](https://commission.europa.eu/strategy-and-policy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en), along with our own posts discussing how the DMA is affecting browser competition [on our blog](https://open-web-advocacy.org/tag/eu/).

--- a/src/es/pages/donate.html
+++ b/src/es/pages/donate.html
@@ -1,0 +1,137 @@
+---
+title: Donate
+permalink: /es/donate/
+metaDesc: Donate to Open Web Advocacy
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Regulators in the UK, EU, Japan, Australia and the USA have begun investigating Apple's ban
+  on third-party browser engines and are considering interventions to enable Web Apps to compete
+  with native. Most significantly, wording to this effect has been included in the EU's 
+  landmark tech act, the Digital Markets Act.</p>
+
+<p>This was not inevitable. Over the past two years, Open Web Advocacy has extensively 
+  briefed regulators and legislators about the Web's potential to counterbalance the 
+  mobile app duopoly.</p>
+
+<p>Almost certainly as a direct result of our advocacy Apple has hired dozens of additional 
+  staff to work on WebKit and Safari. This extra bandwidth and regulatory pressure has directly contributed
+  to the addition of long-delayed features such as push notifications and app badging for Web Apps. 
+  WebKit staff numbers are secret, but we believe this is a significant percentage increase.</p>
+
+<p><strong>Competition, or at least the threat of it, works.</strong></p>
+
+<p>OWA needs your help to continue applying pressure to restore competition and to make
+  universal web apps a reality. You can make a real difference to ensure the future of the
+  web by supporting this work. We rely on donations to challenge unbelievably wealthy 
+  gatekeepers who have every incentive to hold the web back.</p>
+
+<div class="prom-banner">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p>If you love what we're doing and would like to support our work, please consider
+      <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a> or by getting your company to support us.</p>
+    <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+      to ensure the future of Browser competition and Web Apps</p>
+
+    <div>
+        <p><a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG" class="donate-button">Donate Now
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+<h2>We need help</h2>
+
+<p>Collectively we have volunteered several thousand hours promoting and advocating these issues. While we have had significant success, we believe that in order to fulfil our aims it will require having a few of us work full time on this for the next 1 - 3 years to keep up with the sheer volume of work required to push this with multiple regulators. Ideally any regulatory solution should be enacted in as many jurisdictions as possible.</p>
+
+<p>Apple has not lifted their ban on competing browser engines on iOS, Web Apps can’t compete with Native Apps because they are treated unfairly and are missing many features that are exclusive to Native Apps. Thus far, no regulator has yet compelled gatekeepers to fix these issues.</p>
+
+<p>With your help, it will allow us to document, explain, promote and push these issues to ensure they get fixed.</p>
+
+<h2>How will the money be spent?</h2>
+
+<p>All money will be spent on furthering the aims listed above, primarily through talking to
+  regulators, publishing documents that outline the key arguments, talks, promoting the issues
+  via the news/social media and talking to the industry including, developers, OS & Browser
+  Vendors as well as small and large development companies.</p>
+
+<h2>What have we achieved so far?</h2>
+
+<p>Prior to our advocacy work there was very limited discussion by regulators about browsers on mobile device. To our knowledge there <b>was no discussion of Browser Engines or Web Apps</b> by regulators till Open Web Advocacy began highlighting its vital importance in multiple filings to a range of regulators. Typically the only remedy mentioned was browser ballots to overcome the gatekeepers deciding the default browser.</p>
+
+<p>We believe we have achieved some important milestones:</p>
+
+
+<h3>UK’s Competition and Markets Authorities Mobile Ecosystems Report</h3>
+<p>We have discussed the issues extensively with the CMA and they dedicated many pages of their report to Apple's banning of third party browser engines (effectively a browser ban), Webkit is mentioned 122 times throughout the report.<p>
+
+<p>They propose forcing Apple to lift this ban:</p>
+<blockquote>
+    <p>Importantly, due to the WebKit restriction, Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS. This not only restricts competition (as it materially limits the potential for rival browsers to differentiate themselves from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, potentially depriving iOS users of useful innovations they might otherwise benefit from.</p>
+
+    <p>...</p>
+
+    <p>Overall, the evidence that we have seen does not suggest that the WebKit restriction is justified by security concerns. We note that Apple benefits financially from weakening competition in browsers via the browser engine ban</p>
+
+    <p>...</p>
+
+    <p>On this basis, the evidence we have gathered suggests that removal of the WebKit restriction has the potential to deliver strong benefits to competition, consumers, and digital businesses in the UK</p>
+
+    <cite><a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1096277/Mobile_ecosystems_final_report_-_full_draft_-_FINAL__.pdf">UK CMA - Mobile ecosystems Market Study - Final Report</a></cite>
+</blockquote>
+
+<p>This is an excellent document and the CMA outline many of the arguments in great detail.</p>
+
+<p>Additionally the CMA have launched a <a href="https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming">market investigation reference</a> into browsers and cloud gaming of which the key remedy discussed is removing Apple's ban on third party browser engines. <a href="https://www.ashurst.com/en/news-and-insights/legal-updates/quickguide---the-use-of-market-studies-and-market-investigations-in-uk-competition-law/">Market investigation references</a> are the UK's regulator next step after Market Studies, they are only launched if the CMA has convincing evidence of adverse effects to competition and have strong remedy powers.</p>
+
+<h3>Important Changes to the Digital Markets Act</h3>
+
+<p>The European Union has added Browser, Browser Engines and Web Apps to the <a href="https://en.wikipedia.org/wiki/Digital_Markets_Act">Digital Markets Act</a>.</p>
+
+<p>Specifically the following section:</p>
+<blockquote>
+    <p>In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users.</p>
+    <cite><a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital Markets Act</a></cite>
+</blockquote>
+
+
+<h3>Push Notifications/Badging on iOS</h3>
+
+<p>Shortly after our initial consultations with regulators it was quietly announced that Apple was working on Push Notifications for iOS despite there being no signal on the feature for the previous decade, a feature that Native Apps have had since the launch of the App Store. Later Apple very publicly announced that they would be bringing Push Notifications to iOS at Apple Worldwide Developers Conference 2022. This feature was released in <a href="https://twitter.com/OpenWebAdvocacy/status/1626308216861904896">iOS 16.4</a> along with a host of positive Safari/Webkit changes such as Badging. We believe this and the significant uptick in work on Safari is a direct result of our advocacy.</p>
+
+
+<h3>Additional Staff/Funding for Webkit/Safari</h3>
+
+<p>Additionally after our initial consultations with regulators, Apple moved to place more than 60 Webkit/Safari job adverts. We do not know the exact size of the Webkit team but suspect this is a significant percentage increase in the team. This is excellent news for consumers and developers who will all benefit from more features and less bugs in Safari. While we firmly believe that true browser competition is needed for iOS, Apple increasing Safari’s funding is a very positive step.</p>
+
+
+<h3>Other Regulators are investigating</h3>
+
+<p>We have had extensive discussion with other government agencies such as Japan’s HDMC, Australia ACCC and the US’s NTIA. These regulators are now investigating these issues. These regulators have publicly proposed removing Apple restrictions on third party browsers in their latest reports (see <a href="https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf">Japan's HDMC report</a>, <a href="https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf">Australia's ACCC report</a> and <a href="https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf">the US's NTIA report</a>).
+
+
+<h2>Help Out</h2>
+
+<p>You can <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">donate</a> or join our community on 
+  <a href="https://discord.com/invite/x53hkqrRKx">Discord</a> to get more deeply involved. Can't spare the 
+  cash or time? Keep up with what we're up to and help spread the word by following us on 
+  <a href="https://twitter.com/OpenWebAdvocacy">Twitter</a> and/or <a href="https://mastodon.social/@owa">Mastodon</a>
+  .</p>
+</p>
+
+<div class="prom-banner">
+  <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+  <p>If you love what we're doing and would like to support our work, please consider
+    <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a> or by getting your company to support us.</p>
+  <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+    to ensure the future of Browser competition and Web Apps</p>
+
+  <div>
+      <p>
+        <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG" class="donate-button">Donate Now
+          <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a>
+      </p>
+  </div>
+</div>

--- a/src/es/pages/files.html
+++ b/src/es/pages/files.html
@@ -1,0 +1,15 @@
+---
+title: Files
+permalink: /es/files/
+metaDesc: An index of the documents available on the site
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Here is a list of files available in this directory of the site:</p>
+
+<ul>
+  {% for file in files %}
+    <li><a href="{{ file.uri }}">{{ file.name }}</a> [{{ file.size }}]</li>
+  {% endfor %}
+</ul

--- a/src/es/pages/glossary.html
+++ b/src/es/pages/glossary.html
@@ -1,0 +1,140 @@
+---
+title: Glossary
+permalink: /es/glossary/
+metaDesc: Learn language used in Open Web Advocacy's efforts.
+layout: layouts/page.njk
+translated: false
+---
+
+<dl class="glossary">
+  <dt id="third-party-browser">Third Party Browser</dt>
+  <dd>
+    <p>A web browser developed by a company other than the gatekeeper
+    which includes a layout engine and rendering engine either selected or built by the company.</p>
+  </dd>
+
+  <dt id="native-app">Native App</dt>
+  <dd>
+    <p>An app written using a gatekeeper’s proprietary frameworks and APIs which are
+    provided by the operating system.
+    On iOS (Apple’s operating system for iPhone and iPad) these are currently
+    exclusively delivered through Apple’s App Store.</p>
+  </dd>
+
+  <dt id="web-app">Web App</dt>
+  <dd>
+    <p>A Web Application, Web App or Progressive Web App (PWA) is an application developed using Web technologies, such as HTML, CSS, JavaScript and WebAssembly. Web Apps use Web Browsers as the <strong>engine</strong> to run the Web App. The capabilities of a Web Apps depends on the level of advancement of the Web Browser that they run on. Web Assembly allows developers to bring existing software, for example game engines or photoshop, and port/convert them so they run on the web or as a web-app.</p>
+
+    <p>Web Apps can be made to run offline, can run as smoothly as native apps and can support high performance applications, but this functionality depends on the Web Browser. Web Apps offer more privacy and security than native apps. Web Apps are universal, in that they can be written once and then run on all devices. This is in comparison with native apps that have to be rewritten for each platform that they target.</p>
+
+    <p>To the end user a well written Web App should be indistinguishable from a native app.</p>
+  </dd>
+
+  <dt id="webview-browser">WebView Browser</dt>
+  <dd>
+    <p>A web browser that does not include its own engine, and instead uses an engine or an unmodified <strong>Webview</strong> provided by the OS. For example, all browsers on iOS other than Safari on iOS are WebView browsers, in that they do not render the website or run the code for the site and instead hand that job onto Safari WebView.</p>
+  </dd>
+
+  <dt id="pwa">PWA (Progressive Web App)</dt>
+  <dd>
+    <p>Can be used interchangeably with Web App, although PWA is used to describe modern Web
+    Apps with functionality that is typically associated with native apps rather than websites
+    (i.e. installation on device, Offline Storage, Device API access etc).</p>
+  </dd>
+
+  <dt id="gatekeeper">Gatekeeper</dt>
+  <dd>
+    <p>The company that controls the operating system and the apps that run on that operating
+    system (i.e. Apple with iOS, Google with Android).</p>
+  </dd>
+
+  <dt id="browser-vendor">Browser Vendor</dt>
+  <dd>
+    <p>The entity that makes the browser.</p>
+  </dd>
+
+  <dt id="default-browser">Default Browser</dt>
+  <dd>
+    <p>A user’s default browser.</p>
+
+    <p>When a user taps a link, the link’s target website will open in the user’s
+    current default browser separately from any app.</p>
+
+    <p>For example, when a user receives a message containing a link and they tap on it,
+    the focused application will change from their SMS application to the Default Browser
+    (e.g. Firefox) and the website will load in that browser outside of the app.</p>
+
+    <p>This is the default behaviour of operating systems since the 90s and preserves user
+    choice in browsers. It also ensures the privacy and security settings of their browser
+    (including extensions) are applied when browsing sites from these links. This default
+    behaviour enables browser competition and respects user choice.</p>
+
+    <p>Mobile operating systems do not always respect this choice.</p>
+  </dd>
+
+  <dt id="remote-tab-iab">Remote Tab IAB</dt>
+  <dd>
+    <p>A tab from a real browser, but shown inside an app.
+
+    <p>This can occur when a user taps a link and the website loads within the current
+    application (i.e. it does not switch to a browser application) but the site is still
+    rendered using the user’s chosen (default) browser. Twitter for Android implements
+    this pattern using Chrome Custom Tabs (&ldquo;CCT&rdquo;) in the default configuration. It is
+    important to note that while CCT contains the word Chrome, under default settings
+    it will load the users’ default browser even if it is not-chromium, for example
+    Firefox (Gecko).</p>
+
+    <p>User’s default browser choices &mdash; whether Firefox, Edge, Chrome, or Opera &mdash;
+    are respected when the user’s default browser is &ldquo;projected&rdquo; through a Remote Tab
+    IAB. This behaviour strikes a balance between developer interests in not &ldquo;losing&rdquo;
+    users to external applications (browsers) and the user’s agency in choosing and
+    configuring their own browser.</p>
+
+    <p>By default this does not undermine user choice, however on Android there is an
+    option in CCT, which is the component that is used to enable Remote Tab IAB to
+    specify a single engine. This can be used to undermine user choice like in the
+    Android Google Search App. On iOS this always uses Safari whether or not it is
+    the user’s default browser, disrespecting the choices of users that select
+    different default browsers.</p>
+  </dd>
+
+  <dt id="webview-iab">WebView IAB</dt>
+  <dd>
+    <p>An OS-Provided Component for Rendering Web Content.</p>
+
+    <p>Many apps provide an IAB based on the OS-provided webview component. Historically,
+    this was grounded in reasonable motivations by app authors, but as Remote Tab Browsers
+    have become available, the problems with WebVIew IABs have become evident.</p>
+
+    <p>Apps that implement WebView IABs:</p>
+
+    <ol>
+      <li>Do not respect the user’s choice of browser, undermining competition.</li>
+      <li>Reduce functionality relative to &ldquo;real&rdquo; browsers. WebViews are not designed
+      to be drop-in replacements for browsers, and significant work is needed to fill in the gaps;
+      work that many apps do not put in.</li>
+
+      <li>Rely on the operating system to update the WebView component, potentially exacerbating
+      security risks that real browser vendors do work to mitigate.</li>
+
+      <li>Can MITM (Man in the middle) connections to third parties, which means they can
+      intercept all data sent and received to the website without the User’s knowledge or
+      consent. This creates silent tracking/privacy & security risks.</li>
+
+      <li>Can monitor every click, tap, input and interaction with a WebView.</li>
+
+      <li>May not mitigate known security risks in outdated system WebViews (e.g. on older
+        devices), putting users at high risk compared to loading websites in real browser.</li>
+
+      <li>May fail to implement key features (e.g., Push Notifications), despite the underlying
+       WebView providing APIs that would allow it.</li>
+    </ol>
+
+    <p>WebViews are not fully functioning browsers and applications that use them when Remote
+    Tab IAB systems are available are undermining user’ choice in browsers. They also may
+    damage the wider Web ecosystem by causing bugs and removing functionality critical to the content they load.</p>
+
+    <p>A variant of System WebView IABs are IABs built on application-provided browser
+    engines (e.g., Mozilla’s GeckoView, which can be embedded in many native apps).</p>
+  </dd>
+</dl>

--- a/src/es/pages/owa-promotional.html
+++ b/src/es/pages/owa-promotional.html
@@ -1,0 +1,267 @@
+---
+title: OWA Promotional Resources
+permalink: /es/owa-promotional/
+metaDesc: Open Web Advocacy logo and promotional images
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Our logo and communication illustrations are free for you to
+print and apply to any design item you can think of.
+We'd love to see your support for the open web!</p>
+
+<h2>OWA Logo</h2>
+
+<ul class="thumbs">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange-transparent.svg" download="owa-logo-transparent">
+        <img src="/images/prom-gallery/logo-full-orange-transparent.svg"
+          width="154"
+          height="187"
+          alt="Download SVG of Owa Full Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange-transparent.png" download="owa-logo-transparent-png">
+        <img src="/images/prom-gallery/logo-full-orange-transparent.png"
+          width="154"
+          height="187"
+          alt="Download PNG of Owa Full Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 8Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/owa-home-logo.svg" download="owa-home-logo">
+        <img src="/images/owa-home-logo.svg"
+          width="154"
+          height="187"
+          alt="Download SVG of Owa Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/owa-home-logo.png" download="owa-home-logo-png">
+        <img src="/images/prom-gallery/owa-home-logo.png"
+          width="154"
+          height="187"
+          alt="Download PNG of Owa Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/owa-logo.svg" download="owa-logo">
+        <img src="/images/owa-logo.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / White with transparent background" /></a>
+      <figcaption>White/ transparent <span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a class="wide" href="/images/prom-gallery/logo-full-horizontal.svg" download="owa-full-logo-horizontal">
+        <img src="/images/prom-gallery/logo-full-horizontal.svg"
+          width="300"
+          height="160"
+          alt="Download Owa Full Horizontal Logo / Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a class="wide" href="/images/prom-gallery/logo-full-horizontal.png" download="owa-full-logo-horizontal-png">
+        <img src="/images/prom-gallery/logo-full-horizontal.png"
+          width="300"
+          height="160"
+          alt="Download PNG Owa Full Horizontal Logo / Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 8Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-white.svg" download="owa-logo-full-white">
+        <img src="/images/prom-gallery/logo-full-white.svg"
+          width="154"
+          height="187"
+          alt="Download Full Owa Logo / White on squared orange background" /></a>
+      <figcaption>Full White/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange.svg" download="owa-logo-full-orange">
+        <img src="/images/prom-gallery/logo-full-orange.svg"
+          width="154"
+          height="187"
+          alt="Download Full Owa Logo / Orange on squared black background" /></a>
+      <figcaption>Full Orange/ dark <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-white-round.svg" download="owa-logo-round-white">
+        <img src="/images/prom-gallery/logo-white-round.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / White on round orange background" /></a>
+      <figcaption>White/ orange round<span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-orange-round.svg" download="owa-logo-round-orange">
+        <img src="/images/prom-gallery/logo-orange-round.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / Orange on round black background" /></a>
+      <figcaption>Orange/ dark round<span>(SVG, 6Ko)</figcaption>
+    </figure>
+  </li>
+</ul>
+
+<h2>Stickers</h2>
+
+<ul class="thumbs">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-01.svg" download="owa-applebrowserban">
+        <img src="/images/prom-gallery/sticker-applebrowserban-01.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 12Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-01w.svg" download="owa-applebrowserban-white">
+        <img src="/images/prom-gallery/sticker-applebrowserban-01w.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / White" /></a>
+      <figcaption>#AppleBrowserBan Orange/ white <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-02.svg" download="owa-applebrowserban-02">
+        <img src="/images/prom-gallery/sticker-applebrowserban-02.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Round Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 22Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-03.svg" download="owa-applebrowserban-03">
+        <img src="/images/prom-gallery/sticker-applebrowserban-03.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-04.svg" download="owa-applebrowserban-04">
+        <img src="/images/prom-gallery/sticker-applebrowserban-04.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Black on Orange" /></a>
+      <figcaption>#AppleBrowserBan Black/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+</ul>
+
+<h2>For Your Goodies</h2>
+
+<ul class="thumbs goodies">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-owa-full.svg" download="t-owa-full">
+        <img src="/images/prom-gallery/tshirt-v2.jpg"
+          alt="Download Full Owa Logo for t-shirts" /></a>
+      <figcaption>Open Web Advocacy<span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-unlock-the-web.svg" download="tshirt-unlock-web">
+        <img src="/images/prom-gallery/tshirt-unlock-web.jpg"
+          alt="Download Unlock the Web t-shirt image" /></a>
+      <figcaption>OWA/ Unlock the Web<span>(SVG, 19Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-applebrowserban.svg" download="owa-abb">
+        <img src="/images/prom-gallery/tshirt-v3.jpg"
+          alt="Download #AppleBrowserBan t-shirt image" /></a>
+      <figcaption>#AppleBrowserBan <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/loving-openweb.svg" download="loving-openweb">
+        <img src="/images/prom-gallery/tshirt-v5.jpg"
+          alt="Download Loving the Open Web t-shirt image/ White" /></a>
+      <figcaption>Loving the Open Web since 1990 <span>(SVG, 24Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/loving-openweb-02.svg" download="loving-openweb-2">
+        <img src="/images/prom-gallery/tshirt-v6.jpg"
+          alt="Download Loving the Open Web t-shirt image/ Black" /></a>
+      <figcaption>Loving the Open Web since 1990 (alternative) <span>(SVG, 21Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/webapps.svg" download="owa-webapps">
+        <img src="/images/prom-gallery/tshirt-v4.jpg"
+          alt="Download Web Apps are Apps t-shirt image" /></a>
+      <figcaption>Web Apps Are Apps <span>(SVG, 7Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/mug-unlock-the-web.svg" download="mug-unlock-web">
+        <img src="/images/prom-gallery/mug-unlock-web.jpg"
+          alt="Download Unlock the Web mug image" /></a>
+      <figcaption>OWA/ Unlock the Web <span>(SVG, 20Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-05.svg" download="owa-applebrowserban-03">
+        <img src="/images/prom-gallery/mug-v0.jpg"
+          alt="Download #AppleBrowserBan mug image" /></a>
+      <figcaption>#AppleBrowserBan Mug <span>(SVG, 7Ko)</span></figcaption>
+    </figure>
+  </li>
+</ul>
+
+<div class="license">
+  <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/">
+    Open Web Advocacy logo is licensed under
+     <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/?ref=chooser-v1"
+       target="_blank" rel="license noopener noreferrer">
+       CC BY-NC-ND 4.0
+       <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg?ref=chooser-v1" alt=""></a>
+  </p>
+  <p xmlns:cc="http://creativecommons.org/ns#" >
+    Open Web Advocacy Promotional Resources</a> [except OWA logo] by
+      <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://gericci.me/">
+        A P Ricci</a> are licensed under
+    <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-NC-SA 4.0
+      <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a>
+  </p>
+</div>

--- a/src/es/pages/policy.md
+++ b/src/es/pages/policy.md
@@ -1,0 +1,8 @@
+---
+title: Policy
+permalink: /es/policy/
+metaDesc: Learn more about the policy stances held by Open Web Advocacy.
+layout: layouts/page.njk
+translated: false
+---
+

--- a/src/es/pages/press.html
+++ b/src/es/pages/press.html
@@ -1,0 +1,56 @@
+---
+title: Press Coverage
+permalink: /es/press/
+metaDesc: The Open Web Advocacy on the Press
+layout: layouts/page.njk
+translated: false
+---
+
+{% macro pressEntry(entry) %}
+<li lang="{{ entry.lang | default('en') }}">
+  <div class="press-entry">
+    <a href="{{ entry.url }}">{{ entry.title }}</a>
+    <div class="press-details">
+      {% if entry.publisher %}
+      published by "{{ entry.publisher }}"
+      {% else %}
+      published on {{ entry.url | hostnameFilter }}
+      {% endif %}
+      {% if entry.date %}
+      - <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
+      {% endif %}
+    </div>
+  </div>
+</li>
+{% endmacro %}
+
+
+{% if collections.press | length > 0 %}
+<h2>OWA Press mentions</h2>
+{% for yearlyData in collections.press %}
+{% if collections.press | length > 1 %}
+<h3 id="owa_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
+<ul class="press-list">
+  {% for entry in yearlyData.entries %}
+  {{ pressEntry(entry) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endif %}
+
+{% if collections.links | length > 0 %}
+<h2>Related links</h2>
+{% for yearlyData in collections.links %}
+{% if collections.links | length > 1 %}
+<h3 id="related_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
+<ul class="press-list">
+  {% for entry in yearlyData.entries %}
+  {{ pressEntry(entry) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endif %}
+
+<p><strong>Last updated:</strong> <time datetime="2024-02-19">Feb 19th, 2024</time></p>

--- a/src/es/pages/privacy.md
+++ b/src/es/pages/privacy.md
@@ -1,0 +1,64 @@
+---
+title: Privacy Policy
+permalink: /es/privacy/
+metaDesc: Learn about your privacy when using the Open Web Advocacy website.
+layout: layouts/page.njk
+translated: false
+---
+
+This website is provided by the members of the Open Web Advocacy group.
+
+## What data we collect
+
+The personal data we collect from you includes:
+
+- Questions, queries or feedback you leave, including your name & email address if you contact us via email.
+
+We use Netlify as our hosting provider for this website. Details regarding the information they collect can be found on their [data protection commitment page](https://www.netlify.com/gdpr-ccpa).
+
+## Why we need your data
+
+We collect your personal data in order to:
+
+- Gather feedback to improve our services.
+- Respond to any feedback you send us, if you’ve asked us to.
+
+## What we do with your data
+
+We will share your data if we are required to do so by law - for example, by court order, or to prevent fraud or other crime.
+
+We will not:
+
+- Sell or rent your data to third parties.
+- Share your data with third parties for their marketing purposes.
+
+## Linked content & services
+
+If you follow a link to a service or website, that is not directly part of this https://open-web-advocacy.org website, you will be subject to the privacy terms of that service
+or website instead of the terms laid out here.
+
+### Commonly linked services
+
+Below is a non-exhaustive list of services we knowingly link to within our site, along with that service's privacy terms:
+
+- Discord - [Privacy Policy](https://discord.com/privacy)
+- Twitter - [Privacy Policy](https://twitter.com/en/privacy)
+
+## Children’s privacy protection
+
+Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain data about anyone under the age of 13.
+
+## Contact us or make a complaint
+
+Contact us via [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org) if you:
+
+- Have a question about anything in this privacy notice.
+- Think that your personal data has been misused or mishandled.
+
+If you have any concerns about our use of your personal information, you can make a complaint to us at the above email address or contact the local privacy authority for your region.
+
+## Changes to this policy
+
+We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.
+
+Last updated 31 March 2022

--- a/src/es/pages/walled-gardens.md
+++ b/src/es/pages/walled-gardens.md
@@ -1,0 +1,2810 @@
+---
+title: Bringing Competition to Walled Gardens
+permalink: /es/walled-gardens-report/
+layout: layouts/paper.njk
+metaDesc: >-
+  The full Bringing Competition to Walled Gardens report, published by Open Web
+  Advocacy.
+subtitle: Third-Party Browsers & Web Apps - VERSION 1.2
+paperName: OWA - Bringing Competition to Walled Gardens - v1.2
+paperSize: 7.7MB
+translated: false
+---
+
+## 2. Preface
+
+*To the Safari/Webkit Team*,
+
+To anyone who works on Safari/Webkit who reads this document, the authors would like to note that all criticism of Safari/Webkit is aimed squarely at Apple and Apple's upper management.
+We would like to acknowledge your many groundbreaking contributions to the Web over the past two decades.
+
+As people that have dedicated their lives to building browsers we know you care deeply about the open web and may privately disagree with Apple's anti-competitive practices. We also understand that Safari/Webkit’s funding and which features are approved is entirely controlled from above. We understand that building a browser is an enormous, complex undertaking and that it’s not possible to keep up with a modern feature set while making the platform stable without significant investment, despite the hard-work and dedication of each individual.
+
+We also understand that Apple operates under a paranoid air of strict secrecy which can make it difficult for you to engage properly with the development community and that employees can be fired for even mild criticism of the company making it hard for effective change from within. We hope that this document can help start that change.
+
+Our main aim is to ensure open competition so that the Web and Web Apps can compete against the closed proprietary ecosystems. The future of the web is apps, if native can do it, so can the web except with privacy and security built in by design. It is our strong hope that Webkit will meaningfully participate in this future.
+
+Many of us have developed with Safari and Webkit since it first came out and were inspired to build mobile web apps by Steve Job’s 2007 speech with the platform that your team built. The web we use today is built on your legacy.
+It is our hope that with this competition Apple will come to realize the great importance of Safari and Webkit to their overall business goals and will provide the resources and funding to make it the best, most private, stable and feature rich browser available.
+
+**Thank-you for your hard work and for everything you’ve given us**, we hope you will continue to fight for a better open-web.
+
+
+
+## 3. Introduction
+
+The entire future of the **consumer application industry** is being heavily limited by Apple’s ban of third-party browsers. These actions prevent cross-compatibility between devices, and create significant barriers for new market entrants. For businesses and consumers, it greatly increases costs and enables Apple to lock them into their closed ecosystem. This reduces competition for both browsers and applications, and shifts the cycle of investment and funding from an open and free platform to proprietary closed platforms, driving up prices for consumers and developers.
+
+**Apple has banned** competing **Third-Party Browsers** from their iOS devices (iPhone and iPad) by requiring that all browser vendors use Safari’s WebView ([2.5.6 App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.)). Browser vendors are not allowed to ship their browsers which they have spent hundreds of thousands of hours developing and instead are forced to produce a separate browser which is essentially a thin wrapper or skin around the WebKit engine in Apple’s own browser, Safari.
+
+Critically this browser ban prevents the *emergence* of an *open and free universal platform* for apps, where developers can build their application once and have it work across all consumer devices, be it desktop, laptop, tablet or phone. Instead it forces companies to create multiple separate applications to run on each platform, significantly raising the cost and complexity of development and maintenance. These costs are in addition to the 15% - 30% tax charged by the App Store. This greater cost is ultimately passed on to consumers in the form of higher fees, more bug prone applications and the applications not being available on all platforms. This then decreases competition with other manufacturers by depriving them of a healthy library of apps. The costs of developing an interoperable application that works identically are pushed so high that only well funded companies can afford it and as a result many useful or otherwise profitable applications never get built.
+
+Apple is preventing the interoperable, standards-based web from becoming a viable alternative to the native proprietary ecosystems on offer from Apple and Google. In the absence of competition, the poor state of Apple’s own browser and integration of Web Apps has the effect of pushing developers and users towards the gated ecosystem of the App Store. Safari and Apple’s WebView frequently suffer simultaneous, critical application breaking bugs which spill into competing iOS browsers because they cannot bring their own engines which might not contain these bugs.
+
+In a clear conflict of interest with third-party browsers, **[Apple receives 15b USD per year for search engine placement](https://9to5mac.com/2021/08/25/analysts-google-to-pay-apple-15-billion-to-remain-default-safari-search-engine-in-2021/)** in Safari while ensuring other browsers can not effectively compete on iOS, its most popular operating system. Mozilla, a non-profit, produces a browser that consistently bests Apple’s in security and standards conformance with revenues of [less than $500 million per year](https://assets.mozilla.net/annualreport/2019/mozilla-fdn-2019-short-form-0926.pdf).
+
+A lack of market pressure, combined with [alleged systemic underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/#:~:text=We%20asked%20Apple%20about%20the%20IndexedDB%20bug%20and%20whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition.%20We%20would%20be%20stunned%20if%20it%20chose%20to%20reply.) over many years, prevents the web from becoming a viable application platform. The only way for developers to create stable, capable applications is to invest in Apple’s proprietary platform, which it taxes and retains exclusive control over.
+
+Individual companies benefit greatly from locking users in and their competitors out. Apple hides behind claims of extra security and privacy when, in fact, their restrictions deprive the consumer of choice and locks their data and purchases into Apple’s walled garden. This prevents or adds great friction to users moving to competing platforms by hampering interoperability.
+
+Web Apps add an extra layer of security and privacy controls to native application platforms, improving on the operating system’s built-in controls leading to enhanced user safety. If allowed, Web Apps can offer equivalent functionality with greater privacy and security for demanding use-cases that are traditionally the domain of less secure native apps. A free & universal development and distribution platform is what leads to competition and an investment cycle in free and open software that benefits businesses and consumers.
+
+**Two key remedies** from regulation can serve to restore meaningful competition:
+
+1. **Reversing Apple’s ban** on competing browsers and browser engines
+2. Compelling **full integration and functionality** for apps built with open web technology, including on competing browsers
+
+The future of consumer application development depends on these changes.
+
+
+
+### 3.1 This Document
+
+This document outlines the primary issues related to Browsers and Web Apps and the future of consumer application development.
+
+
+
+### 3.2 Open Web Advocacy
+
+Open Web Advocacy is a loose group of software engineers from all over the world, who work for many different companies who have come together to fight for the future of the open web by providing regulators, legislators and policy makers the intricate technical details that they need to understand the major anti-competitive issues in our industry and potential ways to solve them.
+
+It should be noted that all the authors and reviewers of this document are software engineers and not economists, lawyers or regulatory experts. The aim is to explain the current situation, outline the specific problems, how this affects consumers and suggest potential regulatory remedies.
+
+This is a grassroots effort by software engineers as individuals and not on behalf of their employers or any of the browser vendors. We came together with the hope of creating a better world since no major company has been pushing for this change in recent years. The majority of the engineers behind this document have decided to remain anonymous as no individual feels comfortable going up against the world’s most valuable company, particularly one that is so litigious.
+
+We are available to regulators, legislators and policy makers for presentations / Q&A and we can provide expert technical analysis on topics in this area.
+
+For those who would like to help or join us in fighting for a free and open future for the web, please contact us at:
+
+<dl>
+  <dt>Email</dt>
+  <dd><a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a></dd>
+  <dt>Twitter</dt>
+  <dd><a href="https://twitter.com/OpenWebAdvocacy">@OpenWebAdvocacy</a></dd>
+  <dt>Web</dt>
+  <dd><a href="https://open-web-advocacy.org">https://open-web-advocacy.org</a></dd>
+</dl>
+
+
+
+### 3.3 Definitions
+
+**"Third-Party Browser"** - A web browser developed by a company other than the gatekeeper which includes a layout engine and rendering engine either selected or built by the company.
+
+**"Native App"** - An app written using a gatekeeper’s proprietary frameworks and APIs which are provided by the operating system. On iOS (Apple’s operating system for iPhone and iPad) these are currently exclusively delivered through Apple’s App Store.
+
+**"Web App"** - A Web Application, Web App or Progressive Web App (PWA) is an application developed using Web technologies, such as HTML, CSS, JavaScript and WebAssembly. Web Apps use Web Browsers as the "engine" to run the Web App. The capabilities of a Web Apps depends on the level of advancement of the Web Browser that they run on. **WebAssembly** allows developers to bring existing software, for example game engines or photoshop, and port/convert them so they run on the web or as a web-app.
+
+Web Apps can be made to run offline, can run as smoothly as native apps and can support high performance applications, but this functionality depends on the Web Browser. Web Apps offer more privacy and security than native apps. Web Apps are universal, in that they can be written once and then run on all devices. This is in comparison with native apps that have to be rewritten for each platform that they target.
+
+To the end user a well written Web App should be indistinguishable from a native app.
+
+**"WebView Browser"** - A web browser that does not include its own engine, and instead uses an engine or an unmodified "WebView" provided by the OS. For example all browsers on iOS other than Safari on iOS are WebView browsers, in that they do not render the website or run the code for the site and instead hand that job onto Safari WebView.
+
+**"PWA (Progressive Web App)"** - Can be used interchangeably with Web App, although PWA is used to describe modern Web Apps with functionality that is typically associated with native apps rather than websites (i.e. installation on device, Offline Storage, Device API access etc). For the purposes of this document Web App and PWA will be treated identically.
+
+**"Gatekeeper"** - The company that controls the operating system and the apps that run on that operating system (i.e. Apple with iOS, Google with Android).
+
+**"Browser Vendor"** - The entity that makes the browser.
+
+
+
+## 4. Effective Competition?
+
+> Businesses that face effective competition dare not raise prices, or cut down on quality standards, for fear of losing customers to their competitors (and so losing money)
+> <cite>[Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)</cite>
+
+> For the foreseeable future, iOS will be the dominant access pathway, passport, monetizer and platform for not just digital life, but virtual ones. Apple holds this role because it makes best-in-class hardware, offers the best apps, and operates the most lucrative app store.
+> <cite>[Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)</cite>
+
+iOS Safari faces no effective competition as Apple has banned the engines that differentiate other browsers. Customers have little recourse short of buying another phone.
+
+The development, maintenance and lost opportunity costs of supporting a buggy browser that misses key features are mostly hidden from them. It is hard for consumers to see a missing feature or an entire Web App that didn’t get built (due to poor support in iOS Safari). When they do encounter a bug caused by Safari they are more likely to blame the Web App than the browser. The user may get the impression that the web is buggy, slow and that native apps are better, which then has negative flow on effects for the entire web ecosystem.
+
+Businesses have little recourse as they can not suggest their customers install another real browser (there are none) and they are unwilling to lose more than half their mobile customers (51% in the UK, 66% in Japan, 56% in Australia, 46% in the US). Additionally iOS users tend to be wealthier and [spend more](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/) making them a higher priority for companies. In the end the majority of large businesses simply throw in the towel and make an iOS Native App and in doing so agree to pay Apple 15-30% of their revenue.
+
+As such, Apple faces little effective competitive pressure to improve the quality of their iOS Safari browser and has incentives to inhibit it from competing with native. Thus Apple’s decade long prohibition on competition for Safari on iOS has a compounding anti-competitive effect as companies sink money into non-interoperable native iOS applications instead of Web Apps.
+
+Even Apple executives appear to be aware only their stranglehold on iOS installation is allowing their 30% tax on revenue, something they can not achieve on macOS.
+
+> Neither is on the store because they don't have to be. They can be on Mac and distribute to users without sharing the revenue with us
+> <cite>[Philip Schiller - Apple Upper Management - On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)</cite>
+
+
+
+## 5. Apple is Holding Back the Open Web
+
+> Instead, Apple is inhibiting this future Internet. And it does so via tolls, controls, and technologies that not only deny what made and still makes the open web so powerful, but also prevents competition, and prioritize Apple’s own profits.
+> <cite>[Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)</cite>
+
+> Making the web less useful makes apps more useful, from which Apple can take its share; similarly, it is notable that Apple is expanding its own app install product even as it is kneecapping the industry’s.
+> <cite>[Ben Thompson - Stratechery](https://stratechery.com/2020/apple-and-facebook/)</cite>
+
+
+
+### 5.1. Steve Jobs' Original Vision for iOS
+
+Steve Jobs’ original vision for third-party apps on iOS was quite different from today’s status quo.
+
+The following is a transcript of a speech he gave announcing Web Apps as the platform for third-party iOS developers, including his thoughts on security, deployment, and criticisms of other distribution models (emphasis added):
+
+> Now, what about developers?
+>
+> We have been trying to come up with a solution to expand the capabilities of iPhone by allowing developers to write great apps for it, and yet keep the iPhone reliable and secure. And we’ve come up with a very **sweet solution**.
+>
+> Let me tell you about it.
+>
+> So, we’ve got an innovative new way to create applications for mobile devices, really innovative, and it’s all based on the fact that iPhone has the full Safari inside. The full Safari engine is inside of iPhone and it gives us **tremendous capability**, more than there’s ever been in a mobile device to this date, and so you can write **amazing Web** 2.0 and Ajax apps that **look exactly and behave exactly like apps on the iPhone**!
+>
+> And these apps can **integrate perfectly** with iPhone services: they can make a call, they can send an email, they can look up a location on Google Maps. After you write them, you have **instant distribution**.
+>
+> You **don’t have to worry about distribution**: just put them on your internet server. And they’re really easy to update: just change the code on your own server, **rather than having to go through this really complex update process**.
+>
+> They’re secured with the same kind of security you’d use for transactions with Amazon, or a bank, and they run securely on the iPhone so they don’t compromise its reliability or security.
+>
+> And guess what: **there’s no SDK**! You’ve got everything you need, if you know how to write apps **using the most modern web standards**, to write amazing apps for the iPhone today.
+>
+> You can go live on June 29.
+>
+> <cite>[Steve Jobs - Original Announcement of Third-Party Apps (2007)](https://www.youtube.com/watch?v=p1nwLilQy64)</cite>
+
+**Apple invented mobile Web Apps**, but ultimately decided on a proprietary closed ecosystem.
+
+
+
+### 5.2 Apple Claims that Web Apps are a Viable Alternative to the App Store
+
+[Web Apps are applications](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) installed from the browser that utilize the user's browser to give users an experience on par with Native apps. They are interoperable between operating systems, have a [very tight security/privacy model](very tight security/privacy model) and are capable of amazing things.
+
+Apple’s original vision for applications on iOS was Web Apps, and [today they still claim](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf) Web Apps are a viable alternative to the App Store. Apple CEO Tim Cook made a similar claim last year in Congressional testimony when [he suggested](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) the web offers a viable alternative distribution channel to the iOS App Store. They have also [claimed](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple) this during a court case in Australia with Epic.
+
+Despite this Web Apps are not currently a viable competitor to the iOS App Store for three reasons:
+
+1. **Browser Ban** <br />
+Apple’s Safari is the only browser on iOS as all other browsers have been effectively banned
+2. **Missing Features** <br />
+Apple has refused to implement key features (some for more than 10 years) that would allow Web Apps to compete with the App Store, both in iOS and in Safari.
+3. **Bugs** <br />
+Apple's iOS Safari is significantly more buggy and unstable than its rivals making it unviable as a platform for applications.
+
+
+
+### 5.3 Apple has effectively banned all Third-Party browsers
+
+The Apple App Store Review Guidelines contain the [following rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+Webkit is the engine that powers Safari and several Linux browsers. Apple also produces a "WebKit framework" that is included in its operating systems (macOS, iOS, iPadOS, tvOS, and watchOS).
+
+In practice, Section 2.5.6 is a requirement that iOS and iPadOS browsers from Google, Microsoft, Mozilla, Samsung, Opera cannot use their own engines the way they do everywhere else. These engines take hundreds of thousands of engineer hours to develop, and are excluded from Apple’s most successful consumer operating systems. Competing browser vendors are only allowed to produce shells around a very specific, unaltered version of Safari’s WebView; a component whose features Apple dictates.
+
+All rival iOS browsers in the App Store are essentially Safari under the hood. This Browser Ban is unique to Apple’s iOS.
+
+> **Apple has a browser monopoly on iOS**, which is something Microsoft was never able to achieve with IE
+> <cite>[Scott Gilbertson - The Register](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/?td=keepreading-top)</cite>
+
+> All of this is compounded by yet another Apple policy: no third-party browser engines. You can install apps like Chrome, Firefox, Brave, DuckDuckGo, and others on the iPhone — but fundamentally they’re all just skins on top of Apple’s WebKit engine. That means that **Apple’s decisions on what web features to support on Safari are final**. If Apple were to find a way to be comfortable letting competing web browsers run their own browser engines, a lot of this tension would dissipate.
+> <cite>[Dieter Bohn and Tom Warren - The Verge](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)</cite>
+
+> So it’s not just one browser that falls behind. It’s all browsers on iOS. The whole web on iOS falls behind. And iOS has become so important that **the entire web platform is being held back as a result**.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/chrome-is-the-new-safari-and-so-are-edge-and-firefox/)</cite>
+
+> because **WebKit has literally zero competition on iOS**, because Apple doesn’t allow competition, the incentive to make Safari better is much lighter than it could (should) be.
+> <cite>[Chris Coyier - CSS Tricks](https://css-tricks.com/ios-browser-choice)</cite>
+
+> What Gruber conveniently failed to mention is that Apple’s banning of third-party browser engines on **iOS is repressing innovation in web apps.**
+> <cite>[Richard MacManus - NewsStack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)</cite>
+
+No other major operating system imposes a ban on integrated third-party browsers (browsers that include their own engines). Microsoft Windows, Android, Linux, and Apple’s own macOS all enable choice of integrated browser. Even Google’s ChromeOS, named after its browser, is more open to competing engines than iOS.
+
+Despite this uniquely anti-competitive situation, Apple has managed to evade regulatory oversight. Browser choice is what drives the technology forward which ultimately results in better, faster, more reliable software for users.
+
+Microsoft’s IE6 was once the dominant browser with a 95% market share <sup>1</sup> due to its pre-installation on Windows. Without competition on the Windows platform, browser development remained stagnant for years until Firefox’s market share triggered Microsoft to start investing in browsers once again. At no point did Microsoft ban competing browsers as Apple has done.
+
+<sup>1</sup> ["Usage share of web browsers - Wikipedia."](https://en.wikipedia.org/wiki/Usage_share_of_web_browsers) Accessed 23 Jun. 2021.
+
+
+
+#### 5.3.1 Hobbled Competition even within Safari clones
+
+Apple's hobbling of third-party browsers doesn't stop at mandating a specific version of Webkit, Apple provides Safari significant unfair advantages.
+
+The major issues include:
+
+1. **Full Screen Video** <br />
+Safari is allowed to make video full screen, the other "browsers" are prevented from doing so, except on iPad. <br />
+It is hard to see the rationale for allowing it on iPad but disabling it on iPhone.
+
+2. **Full Screen Games** <br />
+Canvas, a software component, which is essential for Games can not be made full screen. **Apple derives most of their App Store revenue from games**.
+
+3. **No Web Apps** <br />
+The other "browsers" can not install Web Apps. Only Safari can.
+
+4. **Extensions** <br />
+Only Safari can use extensions which are used by many users, including to block advertising.
+
+5. **Apple Pay** <br />
+Apple limits the integration of Apple Pay with the other browsers.
+
+6. **In-App Browsers** <br />
+Regardless of the user’s default browser setting, iOS will always force the user to use Safari instead of the user’s choice of browser. An In-App Browser is a browser that you would see inside an application like twitter when you visit a link from inside the application.
+
+
+
+### 5.4 Safari Lags Behind and is Missing Key Features
+
+It’s well known in the web-development industry that Safari is far behind on critical web-features (emphasis added).
+
+> The reason we **lost Safari on Windows** is the same reason we are **losing Safari on Mac. We didn't innovate or enhance Safari**. If you want to compete on something across all platforms, it needs to be the best. We had an amazing start on Safari and then **stopped innovating**. Now, we are starting to work on Safari again but look at Chrome. They put out releases at least every month while we basically do it **once a year**
+> <cite>[Eddy Cue - Apple's Senior Vice President of Services](https://www.theverge.com/22611236/epic-v-apple-emails-project-liberty-app-store-schiller-sweeney-cook-jobs)</cite>
+
+> Apple's Safari **lags considerably** behind its peers in supporting web features
+> <cite>[Scott Gilbertson - The Register](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/?td=keepreading-top)</cite>
+
+> Apple’s web engine **consistently trails** others in both **compatibility** and **features**, resulting in a large and persistent gap with Apple’s native platform.
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/04/progress-delayed/#:~:text=The%20data%20agree%3A%20Apple%27s%20web%20engine%20consistently%20trails%20others%20in%20both%20compatibility%20and%20features%2C%20resulting%20in%20a%20large%20and%20persistent%20gap%20with%20Apple%27s%20native%20platform.)</cite>
+
+> Safari just doesn’t support key features — **and Safari’s the only option**
+> <cite>[Dieter Bohn and Tom Warren - The Verge](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)</cite>
+
+> It’s not just the lack of choice in browser engines on iOS, it’s that **WebKit itself is deficient as a browser engine**.
+> <cite>[Richard MacManus - The New Stack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)</cite>
+
+
+
+#### 5.4.1 Web Platform Tests
+
+The [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned) shows this numerically by showing **every failure** that **only fails in just one browser**.
+
+{% image
+  "/images/walled-gardens/00_web-platform-results.png",
+  "Web platform tests result line chart showing higher Safari failure"
+%}
+
+As can be seen as at 10/11/2021, for each of the experimental builds of these browsers:
+
+- **4180 Failures - Safari**{.stressed}
+- 1346 Failures - Firefox
+- 494 Failures - Chrome
+
+Safari is objectively lagging the competition, and this is likely because Apple has no browser competition on the operating system most important to their business, iOS.
+
+The [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned) is a comprehensive test suite built by the developers of browsers themselves, including Mozilla, Google, Apple, Opera, and others. Not every browser supports every feature, and tests may vary in quality, but this is the closest to **"ground truth"** regarding the fine-grained detail of interoperability for all browsers. The failures listed above are **only** features that fail in just one browser.
+
+
+
+#### 5.4.2 Progressive Web App Feature Detector
+
+The [Progressive Web App Feature Detector](https://tomayac.github.io/pwa-feature-detector/) is a high-level test that can provide directional understanding for developers attempting to assess the suitability of Web Apps for addressing their needs. It contains a short but important list of features that are used throughout native apps. Below is a comparison showing Chrome 95 running on a Samsung Galaxy S20 on the left, and Safari running on an iPhone X with iOS 15.1 on the right.
+
+<div class="gallery screens">
+  <figure>
+    {% image
+      "/images/walled-gardens/01_pwa-features-chrome.jpg",
+      "Chrome (Android) progressive web app feature detector results showing 18/18 feature support",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>Chrome (Android)</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/02_pwa-features-safari.png",
+      "Safari (iOS) progressive web app feature detector results showing 6/18 feature support",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>Safari (iOS)</figcaption>
+  </figure>
+</div>
+
+
+
+#### 5.4.3 Missing Functionality
+
+Safari – or more specifically the WebKit engine that powers it – is well behind the competition.
+
+OWA identified the most important functionality specifically for Web Apps that are available on native or other browsers but missing in Safari.
+
+{% image
+  "/images/walled-gardens/40_missing-functionality.png",
+  "An overview of functionality available to both native and the web - except in Safari"
+%}
+
+This table exposes many anti-competitive issues, namely:
+
+1. Competing Browser’s on iOS are unable to implement functionality that they can on Android
+2. Apple has stagnated development and are many years behind the competition
+3. All of the functionality listed above is available for iOS Native Apps
+4. Google’s refusal to provide competitors a method of minting WebAPK’s prevents competing browsers from producing viable Web Apps.
+
+
+
+##### 5.4.3.1. Install Prompts (7+ Years Behind)
+
+The ability to install Web Apps with at least the same level as ease as a native app. See [5.4.5. iOS Web App Installation - A well hidden Safari exclusive](#ios-web-app-installation---a-well-hidden-safari-exclusive) for more details.
+
+This enables the developer to prompt to install a Web App when a user visits a website. For any implementation to be fair, it needs to match any requirements for native install prompts.
+
+Success Criteria Include:
+
+1. The prompt needs to appear **on the first** load of the website OR by developer request. Since Apple acts as a gatekeeper they should not provide any preference to installing their own apps.
+2. The language used by the Install Prompts should not convey the idea that Web Apps are inferior to Native apps. I.e. they should use the same language as native apps. "Install" instead of "Add to Homescreen"
+3. The UI should be at a minimum equal in encouraging a user to install an app as the UIs provided on websites for installing native apps.
+
+
+
+##### 5.4.3.2. Notifications (7+ Years behind other browsers, 13+ years behind native)
+
+Notifications are essential for a wide range of applications. Without notifications many apps can not function (i.e. Messaging Apps, Social Media apps etc). In general notification functionality should be equivalent to native.
+
+Success criteria for notifications include:
+
+1. The initial Enabling/Disable notifications prompt for an installed Web App should be equivalent to enabling notifications for a native app in terms of user experience and ease-of-use.
+
+2. Delivery of notifications is equivalent to native applications including as it applies to reliability, speed (i.e. the time it takes the notification to reach the device) and whether or not the notification wakes the device when it is in "sleep mode".
+
+3. Users should be able to enable / disable notifications in system settings in the same manner and ease that they enable / disable native apps.
+
+
+
+##### 5.4.3.3. First Class Web Apps (5+ Years behind)
+
+"First Class Web Apps" is a general term that is used to describe a Web App that has equivalent integration into the operating system as a native app.
+
+This includes:
+
+1. Settings
+2. Quick Launch Menus
+3. Integration with Voice Assistants
+4. Storage
+
+Without full integration, this becomes a **significant barrier** to adoption. Businesses (especially large ones) will not take the risk of building Web Apps if they have any significant issues). The overarching principle to ensure Web Apps are able to compete is equality with native apps. That is, installing and managing a Web App should not be worse than installing and managing a native app.
+
+There should be no suggestion to the user that a Web App is inferior or different from a native app.
+
+**Double Prompts and the Permission Problem**
+
+Currently on iOS Web Apps are not considered as "real" apps by the operating system. They don’t show up on the settings menu, they don’t show up on App shortcuts, and they don’t appear on any of the privacy menus.
+
+With the current architecture, for a Web-App to have permission to perform an action, Safari must have that permission. This is unobvious to all but experts. Therefore our recommendation is that permissions should be attached to the Web App itself and not to the browser.
+
+For Example:
+
+| Safari | Web App | Actual |
+| ------ | ------ | ------ |
+| Permission OFF | Permission ON | Permission ON |
+| Permission ON | Permission ON | Permission ON |
+| Permission OFF | Permission OFF | Permission OFF |
+
+i.e. If Safari has notifications OFF and AmazingWebApp has notification ON, AmazingWebApp can still send notifications.
+
+As the functionality of Web Apps in Safari improves, it will become critically important to enable users to have explicit control over what those Apps can and can’t do in a way **that a normal user can understand**.
+
+User’s need to be able to **easily grant and revoke permissions from web apps**. This is essential for the success of Web Apps. As an example if users can not easily and individually disable and enable notifications per app, then user’s might be more inclined to preemptively block them thus providing a significant advantage to native ecosystems.
+
+We recommend that all Web Apps should appear on the settings page and privacy pages identically to Native Apps.
+
+This should include:
+
+1. Settings (Appearing on the settings page and in search)
+2. Privacy (Location Services / Bluetooth / Camera / Microphone etc)
+3. General > iPhone Storage
+4. General > Background App Refresh
+5. Siri Suggestions (With no order preference to native apps)
+6. Singleton Installations (i.e. the ability to only install a Web App once) is likely to be a prerequisite.
+
+
+
+##### 5.4.3.4. App Store Support (3+ Years behind)
+
+Many companies will still want to list their Web Apps in the Apple AppStore. Android already provides this functionality with [Trusted Web Activities](https://developer.chrome.com/docs/android/trusted-web-activity/).
+
+Apple should provide a method where developers who have signed up to the Apple Developer Program can use an API to submit Web Apps to the Apple AppStore.
+
+This should not require users to purchase an Apple Mac or require xcode (i.e. developers should be free to use Windows or Linux). It’s our belief that this will help drive Web App adoption.
+
+
+
+##### 5.4.3.5. Fullscreen API (11+ years behind)
+
+Specific types of apps such as games require fullscreen to work properly. Apple currently only allows fullscreen for video and not for "canvas" which is required for games and other graphics intensive apps.
+
+
+
+##### 5.4.3.6. Badging (5+ years behind)
+
+[Badging](https://web.dev/badging-api/) which is outlined in more detail in section [5.4.4. Short Example](#short-example) allows the app to show a number to indicate the user that something has happened.
+
+Users need the ability to disable badging and this should be managed in the same way badging is managed for native apps.
+
+Success criteria include:
+
+1. Badges update at the same speed as native apps (including in the background)
+2. Badges can be enabled/disabled in the same manner as native apps.
+
+
+
+##### 5.4.3.7. Deep Links (7+ years behind)
+
+Deep links also known as [URL Protocol Handlers](https://web.dev/url-protocol-handler/) provide the ability to link into a Web App from another Web App or Native App via links.
+
+Note that the equivalent has been available for a [very long time](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content) in native apps.
+
+
+
+##### 5.4.3.8. Screen Orientation Lock (10+ Years Behind)
+
+Screen Orientation Lock allows a user to lock the screen to either horizontal or vertical. This is essential to many types of apps, but especially games.
+
+
+
+##### 5.4.3.9. Bluetooth (5+ Years Behind)
+
+Bluetooth allows apps to connect to printers / scanners / internet of things / toys. There are entire categories of apps that can’t be built without Web Bluetooth.
+
+Discussed at length in [5.5.1. Fingerprinting and Web Device APIs](#fingerprinting-and-web-device-apis)
+
+
+
+##### 5.4.3.10. NFC (1+ Year Behind)
+
+Apple has mentioned in regulatory filings issues with NFC and what is called Card Emulation Mode, but they have also refused to implement the entire Web NFC specification in Safari even though it doesn’t include Card Emulation Mode. Since they have effectively banned all other third-party browsers no other browser can provide NFC functionality.
+
+So far Apple has not provided any detailed reasoning as to why they are blocking this functionality besides the following:
+
+> I'm not sure what specifics you're looking for but the issue is that we don't believe permission prompt is sufficient mitigation. Ordinary people don't understand the full security & privacy implications of granting NFC access when asked.
+> <cite>[Ryosuke Niwa - Apple](https://lists.webkit.org/pipermail/webkit-dev/2020-January/031034.html)</cite>
+
+The Web NFC specification contains an [extensive security and privacy section](https://w3c.github.io/web-nfc/#security), but Apple has made little effort to productively convey or solve any perceived security issues. By only providing NFC functionality via [its native ecosystem](https://developer.apple.com/documentation/corenfc) Apple effectively forces any developer that wishes to produce a mobile app with NFC to create a Native App where they can take a 30% cut.
+
+As part of our submission we would argue that Apple should not be able to block NFC access to third-party browsers except where Apple applies on a **demonstrably** consistent basis to Apple's own Apps and Apps from the iOS App Store (**including by rules with analogous intent**).
+
+Additionally any blocks should be narrowly tailored to solve particular security issues and Apple should be compelled to publicly answer and publicly provide technical documentation to any reasonable questions related to these rules or the evidence for them.
+
+NFC has a huge range of current and future applications:
+
+* Cashless payments
+* Asset Tracking
+* Time / Attendance / Check-In
+    * Businesses
+    * Universities
+    * Schools
+* Opening Doors
+    * Hotels
+    * Houses
+    * Guest Access
+    * Corporate
+* Ticketing
+    * Major Events
+    * Cinemas, Sporting Events, Concerts
+* Transport (Public and Private)
+* Pharmaceuticals
+* Pairing Devices via Bluetooths
+* WIFI without passwords, Guest Wifi
+* Smart Posters
+* Smart Cards
+* Business Cards
+* Passports / IDs
+* Smart Home Integration
+* Anti-Counterfeiting of real products
+* App Shortcuts
+* Multi-Factor Authentication
+
+The door to innovation needs to be left open without Apple acting as the gatekeeper except to provide very **narrow scope, heavily justified** security, privacy or digital safety protections.
+
+Our current recommendation is that Apple be forced to provide hardware access to NFC to other third-party browsers for the purposes of implementing the NFC specification (which currently only covers [NDEF](https://w3c.github.io/web-nfc/#ndef-compatible-tag-types) which is already provided to iOS native apps) and should be forced to expand that access as the Web NFC specification expands to cover other parts of NFC. In the case where Apple believes a security risk is too great to users, Apple should prove the harm to users is greater than the loss of utility.
+
+
+
+##### 5.4.3.11. Other Important Functionality
+
+* General
+    * **Push Notifications**
+    * **SQL (WebSQL or equivalent replacement)**
+    * AV1/AVIF and VP8/VP9/WebP (open Media Codecs)
+    * Compression Streams
+    * **Keyboard Lock and Keyboard Layout APIs**
+    * Declarative Shadow DOM
+    * Reporting API
+    * Permissions API
+    * Screen Wakelock
+    * Intersection Observer V2
+    * Shared Workers and Broadcast Channels
+    * **Background Sync**
+    * Background Fetch API
+* Essential Media APIs
+    * Background Audio in Third-Party Browsers and Web Apps. See [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=198277), fix took 3 years.
+    * Features and functionality in [PushKit](https://developer.apple.com/documentation/pushkit)
+    * Features and functionality in [CallKit](https://developer.apple.com/documentation/callkit)
+* Essential Web App APIs
+    * **Web App Install Prompts**
+    * PWA App Shortcuts
+    * getInstalledRelatedApps()
+    * Periodic Background Sync
+    * **Web Share Target**
+    * Content Indexing
+    * **Badging**
+* Device APIs
+    * **Web Bluetooth**
+    * **Web NFC**
+    * Web USB
+    * Web MIDI
+    * Web Serial
+    * Web HID
+    * Shape Detection
+    * Generic Sensors API
+* Gaming and 3D-related APIs
+    * **Fullscreen API** for `<canvas>` and other non-`<video>` elements
+    * **WASM Threads**
+    * Shared Array Buffers
+    * SIMD
+    * WebXR
+    * Offscreen Canvas
+
+The article [Progress Delayed is Progress Denied](https://infrequently.org/2021/04/progress-delayed/) is a detailed look at how far Safari has fallen behind in features.
+
+Not every developer needs every feature listed above but some are the critical missing piece required to build a Web App instead of a Native App. For competition between Web Apps and Native Apps it’s important to compare the functionality of Web Apps with Native Apps and not simply between browsers
+
+
+
+#### 5.4.4. Short Example
+
+To expand on each of these to explain why these missing features are important to developers would be a lengthy undertaking so instead we will highlight just a few and explain why they are essential to allow Web Apps to compete with the App Store. Please note that most of these capabilities or something analogous are possible in Native Applications.
+
+Imagine you were building a social networking App and decided to build it as a Web App instead of as a Native App.
+
+The two key pieces of functionality you would need to compete with the App Store would be being able to notify a user when they have received a new message (**Push Notifications**) and being able to add unread message count badges to the App Icon (**App Badging**). Both of these features are missing on iOS for Web Apps despite coming out for Native Apps more than 10 years ago. Multiple browsers support these features across many operating systems, both desktop and mobile whereas iOS Safari does not.
+
+[Twitter](https://twitter.com/) has built a high-quality Web App for Twitter that you can install on iOS but they still recommend you use the iOS Twitter App, likely due to these critical missing features.
+
+An App Badge showing a count of 29 on iOS in 2011:
+
+{% image
+  "/images/walled-gardens/03_ios-app-badge.png",
+  "iOS app badge example screenshot",
+  "screenshot rounded", null, null,
+  "121px"
+%}
+
+Because of these missing features entire categories of apps can either not be built using the web or which ensure that the native app is significantly better.
+
+
+
+#### 5.4.5. iOS Web App Installation - A well hidden Safari exclusive
+
+Apple heavily preferences Native Apps while placing **strong limitations** on Web Apps.
+
+On Android devices, Web Apps are easy to find and install. Firefox / Chrome & Edge all provide functionality that allow developers to make installing Web Apps on Android simple, intuitive and easy.
+
+By comparison it can be very difficult to explain to a user how to install a web-app on iOS through Safari, as it is **hidden away** and requires multiple steps to find. It could be argued that Apple benefits from this as it will drive companies to use native apps. Apple makes it easy to install native apps with [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) while making it very difficult to install Web Apps.
+
+For the other reskinned/rebranded Safari WebView browsers (Chrome/Edge/Firefox) Apple has **blocked them from installing Web Apps**. This functionality is exclusive to Safari.
+
+
+
+##### 5.4.5.1. Android
+
+On Android devices, the process for installing a Web App on either Firefox or Chrome is very straightforward and there are many options as shown by the following examples taken from [web.dev](https://web.dev/promote-install/).
+
+Developers have a huge freedom of choice and can add installers in headers, footers, menu bars, and temporary pop-ups backed [by an open API](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent). This ensures that there is minimal difficulty installing a Web App on Android.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/04_install-banner-top.png",
+    "Mockup view of web app install banner at top of window",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/05_install-banner-bottom.png",
+    "Mockup view of web app install banner across webpage",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/06_install-banner-sidebar.png",
+    "Mockup view of web app install banner in sidebar",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/07_install-banner-inline.png",
+    "Mockup view of web app install banner within page content",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/08_install-via-menu.png",
+    "Mockup view of web app install banner in app menu",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/09_install-toast.png",
+    "Mockup view of web app install banner bottom popup toast",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+Finally there is a clearly marked "**Install App**" on the main menu. As demonstrated there is **no barrier** to installing Web Apps on Android systems and is made easy for developers to add and users to use.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/15_proxx-install-a.jpg",
+    "proxx.app web app install banner example",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/16_proxx-install-b.jpg",
+    "proxx.app web app install banner expanded",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+As a real life example, the game [PROXX](https://proxx.app) displays a pop-up bottom banner when you first play, sliding that up displays more information about the app. Tapping install can directly install the app although the exact experience differs between different manufacturers devices.
+
+
+
+##### 5.4.5.2. iOS Safari
+
+The process on iOS Safari is considerably more difficult and [quite a bit more hidden and awkward](https://brucelawson.co.uk/2021/briefing-to-the-uk-competition-and-markets-authority-on-apples-ios-browser-monopoly-and-progressive-web-apps/). The majority of users we have asked **do not know the functionality exists** and have never used it. Apple has [refused](https://bugs.webkit.org/show_bug.cgi?id=193959) to implement this feature without any good justification providing App Store apps a significant advantage over Web Apps.
+
+On iOS, Apple makes installing native apps very easy with [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) while making installing open Web Apps **as obscure as possible**. Even when on phone support with users it can be difficult to explain how to add a Web App. This is not a problem on Android.
+
+{% image
+  "/images/walled-gardens/17_ios-app-install-banner.png",
+  "oceanjournalweb.com webpage showing an app store install banner",
+  "screenshot", null,
+  [150, 200, 300],
+  "150px"
+%}
+
+You can see in the example taken from Apple’s documentation that a **link to the native app is prominently displayed at the top of the screen.**
+
+To install a Web App on iOS the current process is as follows:
+
+<div class="gallery screens">
+  <figure>
+    {% image
+      "/images/walled-gardens/18_ios-web-install-step-1.png",
+      "A circled example of the share button in iOS Safari",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>1. The user must know to hit this "share" button. Even this share button can be obscured if the user has scrolled, because the bottom bar is hidden away.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/19_ios-web-install-step-2.png",
+      "An example of the iOS share panel open at the bottom of the screen with various share options",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>2. This causes a bottom panel to be displayed on screen. Then the user <em>must know</em> to scroll down that panel. At this point it is obvious that installing Web Apps is deeply obscured.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/20_ios-web-install-step-3.png",
+      "A circled example of the Add to Home Screen action in the iOS Safari share drawer",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>3. Then the user must hit the "Add to Home Screen" button.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/21_ios-web-install-step-4.png",
+      "An Add to Home Screen view with details of a web page in addition to Cancel and Add buttons",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>4. Then the user must hit "Add".</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/22_ios-web-install-step-5.png",
+      "A view of the iOS home screen with an icon for the added web page",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>5. Finally the Web App appears on the user's home screen.</figcaption>
+  </figure>
+</div>
+
+Other "browsers" on iOS **do not have the ability to install Web Apps**.
+
+This means that despite simply being thin user interface shells around Safari’s WebKit, every "browser" on iOS including Firefox, Chrome, Edge, Opera, Brave can not add Web Apps. Users visiting a Web App capable site in these browsers on iOS would not even find the install button unless they would know to switch to Safari, then go through the steps as described here. This is clearly evidence of Apple preferencing their browser and native apps.
+
+
+
+##### 5.4.5.3. App Clips
+
+An [App Clip](https://developer.apple.com/app-clips/) is a micro-version of native iOS application which allows consumers to load and use part of the application without installing the full application.
+
+{% image
+  "/images/walled-gardens/23_ios-app-clips.png",
+  "A series of 5 iPhones each showing an App Clip panel with a prominent open action",
+  null, ["webp", "png"]
+%}
+
+<cite>App Clips as shown on [Apple.com](https://developer.apple.com/app-clips/)</cite>
+
+This is good for native application developers who want to decrease friction by allowing users to nearly instantly preview or use a subsection of functionality. An App Clip does not require a user to have to go through the App Store, removing a key barrier.
+
+As seen in the previous section, Apple has not implemented any way to inform users that they can install a Web App, and makes the whole installation process very cumbersome. In the meantime, Apple has added the ability for developers to display these native App Clip panels on top of web pages often to **incite users to use a native app instead of the web page they are currently viewing**.
+
+Apple’s addition of this feature while at the same time ensuring that Web Apps are hidden away, difficult to install and have other barriers to adoption which increase user friction, is a clear demonstration of anti-competitive behaviour.
+
+
+
+##### 5.4.5.4. Smart App Banners
+
+Apple has a technology called [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners). These are little banners that appear in Safari when visiting a url that matches the universal link patterns set for an App or by including a special meta tag.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/25_ios-smart-banner-open.png",
+    "iOS Safari shown an Ocean Journal website with a banner at the top to open in the Ocean Journal app",
+    null, null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/26_ios-smart-banner-view.png",
+    "iOS Safari shown an Ocean Journal website with a banner at the top to view in the Ocean Journal app",
+    null, null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+If the App is not installed it displays a deep link to the iOS App Store. If the App is installed it provides a link to open the App on iOS.
+
+According to [this complaint](https://developer.apple.com/forums/thread/105129?answerId=639849022#639849022) there is no way for the developer to stop the Smart App Banner from appearing even if they do not add the meta-tag. Provided the universal link patterns set for an App match it will display the banner.
+
+There is no meta-tag to disable this behavior, forcing all developers to include a banner on their Website even if they wish to disable it is a clear attempt to direct traffic off the Web and into Apple’s ecosystem. Smart App Banners should likely be opt-in and respect the developers wishes. At the very least developers should be able to opt-out.
+
+
+
+##### 5.4.5.5. Dark Patterns
+
+> Dark patterns are design elements that deliberately **obscure**, mislead, coerce and/or deceive website visitors into making unintended and possibly harmful choices.
+> <cite>[Misha Ketchell - The Conversation](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362)</cite>
+
+The friction added to installing Web Apps by hiding away installation options, preventing the installation from other "browsers" and the clear preference shown to native apps through Smart Banners and App Clips are arguably [dark patterns](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362) and can completely hobble developers' attempts to provide apps to their users through the open web.
+
+Despite Apple’s [claims to regulators](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf) that "PWA’s eliminate the need to download a developer’s app through the App Store (or other means)" the reality is that Apple has limited the user experience for Web Apps to the point where developers are forced to develop native apps.
+
+
+
+### 5.5. Apple Uses Flawed Privacy Arguments
+
+> The most dangerous feature that browsers have are not the device API’s; it is the ability to **link to and download native apps**.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)</cite>
+
+
+
+#### 5.5.1. Fingerprinting and Web Device APIs
+
+The goal of fingerprinting is to re-identify users uniquely (without their permission), this is typically for advertising purposes. This is done by collecting many different data points about the device (ip address, screen size, operating system version, existence of certain fonts). Each of those data points cannot identify an individual, but it could be possible to track users if you have enough of these data points and combine them.
+
+Apple has [rejected certain web standard device APIs](https://webkit.org/tracking-prevention/#anti-fingerprinting) that would provide Web Apps equivalent capabilities to Native Apps (the web standard versions are actually arguably much more strict and secure than their native counterparts, see Section 4.14 below).
+
+> Finally, if we find that features and web APIs increase fingerprintability and offer no safe way to protect our users, we will not implement them until we or others have found a good way to reduce that fingerprintability.
+> <cite>[Apple](https://webkit.org/tracking-prevention/#anti-fingerprinting)</cite>
+
+This was the stated reason Apple used to reject WebBluetooth from Safari (Webkit). This doesn’t make a great deal of sense.
+
+Bluetooth is a short-range, standardized wireless technology standard that is used for exchanging data between fixed and mobile devices over short distances. [Web Bluetooth](https://web.dev/bluetooth/) is an API that provides the ability to connect and interact with Bluetooth Low Energy peripherals (but not classic Bluetooth devices, for security reasons). For example printers, toys, scanners, lights, home automation, washing machines, dryers, scanners, payment devices and a huge list of other "Internet of Things" (IoT) devices.
+
+With Web Bluetooth, a Web App **can not get a list of bluetooth devices**. Instead, **only with user interaction** (e.g., clicking on a button), can a site request the browser open a permission prompt to connect to a bluetooth device and the site can provide filters to potentially reduce the list to devices it can understand, but cannot skip the user’s consent. The list is **made available to the user, not to the Website/Web App**. The user can give access to a single device or deny access altogether.
+
+This is a very unreliable method of fingerprinting and requires a scary permission prompt to the user on each Web App.
+
+Similar arguments can be extended to each of the other hardware APIs, they are all difficult to use for fingerprinting as it's impossible to do so without alerting the users and requiring their permission.
+
+> Device API’s are simply bad for fingerprinting. It is unreliable and really obvious when it is used.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)</cite>
+
+We are not saying that iOS Safari must implement every feature implemented by the other browsers, in fact it is healthy for browser makers to pursue their own vision for the web. What is a problem is that Apple has banned all other browsers, so on iOS users have no option to use a different browser that does support these APIs.
+
+It should be expected that **privacy** and **security** standards that apply to the web **should also apply to native apps where Apple derives their profit**.
+
+Apple by both not supporting these APIs in iOS Safari and banning all competing browsers, is making it impossible for Web Apps to compete with native apps in cases where these device APIs are a core or important part of the application.
+
+It is important to note here that Apple in their rejection of Web Bluetooth and other Device APIs have focused on fingerprinting (as opposed to firmware hacks) despite doing a far poorer job in mitigating these risks in native. Possibly this is in a effort to frame the rejection of these features through the lens that both Apple is pro-privacy as opposed to a general belief that the web should not be an application platform on iOS, and as a slight on other browsers vendors/developers by implying they want these features in order to spy on users.
+
+
+
+#### 5.5.2. Native vs Web Privacy/Security
+
+The web’s paranoid security model was not developed in a vacuum. Browsers have evolved to place a high value on security and privacy, and the same is true of the [Web Bluetooth Security Model](https://medium.com/@jyasskin/the-web-bluetooth-security-model-666b4e7eed2).
+
+Behind each expansion of browser capabilities is a simple idea: if browsers do not provide important features, users will feel the need to install applications to meet their computing needs. It is also important to note that there is **no discussion** of entirely removing for example bluetooth from iOS (web and native).
+
+Therefore, privacy and security risks must be viewed in terms of mitigation and in comparison with native apps. As such bluetooth is a useful example to compare web and native in utility/privacy and security. From this vantage point, we can compare the level of care taken by browsers in exposing bluetooth devices versus native apps.
+
+
+
+##### 5.5.2.1. Potential security/privacy concerns
+
+A number of potential security and privacy issues have been raised by participants in the Working Group developing the [Web Bluetooth standard](https://webbluetoothcg.github.io/web-bluetooth/):
+
+These include:
+
+* Malicious messages sent to poorly designed, or older, bluetooth devices. <br /><br />
+A Website/Web App could connect to poorly designed older bluetooth devices and then hack them to launch further attacks on the user. <br /><br />
+Note for this attack to work:
+    1. The device needs to be poorly designed without functionality that prevents an attacker from doing harmful actions. Note that most devices that offer a harmful actions have security protections in place (i.e. they required updates in place)
+    2. The attacker needs to have specific code that targets that device, the user has to own that device and then ask to connect to that device and then the user has to give the website permission.
+    3. The Web Bluetooth specification maintains a block-list of known-vulnerable devices which browsers are expected to block from connections.
+    4. Browsers include the ability to strip permissions, including blocking the loading of, websites that act maliciously in this way (e.g. [Google’s SafeBrowsing](https://safebrowsing.google.com/), used by Chrome and Firefox, and [Microsoft SmartScreen](https://support.microsoft.com/en-us/microsoft-edge/what-is-smartscreen-and-how-can-it-help-protect-me-1c9a874a-6826-be5e-45b1-67fa445a74c8))
+* Collecting lists of nearby devices (for location tracking)<br /><br />
+Shops could place bluetooth devices on their premises and a Website/Web App with completely unfettered access to bluetooth could connect to them thus revealing the users location without permission.<br /><br />
+Thankfully, the Web Bluetooth specification prevents this ambient attack by creating the opportunity for a user to select the devices they wish to connect to before any data is sent.
+* Fingerprinting <br /><br />
+The goal of fingerprinting is to reidentify users uniquely (without their permission), this is typically for advertising purposes. Typical fingerprinting is done by silently collecting many different data points on the website (ip address, screen size, operating system, existence of certain fonts). Each data point is unlikely to uniquely identify an individual, but it is possible to track users if you have enough of them. A user connecting to the same device on two different websites could uniquely identify the user. <br /><br />
+Web Bluetooth adds a strong deterrent to ambient fingerprinting through the addition of a user-visible permission prompt. Permission-based APIs are not frequently used for fingerprinting today due to the low acceptance rates by users of these grants, making them **nearly useless for pervasive, low-friction fingerprinting**. <br /><br />
+Risks endure for users who have elevated threats and clear their caches, but thanks to the permission model of Web Bluetooth, browsers can also inform users of the risks of re-identification at the time of use. By managing these capabilities more tightly than native OS APIs (which expose blanket grants to bluetooth stacks), browsers mitigate these risks more directly.
+
+
+
+##### 5.5.2.2. Process for connecting to a device on web and iOS native
+
+###### 5.5.2.2.1. Web
+
+The process in the web specification is as follows:
+
+1. Upon a user gesture (click, touching a button etc) the Website/Web App may request to connect to a specific bluetooth device OR they may provide a specific category of device to be used as a filter.
+2. The browser displays a prompt to the user indicating that the Website / Web App would like to connect to a bluetooth enabled device and displays a list of devices. <br />
+The Website/Web App **never gets to see this list of bluetooth devices, it may not connect to any device without specific consent**.
+3. If the user choices to connect to a device, the Website/Web App may now communicate with that specific device
+4. This permission can be revoked at any time via the browser but it is important to note it is only for this specific Website/Web App and only the specifically chosen device
+
+{% image
+  "/images/walled-gardens/27_pair-process-web.png",
+  "An Android screenshot showing device options to pair with, for a webpage, with a 'PAIR' primary action",
+  "screenshot", null,
+  [200, 300, 400],
+  "200px"
+%}
+
+
+
+###### 5.5.2.2.2. iOS Native
+
+The process for iOS native applications using Swift CoreBluetooth is:
+
+1. Declare that the application needs to use bluetooth along with a description in the info.plist *
+2. On first boot of the application, it will ask the user permission (via a prompt) to use bluetooth *
+3. If the user agrees the application now has access to bluetooth <sup>2</sup>
+4. This permission can be revoked at any time via user settings
+5. The application **can now get lists of any nearby bluetooth devices and connect/communicate with them indefinitely without user interaction**.
+
+{% image
+  "/images/walled-gardens/28_pair-process-ios-a.jpg",
+  "iOS screenshot showing a prompt asking if the application can use Bluetooth",
+  "screenshot"
+%}
+
+<sup>2</sup> Until 2019, steps 1 - 3 were not required. **This means before 2019 that the very large number of apps with bluetooth permissions track all users and connect to any device**.
+
+
+
+##### 5.5.2.3. How does iOS bluetooth for native apps mitigate these concerns?
+
+The permission system on iOS is a bit more of a **[blank check](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)**. Once given initial Bluetooth permission, applications are essentially given free reign to do whatever they want with regards to Bluetooth. They can list all nearby devices (without user interaction) and they can communicate with any nearby Bluetooth device (without user interaction).
+
+Prior to iOS 13 (late 2019) the situation was even worse. Applications did not even need to ask for bluetooth permission at all.
+
+Many companies were using this to [track users' locations without their consent](https://www.fastcompany.com/90386781/ios-13s-new-bluetooth-privacy-feature-is-important-but-confusing). Shops were placing bluetooth beacons in their stores and then tracking users' physical location without consent. This was only possibly due to the weak security/privacy implementation on iOS Native CoreBluetooth. **Note this still has not been fixed** and this sort of abuse is still possible today, provided an application can convince a user that it has a plausible reason to provide access to bluetooth (a simple yes/no prompt).
+
+{% image
+  "/images/walled-gardens/29_pair-process-ios-b.jpg",
+  "iOS screenshot showing a prompt asking if the application can use Bluetooth",
+  "screenshot"
+%}
+
+All three of the above listed privacy/security concerns are currently essentially unmitigated except by:
+
+1. App Store Review ([a dubious defense](https://habr.com/en/post/580272/))
+2. The user giving permission to access bluetooth once
+
+It's odd that Apple **is not implementing** Web-Bluetooth over security/privacy concerns and, in effect, forcing users to download a native app with far broader powers when they don't appear to have adopted equivalently strong protections within their native app ecosystem. Rejecting WebBluetooth on these grounds is nonsensical.
+
+These issues still have not been fixed with native iOS Apps bluetooth permissions. Their APIs were not designed to enable a more respectful prompt the way the Web Bluetooth specification was, and shifting all existing applications to a less invasive model may break many unmaintained programs. In these tradeoffs Apple could choose user privacy and security and against invasive developers, but they have not, and yet they hold up the less problematic web API as an unacceptable risk.
+
+When comparing risk in allowing a Web App feature, the comparison is not between the risk the feature brings and nothing (i.e not allowing the feature). The comparison is between the feature and getting the user to download a native application with an analogous feature.
+
+As shown in the previous sections, with regards to bluetooth the web is far more restricted, secure and private than what is allowed in native. It could be argued that not allowing Web Bluetooth is actually worsening the user's risk profile, in addition to denying them convenient functionality. If the only alternative is to download a native app with far greater permissions then this arguably puts the user at greater risk.
+
+Web Bluetooth is largely analogous to the other Device APIs.
+
+Device APIs and File System Access are probably the most complex in terms of security privacy. There are legitimate security concerns (as there are with equivalent APIs for native applications). The web specifications have in our opinion largely mitigated these concerns (certainly far better than native apps on iOS have).
+
+Apple has done an extremely poor job communicating what their concerns are (in sufficient technical detail, including why they think the mitigations are insufficient) to developers and other browser vendors.
+
+
+
+##### 5.5.2.4. Safari WebBluetooth Extension
+
+> Can't we solve this using browser extensions?
+> <cite>[Daniel Bates - Apple Webkit Team - 8th November 2017](https://www.w3.org/2017/11/08-device-api-minutes.html#:~:text=can%27t%20we%20solve%20this%20using%20browser%20extensions%3F)</cite>
+
+In the last public discussion about Web Bluetooth Standard between Apple and the other browser vendors it was suggested that browser extensions could offer a potential solution.
+
+The idea is that users who need Web Bluetooth could install a browser extension via the iOS App Store that provides this functionality to Safari. A [prototype](https://vimeo.com/642462265) of this has been produced for iOS.
+
+While developers producing these types of extensions are almost certainly just trying to help users, this solution is problematic for several reasons:
+
+1. Security/Privacy is hard, Device APIs are powerful and while they provide great utility this seems more a job for the dedicated teams at the browser vendors to handle.
+2. iOS Native has poor privacy protection relative to Web Bluetooth and the developer of these extensions would need to attempt to replicate all the mitigations in the extension itself.
+3. It is arguably a [dark pattern](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362) to discourage usage of Web Apps vs Native Apps to add extra hoops for users wanting to use Bluetooth on the web. This style of solution would presumably be unacceptable for Native Apps.
+
+
+
+##### 5.5.2.5. Apple's Identifier for Advertisers (IDFA)
+
+> Apple has a tactical commitment to your privacy, not a moral one. When it comes down to guarding your privacy or losing access to Chinese markets and manufacturing, **your privacy is jettisoned without a second thought.**
+> <cite>[Cory Doctorow - Former European director of the Electronic Frontier Foundation](https://twitter.com/doctorow/status/1459914164152016905)</cite>
+
+Given Apple’s strong stance on user privacy on the web, to the point of rejecting extremely useful functionality on the mere possibility that a user could be assigned a unique identifier it may surprise readers to learn that **Apple offers a method to uniquely fingerprint users** in native apps called [Apple's Identifier for Advertisers (IDFA)](https://en.wikipedia.org/wiki/Identifier_for_Advertisers).
+
+Up until iOS 10 there was no way for users to disable this, starting in iOS 14 users are asked via this slightly ambiguous prompt if they consent (about 20% of users have turned this operating system provided fingerprint off).
+
+Even when users do turn this functionality off, due to Natives' very permissive privacy and security model (relative to the Web) Apps can continue to fingerprint users.
+
+> Our investigation found the iPhone’s tracking protections are nowhere nearly as comprehensive as Apple’s advertising might suggest. We found at least three popular iPhone games share a substantial amount of identifying information with ad companies, even after being asked not to track. <br />
+When we flagged our findings to Apple, it said it was reaching out to these companies to understand what information they are collecting and how they are sharing it. After several weeks, nothing appears to have changed.
+> <cite>[Geoffrey Fowler And Tatum Hunter - Washington Post](https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/)</cite>
+
+The only consistent privacy policy with Apple’s concern for uniquely fingerprinting users on the web and with users being tricked via prompt) would **be to remove this functionality from iOS altogether**.
+
+{% image
+  "/images/walled-gardens/30_allow-tracking-prompt.png",
+  "iOS prompt asking if an application can track the user across apps and websites",
+  "screenshot"
+%}
+
+Apple has not announced any plans to entirely remove this functionality from iOS. Apple’s privacy stance needs to be consistent to believe that they are doing it for the benefit of the user. If they apply strict conditions that limit functionality on the web but allow pervasive tracking in native it can be argued they are providing pervasive tracking in the area which generates revenue while applying heavy restrictions beyond what is needed to prevent tracking on the other side.
+
+
+
+### 5.6. iOS Safari is Buggy
+
+In the [Mozilla Developer Network Web Developer Needs Assessment 2020 Survey](https://insights.developer.mozilla.org/reports/mdn-web-developer-needs-assessment-2020.html) developers listed browser compatibility issues as the largest issue as defined by:
+
+* Having to support specific browsers (e.g IE 11)
+* Avoiding or removing a feature that doesn’t work across browsers
+* Making a design look/work the same across browsers
+* Testing across browsers
+
+{% image
+  "/images/walled-gardens/31_mdn-needs-survey.png",
+  "A chart showing the popularity of issues faced by web developers"
+%}
+
+Drilling down further it was specific browsers that were causing the issues.
+
+Internet Explorer is at End of Life in June 2022, and has not been in serious development since 2015. This means that **Safari causes at least 5 times more issues** than the next active browser on the list.
+
+Note that Edge (based on the EdgeHTML engine) has been discontinued and now accounts for much less than 1% of global use. The Edge browser has been rebuilt on Chromium.
+
+This suggests that once Internet Explorer ceases to be used (its usage is already [below 1%](https://gs.statcounter.com/browser-market-share)) than the **primary browser causing serious issues for developers will be Safari**.
+
+{% image
+  "/images/walled-gardens/32_mdn-survey-browser-developer-issues.png",
+  "A chart shown what browsers developers have ranked as causing issues"
+%}
+
+Safari on iOS has had countless, severe application breaking bugs that make it impossible to use as a foundation for a stable application. Furthermore, the mechanism by which updates for Safari on iOS are pushed to users, **requiring a full OS update** instead of just updating the browser, means it can take multiple weeks, if not months, for a severe bug to be fixed. All this time, Web Apps and sites may be broken or even unusable. This means many companies are forced to develop native applications simply for the stability they provide.
+
+It is important to note that we believe these bugs are likely a result of reverse incentives in relation to the App Store and a lack of competition which has led to a [systemic underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/#:~:text=We%20asked%20Apple%20about%20the%20IndexedDB%20bug%20and%20whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition.%20We%20would%20be%20stunned%20if%20it%20chose%20to%20reply.) of the Safari/webkit team for many years. It’s likely that the Safari/Webkit team is working as hard as they can to make a stable browser but just can’t keep up because Apple has not provided enough resources for them to be able to do it.
+
+
+
+#### 5.6.1. State of CSS Survey
+
+[CSS](https://en.wikipedia.org/wiki/CSS) stands for Cascading Style Sheets which is used for formatting and layout for websites and Web Apps. It is one of the four languages used to develop websites and Web Apps, along with [HTML](https://en.wikipedia.org/wiki/HTML), [JavaScript](https://en.wikipedia.org/wiki/JavaScript) and [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly). It is used in nearly every web page, and is definitionally an uncontroversial core web standard.
+
+The [State of CSS](https://stateofcss.com) survey of web developers recently had a question about "pain points" and "browser incompatibilities". In the [raw text](https://gist.github.com/SachaG/cd7cf12623a95d8162ac2b8e340c4724) of the answers, the yellow lines are the ones that contain the word Safari:
+
+{% image
+  "/images/walled-gardens/32_mdn-survey-browser-developer-issues.png",
+  "Text file view showing a large amount of matches for the term 'Safari'"
+%}
+
+Extracting some of the quotes from the survey, it’s obvious that the opinion among developers that Safari is both buggy and lagging behind features is commonly shared amongst developers. Safari/iOS/webkit/iPhone/ipad was mentioned 369 times several times. By comparison Firefox only had 12 negative mentions in the entire survey.
+
+Here are some extracts from the survey:
+
+> I hate Safari with a passion of a thousand burning suns.
+
+> **Why is Safari so crap?** Why on earth do I still have discussions about IE11?
+
+> The Safari team should put their head out of their arse - Safari, Especially iOS Safari, are such a pain to work with as a webdeveloper, they lag years behind on too many features for both CSS & JS.
+
+> Safari feels pretty behind the times most of the time
+
+> **Safari is always years behind** Edge/Chrome and has many many many bugs related to viewheight/scroll.
+
+> iOS Safari is the biggest limiting factor in all web development.
+
+> mostly things that safari is catching up on
+
+> safari is evil
+
+> Flex gap :( it's so good but Safari is the new IE.
+
+> Safari is the main problem
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> Full screen height is a pain to work with in Safari
+
+> Still have been held back by IE11, but that ends soon. (Safari though...)
+
+> **Anything Safari doesn't want to implement**
+
+> Safari is just weird a lot
+
+> Too many to list for Safari on iOS/ipadOS
+
+> Only **lacking/lagging** support in Safari
+
+> Safari in general has issues with standards implementation
+
+> All of CSS with Safari. Notch specially
+
+> All the new stuff **being held back by Safari**
+
+> Anything iOS Safari doesn't support is a blocker, **because its rendering engine is mandatory in iOS**.
+
+> Anything new when using a WebKit browser -.-
+
+> Anything related to Apple company, **most of the new features are not available over there** ;)
+
+> Anything **safari does not support**
+
+> Anything Safari doesn't want to implement
+
+> **Anything that Firefox and Chrome support but Safari doesn't. It's a pain having to account for Apple's low bar**.
+
+> Anything that’s implemented differently in Safari & iOS Safari
+
+> Better Safari update cycle, detached from OS updates
+
+> Bugs in Safari related to shadow DOM.
+
+> Everything Safari doesn't support but Chromium & Firefox do
+
+> Flex gap, damn you Safari!
+
+> focus-visible is not yet supported by Safari
+
+> For whatever reasons, I wish Safari was quicker at implementing things.
+
+> Full screen height is a pain to work with in Safari
+
+> height being inconsistent on IOS safari
+
+> I hate Safari.
+
+> I have more and more instances where **stuff works everywhere but not in Safari**.
+
+> **I just treat safari as a hellhole** where css goes to die
+
+> I often find myself with layout issues that only happen in Safari
+
+> I'm not sure exactly what it is, but **Safari is now my problem child across all metrics**. It seems to be a little different each time, but overall Safari is always the browser with CSS related bugs.
+
+> Incompatibilities, poor CSS support in Safari
+
+> It is difficult for me to treat Safari as an important testing target or to pretend I care about its compatibility when **Apple seems utterly determined to make it difficult to test on Safari, and to use its incompatibilities to hold back open web development on Mac and especially on iOS**. I increasingly feel that **Safari doesn't really want to be part of a creative or open web**, and that's fine I guess, but I'm not going to waste my time and money buying an iPhone to test on when Apple would just prefer I made a native app for their platform anyway.
+
+> Just all of Safari.
+
+> Just wish Safari would die already
+
+> Main CSS pain point above all: Safari (i.e. all iOS) being rigged with bugs and lagging behind in features.
+
+> Many technologies blocked by lack of Safari support
+
+> Mostly just slow adoption by Safari
+
+> mostly things that safari is catching up on
+
+> **Nearly all pain points are Safari**.
+
+> Not any specific at the top of my head, but usually Safari is the one giving me a hard time :(
+
+> Not many but it's annoying when it happens. It's usually Safari lagging behind or rendering random stuff instead of the UI specified.
+
+> Not really difficulties, but Safari is one he** of a pain in the a** and having a more precise way of targeting it instead of both him and Chrome would be great (like -moz- prefix instead of having to write a bunch of @supports)
+
+> Only lacking/lagging support in Safari
+
+> Perf issues in Safari
+
+> Pretty much anything modern, as **Safari is lagging behind**.
+
+> Pretty much **anything that Safari shipped less than 18 months ago**
+
+> REMs in media queries. Damn you Safari!!
+
+> Safari (in general)
+
+> Safari and apple in general have incompatibility because they are late
+
+> **Safari became the new Internet Explorer** fro us
+
+> Safari feels pretty behind the times most of the time
+
+> safari has been a bit of a pain
+
+> Safari imcompatibilities
+
+> Safari iOS is becoming tiresome.
+
+> Safari is a huge mess
+
+> Safari is always years behind Edge/Chrome and has many many many bugs related to viewheight/scroll. iOS Safari is the biggest limiting factor in all web development.
+
+> **Safari is constantly dragging its heels**.
+
+> safari is evil
+
+> Safari is just weird a lot
+
+> **Safari is neglected**
+
+> safari is pain in the ass for debug if you have pc
+
+> Safari is the main problem
+
+> Safari is the new IE
+
+> Safari is the new Internet Explorer...
+
+> Safari on iOS :D
+
+> Safari should die!
+
+> Safari sucks
+
+> Safari updates not frequent enough
+
+> Safari, especially mobile
+
+> Safari. Everything WebKit. Freaking Apple…
+
+> The number one web problem is browser compatibility. **Browser like Safari is slowing down the evolution of web unfortunately**
+
+> Too many to list for Safari on iOS/ipadOS
+
+> Using Flexbox to layout forms because Safari on iOS shrinks radio buttons.
+
+> we can create any new features, but if browsers (like Safari) are waiting 3 years to implement it, it's totally useless.
+
+> **WebKit is never up to date and doesn't implement features fast enough (or at all)**.
+
+> yea, loads, mostly because of safari - like gap or ::marker
+
+> Yeah **Safari is killing me, it's the new IE**!
+
+> Yep, Safari is the new IE regarding grid and flexbox issues
+
+> Yes - and Safari is nearly always the browser that gets it wrong.
+
+> Yes, **horrible Safari support**
+
+> Yes, specifically compatibility with Safari
+
+> Yes, usually it's Safari. It became new IE😂
+
+> **Yes. And we have Apple to blame for it**! Flexbox gap is a good example.
+
+> Yes. Too much new useful features not supported by fcking safari.
+
+  </div>
+</div>
+
+
+
+#### 5.6.2. WebRTC
+
+WebRTC is a standard for web video calls, access to microphones and cameras, and enables streaming video applications such as game streaming (Stadia, xCloud, Luna, GeForce NOW, etc.).
+
+> During March 2020 and the rise of the pandemic in Norway EVERYONE needed video calling. We are the number one video calling tool for healthcare here, and our use base is around 60% iOS Safari. I can tell first hand having to deal with onboarding 70% of the doctors in Norway with active bugs on iOS in simple things like media reliability, and with no real alternative (a lot of people only have one modern device, and that's their phone), **it was near catastrophe for us, and a lot of pain for doctors missing their patients due to bugs**
+> <cite>Das-Igne Aas – CTO Confrere</cite>
+
+> iOS Safari WebRTC is such a broken mess that my going suggestion to clients unfortunately is to not support it and redirect users to a native app installation. I had to manually go through all open WebRTC bugs in webkit to figure out how to explain this to my clients and help them in reaching that conclusion and even conveying that to their customers.
+>
+> There are nasty bugs in iOS Safari that have been opened since 2019 or earlier relating to media handling of WebRTC. These aren’t just edge cases, but rather things you’ll have users bump into in regular use. Some of them have finally been fixed in the latest 13.5.5 beta earlier this month.
+>
+> Oh – and if you plan on using any OTHER browser on iOS then WebRTC won’t be supported there. Why? Because Apple hasn’t made WebRTC available in its Webkit Webview on iOS and they aren’t allowing anyone to build a mobile iOS browser that doesn’t use Webkit as its rendering engine. So much for freedom and choice.
+> <cite>[Tsahi Levent-Levi](https://bloggeek.me/webrtc-browser-support/)</cite>
+
+
+
+#### 5.6.3. IndexedDB
+
+IndexedDB is a local browser database for storing data. It is essential for many apps, especially apps that require offline functionality. IndexedDB on iOS Safari has had many bugs and been broken many times since it was first introduced. Recently, both IndexedDB and LocalStorage, a similar API for storing small amounts of data, were broken, leaving developers little alternatives to store data or risk data loss or corruption. Local Storage which is also essential for many websites was broken at the same time.
+
+> Apple's WebKit team has managed to break the popular IndexedDB JavaScript API in the latest version of Safari (14.1.1) on macOS 11.4 and iOS 14.6.
+> <cite>[Thomas Claburn - The Register](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug)</cite>
+
+> Ran into a spectacularly awful Safari bug in the latest Safari (14.1.1 on macOS and iOS 14.6).
+>
+> Opening an IndexedDB database fails 100% of the time on the first try. 😩
+>
+> If you refresh, it starts working. <br />
+> Bug report: [https://bugs.webkit.org/show_bug.cgi?id=226547](https://bugs.webkit.org/show_bug.cgi?id=226547)
+>
+> It's really really hard to build reliable websites on macOS and iOS with showstopper bugs like this.
+> This should have been caught by basic unit testing.
+> <cite>[Feross Aboukhadijeh (Stanford Computer Security University Lecturer and Open-Source Developer of Socket)](https://twitter.com/feross/status/1404568122158313474)</cite>
+
+
+
+### 5.7. Default Browser Choice
+
+Until [late 2020](https://www.theverge.com/2020/10/21/21526556/ios-14-resets-default-email-browser-apps-after-updates), it was impossible for iOS users to choose an alternative browser to handle links, even if they had installed other WebKit-skin browsers from the App Store. Apple continues to prevent competitors from bringing differentiating features via their own engines.
+
+As the only company banning competing engines, **Apple is clearly the worst offender**, but they are not the only ones impeding user choice. It is our opinion that to preserve competition, users must be given the ability to easily change their default browser and that choice must be respected by the operating system
+
+> Google’s “Android Google Search App” has been ignoring browser choice on Android.
+>
+> Known as the "Android Google Search App" ("AGSA", or "AGA"), this humble text input is the source of a truly shocking amount of web traffic; traffic that all goes to Chrome, no matter the user's choice of browser.
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser.)</cite>
+
+Facebook has been abusing IAB (In App Browsers) to prevent users from opening links from within the Facebook app in either their own browser or in a view that uses the users default browser (both iOS and Android provide this, although the iOS is only iOS Safari).
+
+Using IAB (In App Browsers) to deny users choice is a very complex topic. [This article](https://infrequently.org/2021/07/hobsons-browser) does an excellent summary of the current situation and why it is bad for consumers. We have also made a separate submission covering this topic.
+
+It is our opinion that mass market operating systems and major applications should as much as possible provide users with the means of selecting a default browser (complete with its engine) and respect it. Additionally they should avoid using dark patterns or misleading interfaces to favour their own browser.
+
+
+
+### 5.8. Evidence of Long Term Neglect and Developer Discontent
+
+In addition to [5.6. iOS Safari is Buggy](#ios-safari-is-buggy), this section describes some of the long term evidence of neglect and developer discontent with Safari by providing quotes with links to external sources. This evidence is not exhaustive and is simply a subset of what’s available. The sources date from 2011 to 2022.
+
+
+
+#### 5.8.1. Push Notifications
+
+Push Notifications for iOS on Native was released on [June 17, 2009](https://en.wikipedia.org/wiki/Apple_Push_Notification_service). As of writing **almost 13 years have passed** and Apple has provided no mechanism to allow Web Apps to send notifications, a critical feature for many applications.
+
+It is undoubtedly the most requested feature but has been repeatedly ignored by Apple. It was only on September 26th 2021 (after OWA’s #AppleBrowserBan campaign and presentations to regulators) that Apple started work on Push API, although over 200 days later and there have been no indication that this feature will be ready any time soon.
+
+There are countless requests for this feature across platforms frequented by developers including twitter/stackoverflow/reddit and Apple’s own bug tracker.
+
+Developers were so frustrated in the lack of development and response from Apple they started their own change.org petition which has garnered over 7000 signatures, a substantial amount considering how poorly supported Web Apps are on mobile devices.
+
+{% image
+  "/images/walled-gardens/41_change-dot-org-petition-web-push.png",
+  "A change.org petition, asking Apple to implement Web Push notifications",
+  "screenshot"
+%}
+
+Extracted from the site are some quotes:
+
+> It's **hard enough to develop for Apple as is**. Stop making it harder for me to make something for your users to use.
+> <cite>[James Hessell-Bowman (Feb 9, 2022)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **PWAs are the future. iOS Safari isn't. Change it!**
+> <cite>[Mauricé Ricardo Bärisch (Jan 7, 2022) ](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Safari is the new IE
+> <cite>[Flavio Spezi (Nov 24, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> My goodness no push notification yet, **disgrace**
+> <cite>[Daniel Gadd (Nov 24, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> IMHO, **PWAs are a better way to reach mobile users**, compared to native mobile apps, for not-hardware-intensive apps.
+> <cite>[Saqib Shafin (Oct 3, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I'm a developer who would like to be able to sell this feature to clients without caveats or additional costs. **It would also be great to have a unified web for all platforms**.
+> <cite>[Alex Grant (Jun 26, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Please implement the W3C standards. **Don't be like IE or soon the developer community will turn on you**.
+> <cite>[Frank Ali (May 26, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **We need this** web developers
+> <cite>[Jack Smith (Apr 29, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Come on guys, we need this**... It's crucial.
+> <cite>[Morne Erasmus (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **It's the right thing to do Apple.**
+> <cite>[Shaun Bliss (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> Need it! **Soon**!!
+> <cite>[Francesco Rombecchi (Dec 1, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Desperately** needed for modern web apps
+> <cite>[Michoel Samuels (Jun 9, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I would like to write from **one codebase** and deploy on **all platforms**
+> <cite>[David Murdoch (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Shocking what they are doing. Pure monopoly**. They are **lowering the technological progress to protect their pockets**, but they are the most rich stock in the world…
+> <cite>[Federico Schiocchet (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This would **dramatically** simplify some business apps.
+> <cite>[Ben in CA (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> It's **ridiculous** they don't have it!
+> <cite>[Mohameth Seck (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **It's sad that we have to petition** for something like this. I wonder if Steve was alive if he would hold back the progress of technology like these clowns at apple.
+> <cite>[Shaquille Hinds (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Because developers don't want to have to build a whole new frontend iOS app just to send push notifications.**
+> <cite>[Miles Exner (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Seriously ? Still not implemented ??? **Apple, you're standing in the way of a better life for all humans**. Get over it and do the right thing.
+> <cite>[Edouard SILHOL (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This feature will helps developers to create a fast and eficient communication trought sites. Increases PWA experience. **It will help any business type**.
+> <cite>[Lucas Santos (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **This is SO long overdue. It needs to happen. Like... NOW.**
+> <cite>[Sean McDade (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Stop calling iphone a smartphone **when it can't even handle web push**. It's **2020 and we're still fighting for this**. Please make your dumbphone smart again.
+> <cite>[Jonelle Mancilla (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This is an **absolutely necessary feature** to allow iOS users to have the same experience across so many apps as Android users have. Resisting adding this feature only ends in frustration and brand disdain, **not any type of monopolistic win that Apple** might want to go for as an alternative.
+> <cite>[William Lancaster (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **In 2020 it is beyond my comprehension that Apple’s support for PWAs - but more specifically the WebPush API - is non-existent**
+> <cite>[Christopher Deeming (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I want to be able to give push notifications to users of my web application **without having to build a native app**!
+> <cite>[Adam Ullman (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Enabling Push Notifications for iOS Safari will lead to more **innovation** in the web space.
+> <cite>[Alexander Matulionis (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> PWAs are the future for smaller apps that don't want to invest in the skill required to make native or native-ish apps. **Apple you're currently the weakest link**. People will still make microtransations in games, and native apps will still be a necessity for video and audio purposes -- your app…
+> <cite>[Jacob Clarke (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> When it is a matter of standardize systems that can contribute to deliver safety or security notifications to consumers, **a vendor shouldn't have the right to lock those consumers to proprietary platforms**.
+> <cite>[Alberto Cruz (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> as a developer this is a **vital requirement for any modern application**.
+> <cite>[Luke Whitehouse (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Because apple is making life hard (and expensive) for everyone.**
+> <cite>[Micah Galizia (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I signed because I think it's **silly to be the only platform out there to not support web notifications**. Every other browser and os supports this feature. When iPhone came out, it was game changing because it could do everything a computer could as far as web browsing (other than flash…
+> <cite>[Joshua Shell (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> It's **very** important for web experiences!
+> <cite>[Juan David Nicholls Cardona (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> we **need** this feature to get free of apps
+> <cite>[Tamir Konor (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> our app helps restaurants notify guest when their food is ready, guest can opt to receive a notification. **but iphone users cant**. only android users can. Not everyone wants to install an app to receive mobile event based notifications.
+> <cite>[sal iozzia (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I'm a web dev, **it makes no sense that apple is behind on this**.
+> <cite>[Darren Allen (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> PWAs are here now! Empower developers to use the skills they know today (HTML, CSS, JavaScript) to create amazing products.
+> <cite>[Cesar Perez (Feb 23, 2022)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Add notifications!
+> <cite>[Wesley Pohto (Jan 24, 2022))](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> **We built a small app for the push** and have **difficulty to maintain it**. We are in a big need to have web push to run in iOS
+> <cite>[Brenda Kwok (Oct 22, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I m facing same issue and I want to request for notification on web IOS devices
+> <cite>[Nitesh Sharma (Oct 15, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I have no idea when a client comes into my retail chat platform with me while I work on my iPad. I don't receive a chime or banner so I am unable to use my iPad as a tool for work. Please enable push notifications for ios.
+> <cite>[Blake Y (Oct 2, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> we need it
+> <cite>[呂 昶億 (Sep 15, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Our clients will benefit greatly from push notifications on iPhones
+> <cite>[Sergei Gorlovetsky (Aug 22, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> OMG!!!! PLEASE!!! WHY YOU DIDN'T IMPLEMENT THIS YET?!!!!
+> <cite>[Leandro Simões da Silva (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I think that this is a very important feature to have.
+> <cite>[David Rychlý (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> To remove the barrier requiring users to download an app just to deliver push notifications
+> <cite>[Loveth Ezeoye (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> This is need of the hour. iOS users are loosing on a great UX.
+> <cite>[adarsh madrecha (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> apple! i want to be able to use web push notification from my favorite sites and pwa apps!
+> <cite>[ChunTing Tai (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I represent a small company that creates membership administration software for dance/martial arts/yoga studios, which includes a PWA for their members for ease of communication, conveying absence, sharing calendar and events, etc. Currently approximately 40.000+ dancers …
+> <cite>[Johan van Ingen (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Apple are going to lose support from their loyal customers over this glaring omission. Thousands of great websites will work great on Android and PCs but not on Apple.
+> <cite>[Mac MacLaren (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Support open web standards
+Those kind of systems must be more agnostic.
+> <cite>[Brian Kephart (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> It's a huge feature that "the best of the best" should of thought of first and is falling behind once again.
+> <cite>[joseph simmons (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Just do it.
+> <cite>[Jazmyn Cote (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I really need this for a web app I am developing.
+> <cite>[Adrian Meyers (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Implementen push notification en safari
+> <cite>[Hector Luis Batista (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Web notifications can be useful for users that do not want to download an app just to receive notifications. Email notifications are not as effective and SMS are pricey
+> <cite>[Mo Alraddadi (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Hoy en día los usuarios tienen que tener la posibilidad de ELEGIR si recibir notificaciones web push en su celular o no... No debe ser algo restricto!
+> <cite>[Mauro Francisco Arrigoni (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Make this a reality.
+> <cite>[Devonte Valentine (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Apple initially unveiled Safari as the means by which developers could develop applications for iPhone. An idea ahead of its time. But that was followed by the first iOS SDK and app store. I believe there is room for both. PWA's are not meant to wipe out app stores, but to open a new pathway to…
+> <cite>[Michael Bunchball (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I develop PWA and I want to send web push notifications to users
+> <cite>[Erick Daniel Miranda Varas (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> **Ios should lead this technology, not slack behind!**
+> <cite>[Anton Albèrt Karlström (2 years ago) ](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> NEED THIS BIG TIME!
+> <cite>[Nevaan Perera (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> to deliver a consistent and smooth user experience on iOS and Android devices - **to remove the barrier requiring users to download an app just to deliver push notifications**
+> <cite>[Lukas Schmyrczyk (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> really hoping in new **iOS 12** they added web push notifications in Safari
+#PWA
+> <cite>[Irsyad Ilham (Jun 5, 2018)](https://twitter.com/_irsyadilham_/status/1003837872850362368?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> When is iOS Safari gonna get Web Push?
+> <cite>[@chendo (Jul 31, 2018)](https://twitter.com/chendo/status/1024165614577840129?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Hi! I've watched a Google IO keynote about the PWA and they've shown this table. Are Web Push & Notifications coming to Safari, even on iOS? Thanks for the answer!
+> <cite>[Thibault (May 9, 2018)](https://twitter.com/ThibB/status/994214627570569216?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Dear @Apple,
+>
+> Can you **please please please** enable push notifications for safari ios ?
+>
+> Sincerely yours, <br />
+> Alan, a #PWA developer.
+> <cite>[@AlanCrevon (Jun 28, 2018)](https://twitter.com/AlanCrevon/status/1011984630738759681?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> So sad that push notifications **are still not possible** in Safari for iOS 10.
+> <cite>[Boris Smus (Oct 9, 2016)](https://twitter.com/borismus/status/784917901945872384?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Hey @jonathandavis, Any plans to bring Web Push Notifications to iOS Safari?
+> <cite>[Diogo Cunha (Jun 26, 2018)](https://twitter.com/diffcunha/status/1011582721737383936?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> iOS Safari DOES NOT support push notifications. With macOS Safari will it support push notifications for WEB APPS?
+> <cite>[eon V Baravykas (Jun 16, 2016)](https://twitter.com/AussieVilkas/status/743239015143399425?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Apple should bring Safari push notifications to iOS.
+>
+> A much-needed bridge.
+> <cite>[George Papadakis (Jan 12, 2014)](https://twitter.com/phaistonian/status/422242877461106688?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Why **doesn't iOS allow push notifications** from Safari? #firstworldproblems
+> <cite>[Josh Manders (Nov 20, 2011)](https://twitter.com/joshmanders/status/137976204702658560?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I **guess still no Push Notifications** on iOS Safari, even proprietary ones
+> <cite>[Arthur Stolyar (Jun 6, 2017)](https://twitter.com/nekrtemplar/status/871825566999212033?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Anyone else find it odd that OS X is getting push notifications for Safari before iOS is?
+> <cite>[Dan Ryan (Jun 12, 2013)](https://twitter.com/dryan/status/344591918749069312?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> One more thing…noticed how Push notifications for safari was listed under iOS/OSX. Maybe well get push notifcations for mobilesafari at wwdc
+> <cite>[Constantin Jacob (Apr 27, 2014)](https://twitter.com/tzeejay/status/460303135022780418?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Safari for iOS should support push notification…
+> <cite>[K̾a̾x̾i̾n̾g̾🛸 (May 21, 2011)](https://twitter.com/kaxing/status/71823217274261505?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> **Seeing a Web App I worked on used by *Apple* to justify that the Web is a viable platform on iOS is bullshit**
+>
+> The Web can be an ideal place to build apps but Apple is consistently dragging their heals on implementing the Web APIs that would allow them to compete with native apps
+> <cite>[Ada Rose Cannon (May, 2021)](https://twitter.com/AdaRoseCannon/status/1389642353472851970) <br />(emphasis added)</cite>
+
+  </div>
+</div>
+
+#### 5.8.2. Safari has been buggy for a long time
+
+> I'm always **amazed at the irriparable bugs Safari** on iOS yields due to its cutting corners whereever it can. **Thank you for being our new IE!**
+> <cite>[Christian Schaefer (Oct 10, 2017)](https://twitter.com/derSchepp/status/917668189592588288?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Severe two year old iOS Safari bug** with position:fixed that started in iOS 8, finally closed…
+> <cite>[Jeff Atwood (Jun 15, 2017)](https://twitter.com/codinghorror/status/875127338190503937?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> iOS safari bugs have **added 80 hours of work** to my current project - now I'm kinda fed up with it! But seems to have everything fixed now :-)
+> <cite>[Michael Vestergaard (Nov 5, 2016)](https://twitter.com/iltp/status/794535136645750789?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Can we all pause and reflect on the disgusting fact that Safari desktop still does not support HTML input type date? Every other modern browser does. **Safari iOS support is half baked with bugs** such as the default date being today even if the max attribute is set with a past date.
+> <cite>[Jayden Seric (Dec 12, 2018)](https://twitter.com/jaydenseric/status/1072649315397615616?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I 💓 bugs in Safari/iOS that **do not appear in any other browser incl. Safari/Desktop** and Safari/iOS Simulator. Great way to spend one's time.
+> <cite>[Manuel Strehl (Apr 26, 2017)](https://twitter.com/m_strehl/status/857186402261512192?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Safari for iOS sucks. 5 bugs on website only because of Safari**. It’s getting out of control. Still no good service worker implementation. Becoming new Internet Explorer in some time. 😭
+> <cite>[Dariusz Lorek (Oct 11, 2018)](https://twitter.com/dariuszlorek/status/1050176807272624130?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> But you will find lots of **iOS Safari-only bugs**, so… swings and roundabouts 😉
+> <cite>[Matt Stow (Sep 26, 2017)](https://twitter.com/stowball/status/912611092018323456?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Oh and we fixed those **crazy iOS layout bugs** (since Safari on iOS does not really respect viewport height. I mean, it does, but come on..)
+> <cite>[Clean Email (May 9, 2017)](https://twitter.com/clean_email/status/861767744919814144?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> iOS 12 introduced some nasty Safari bugs. **Safari is the new IE for developers**.
+> <cite>[Grant McCall (Sep 20, 2018)](https://twitter.com/grantmccall/status/1042542145612075008?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **I can't believe iOS Safari has such major bugs**. Showing cached pages unexpectedly all the time, like when opening a homescreen link
+> <cite>[Tom Bielecki (May 1, 2016)](https://twitter.com/tombielecki/status/726560977823526912?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> A number of issues C3 has in "Add to home screen" mode on iOS are Safari bugs. We report them **but Apple are very slow and opaque in dealing with them**. For example switching between Safari and web app loses all storage: [https://bugs.webkit.org/show_bug.cgi?id=181849](https://bugs.webkit.org/show_bug.cgi?id=181849)
+> <cite>[Ashley Gullen (Nov 3, 2018)](https://twitter.com/AshleyGullen/status/1058373005120860161?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Safari on iOS tends to ship with tons of bugs** (think of fixed position handling) that need version-specific workarounds. Don't take away our last straw for building something somewhat useable in Safari.
+> <cite>[Matthias Keller (Dec 21, 2017)](https://twitter.com/kellermatth/status/943812107358924800?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Calypso is so advanced it can’t even see into its own bewildered state. This is manifest in **the plague of interaction bugs on iOS Safari**.
+> <cite>[Ryan Boren (Aug 19, 2018)](https://twitter.com/rboren/status/1030832012469395456?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Alright, it should work now as far as I could test. **There are a lot of Safari & iOS bugs in WebGL**; I'm still grappling with some (and that on a Friday night!) :)
+> <cite>[David Lenaerts (Oct 6, 2018)](https://twitter.com/DerSchmale/status/1048291855589421057?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **We have to spend way too much time on Flexbox related iOS Safari bugs** each sprint, but I'm not sure what Safari version that is so you could be right about the "right now" part 😅
+> <cite>[Dillon de Voor (Apr 13, 2018)](https://twitter.com/CrocoDillon/status/984706727898644481?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I may or may not have **just spent 2hrs fixing a bug caused by iOS Safari being a piece of shit** and I may or may not have an entirely different opinion on this tomorrow okay thx bye.
+> <cite>[Scott (Dec 5, 2018)](https://twitter.com/scott_riley/status/1070051423860203520?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Thinking Webkit (Safari and Chrome for iOS) is on verge of becoming the new IE for developers: Brittle, cumbersome, and falling behind**.
+> <cite>[CK MacLeod (Jul 6, 2018)](https://twitter.com/CK_MacLeod/status/1014957101179797504?s=20&t=Pjt8d3GlAJzYPgdlQPbp5) <br />(emphasis added)</cite>
+
+> There was article about Chrome being the new IE and it makes a lot of valid points, but **to me, it's Safari on iOS**. It's such horseshit. <br />
+> #webdev <br />
+> [https://medium.com/@bdc/chrome-is-the-new-ie-1a21c1efc133](https://medium.com/@bdc/chrome-is-the-new-ie-1a21c1efc133)
+> <cite>[Longzero (Feb 16, 2018)](https://twitter.com/Longzero/status/964166488482631684?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Two major complains to @Apple. Safari is slow on adopting new JS/CSS APIs & iOS11 is too buggy. **Safari is new IE**, iOS is new Android.
+> <cite>[Ilya (Sep 23, 2017)](https://twitter.com/darasus_/status/911593652635488256?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Unfortunately, since Steve Jobs died, **we have the buggiest Safari starting from iOS 7**, completely denying the perfection which was set initially. <br />
+> [https://dzone.com/articles/safari-ios-7-and-html5](https://dzone.com/articles/safari-ios-7-and-html5)
+> <cite>[Brian Cannard (Nov 18, 2018)](https://twitter.com/briancannard/status/1063879561606098954?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Hey Apple, **please take some of your $180 billion cash reserves and fix Safari and iOS**. They are easily the buggiest modern OS and browser.
+> <cite>[Creative Logic (Apr 15, 2015)](https://twitter.com/creative_logic/status/588002875239899136?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I think **Safari might be the buggiest app I currently run in OS X. Debugging an iOS device is almost unbearable**.
+> <cite>[George Crawford (Jun 27, 2014)](https://twitter.com/georgeocrawford/status/482515603211968513?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> "Bad news! **Apple iOS 7 is plagued with HTML5 bugs**" -InfoWorld (2013), "**This is the buggiest Safari version since**..." <br />
+> [http://fb.me/37BcJBuaK](http://fb.me/37BcJBuaK)
+> <cite>[Occupy HTML5 (Jan 5, 2014)](https://twitter.com/occupy_html5/status/419650316632850432?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Apple has published just 10% of the necessary information for web developers, and I can say without fear of mistake that **this is the buggiest Safari version since 1.0**
+> <cite>[Maximiliano Firtman](https://firt.dev/ios-7) <br />(emphasis added)</cite>
+
+> Yo, @Apple, **Your new iOS is trash, especially safari. So many bugs**.
+>
+> Honestly, Apple has been going down hill since Jobs died.
+> <cite>[Sarah (Nov 30, 2020)](https://twitter.com/HvrdTimes/status/1333052218963062785?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Everyone in my mentions saying Safari is the worst, it’s the new IE**… Can you point to specific bugs & missing support that frustrate you, inhibit you making websites/apps. Bonus points for links to tickets.
+>
+> Specifics we can fix. Vague hate is honestly super counterproductive.
+> <cite>[Jen Simmons (Apple Developer Relations) - Feb 9, 2022](https://twitter.com/jensimmons/status/1491064075987873792) <br />(emphasis added)</cite>
+
+> Hi @jensimmons - I'm a big fan of yours and your work (specifically CSS articles), but **I've been super-frustrated with Safari for the past few years** - thank you for asking for input. It is like the new IE, but not quite as bad. (cont'd)
+>
+> Part of the issue is that **it seems like the webkit bugzilla is a dead-end** - it seems like any info posted there just sits there, and may be sucked into another system, so the public view is radio silent. Here's one that I posted (still a bug):<br />
+> [https://t.co/048O9KTnBJ](https://t.co/048O9KTnBJ) <br />
+> … <br />
+> It also seems like **webkit (and webkit iOS) has just been understaffed**/not a priority for Apple. We're investing heavily in PWAs so our apps run on all platforms, **but PWA support on webkit has well-documented gaps**. For a small startup, we'll necessarily deprioritize iOS.
+> <cite>[John Crim (Feb 11, 2022)](https://twitter.com/johnwcrim/status/1491828595433836545?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> I can't point to specific bugs on this, **but I've all but given up on iOS support for my 3D engine** because out of every browser and OS I support, iOS Safari is the most trigger-happy when it comes to killing tabs for using "too much" memory. How much is too much?🤷‍♂️ wish I knew!
+> <cite>[James Baicoianu (Feb 9, 2022)](https://twitter.com/bai0/status/1491147591555645440?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> You want the truth? Okay
+>
+> Plugin support on Safari is trash since **you’re at the mercy of the awful App Store**, which is a nightmare to search and is lacking in support compared to Firefox and Chrome
+>
+> Webkit is also restricted for third parties so they can’t make any good web apps
+> <cite>[Dri Scaphandre (Feb 10, 2022)](https://twitter.com/Dr_Scaphandre/status/1491437615241109505?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> [https://bugs.webkit.org/show_bug.cgi?id=218012](https://bugs.webkit.org/show_bug.cgi?id=218012)
+>
+> including analysis and specific suggestion in comment 12. This is a hard problem for a web app obviously but 1.5+ years without traction... (**but a sleuth of other audio bugs, it is hard to keep them apart even at this point**)
+> <cite>[Philipp Hancke (Feb 9, 2022)](https://twitter.com/HCornflower/status/1491154421048573952?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> A lot of the hate comes from product decisions / forcing people to use Safari (on iOS), which you probably have no control over, so the hate shouldn’t be directed at you. **But it’s a browser that lags in features and fixes, gets updated less often, and is forced on users**.
+> <cite>[Matthew Dean (Feb 9, 2022)](https://twitter.com/MatthewDeaners/status/1491230548702142466?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> Safari is quickly turning into the new IE.
+>
+> **20% of my time is spent writing hacky code apologizing for Safari's failures as a browser**
+>
+> In our project, we've just started the E2E testing phase on Safari
+>
+> I'm just trying my best to survive the imminent bug avalanche on Jira 🤮🤮
+> <cite>[Aurelian Lucius (Apr 13, 2022)](https://twitter.com/aurelian_lucius/status/1514174112314318849) <br />(emphasis added)</cite>
+
+  </div>
+</div>
+
+
+
+#### 5.8.3. News and Blog Articles
+
+Many have written about the issues surrounding Safari, Web Apps and iOS. This section goes through just a small number of articles.
+
+> First, it means that Dieter and I drink a lot of bourbon and talk about the sad, **slow death of the open web a lot**. (It was a good run, open web! So sorry that **Apple killed you** by turning Safari into the new IE and **forbidding alternative browsers to innovate on iOS**.)
+> <cite>[Nilay Patel - Editor-in-Chief - The Verge (Oct 6, 2016))](https://www.theverge.com/2016/10/6/13188306/refreshing-the-verge-facebook-video-google-amp-future-of-the-web) <br />(emphasis added)</cite>
+
+> Devices using iOS and the future Windows RT **hobble third-party browsers**. Despite some good reasons for doing so, the change could **undermine browser competition**. <br />
+> … <br />
+> On iOS devices, **Apple permits only its own version of the WebKit browser engine**. Technically other browsers besides Safari are allowed, but they must use Apple's technology for actually rendering Web pages. <br />
+> … <br />
+> Apple, though, gives its Safari browser privileges using Apple's WebKit browser engine that third-party apps from the App Store don't get.
+> <cite>[CNET Browser Choice - A thing of the Past? (May 23, 2012)](https://www.cnet.com/tech/services-and-software/browser-choice-a-thing-of-the-past/) <br />(emphasis added)</cite>
+
+> Firefox won't land on Apple's iOS until the fruity company relaxes its rules about third-party browsers, according to Jay Sullivan, vice president of product at Mozilla.
+>
+> Sullivan spoke on a panel at the SXSW music-and-tech-fest in Austin, Texas, over the weekend, and told the crowd **Apple's refusal to allow the installation of Mozilla's preferred Gecko rendering engine is an immovable obstacle to development of an iOS version of Firefox**.
+> <cite>[The Register (Mar 10, 2013)](https://www.theregister.com/2013/03/10/no_firefox_for_ios/) <br />(emphasis added)</cite>
+
+> I think there is a **general feeling among web developers that Safari is lagging behind the other browsers**, but when you go to a conference like EdgeConf, it really strikes you **just how wide the gap is**. All of the APIs I mentioned above are not implemented in Safari, and Apple has shown no public interest in them. <br />
+> … <br />
+> **Even when Apple does implement newer APIs, they often do it halfheartedly**. To take an example close to my heart, IndexedDB was proposed more than 5 years ago and has been available in IE, Firefox, and Chrome since 2012. Apple, on the other hand, didn’t release IndexedDB until mid-2014, and **when they did, they unveiled a bafflingly incompetent implementation that was so bad, it’s been universally derided as unusable**. <br />
+> … <br />
+> Now, after one year, Apple has fixed a whopping two bugs in IndexedDB (out of several), and they’ve publicly stated that they don’t find much value in working on it, because they don’t see “a huge use.” Well duh, nobody’s going to use IndexedDB if the browser support is completely broken. (Microsoft, I’m looking at you too.) <br />
+>
+> It’s **hard to get insight into why Apple is behaving this way. They never send anyone to web conferences**, their Surfin’ Safari blog is a shadow of its former self, and nobody knows what the next version of Safari will contain until that year’s WWDC. In a sense, **Apple is like Santa Claus, descending yearly to give us some much-anticipated presents, with no forewarning about which of our wishes he’ll grant this year. And frankly, the presents have been getting smaller and smaller lately**. <br />
+> … <br />
+> In recent years, Apple’s strategy towards the web can **most charitably be described as “benevolent neglect.”** Although performance has been improving significantly with JSCore and the new WKWebView, the emerging features of the web platform – offline storage, push notifications, and “installable” webapps – **have been notably absent on Safari**. <br />
+> … <br />
+> The tragedy here is that Apple hasn’t always been a web skeptic. As recently as 2010, back when Steve Jobs famously skewered Flash while declaring that HTML5 is the future, Apple was a fierce web partisan. <br />
+… <br />
+> Around that same time, when WebSQL was deprecated in favor of IndexedDB, you’ll even find mailing list arguments where **Apple employees vigorously defended WebSQL as a must for performant web applications**. Reading the debates, I sense a lot of bitterness from Apple after IndexedDB won out.
+> <cite>[Nolan Lawson - Safari is the New IE (Jan 2015)](https://nolanlawson.com/2015/06/30/safari-is-the-new-ie/) <br />(emphasis added)</cite>
+
+> **The real problem is Apple’s lack of browser-choice in iOS**, and that’s a problem for several reasons: <br />
+> … <br />
+> **It's limiting the browser-vendor competition on Apple’s iOS platfrom, as Apple are the only one allowed to innovate within the browser engine**. This for example means Google are limited to only compete on the UI-front in Chrome, and can’t bring new platform features, that already are available on other platforms, to iOS. <br />
+> <br />
+> As a vendor of dominant mobile operating system, Apple, should make a real browser choice possible in iOS in order to ensure fair competition and innovation. **Any other major operating system (Android, Windows, OSX, Linux) has a free browser choice, and iOS should be no different**. <br />
+> <br />
+> To me this this draws many parallels to the antitrust case against Microsoft back in the golden-era of Windows, as Safari is deeply integrated into iOS. It can't be removed or replaced. It's forcefully distributed by Apple, and is embedded inside native applications as WebViews. Since I’m not a lawyer, I don’t know if there exists similar legal reasoning as in the Microsoft case, but I do see the similarities when comparing the two.
+> <cite>[Safari isn’t the problem, but the lack of browser choice in iOS is - Kenneth Auchenberg (July 2015)](https://kenneth.io/post/safari-isnt-the-problem-but-the-lack-of-browser-choice-in-ios-is) <br />(emphasis added)</cite>
+
+> Bad PC software created the opportunity for the web to exist in the first place, **just as bad mobile web performance created the market for mobile apps**. <br />
+> … <br />
+> **But we can't fix the performance of Mobile Safari. Apple totally forbids other companies from developing alternative web rendering engines for the iPhone, so there's no competition** for better performance, **and no incentive for Apple to invest heavily in Safari development**. In many ways, Safari is the new Internet Explorer. <br />
+> … <br />
+> **That's a recipe for stagnation, and stagnation is what we have**. It's leading powerful players like Apple and Facebook to create ersatz copies of the web inside their walled gardens, when what we really need is a more powerful, more robust web.
+> <cite>[The mobile web sucks - Nilay Patel - Editor in Chief - The Verge ](https://www.theverge.com/2015/7/20/9002721/the-mobile-web-sucks) <br />(emphasis added)</cite>
+
+> But **Apple has a reason not to like this recycling of web technology**. It wants its **Mac App Store to be filled with apps that you can’t find anywhere else, not apps that are available on every platform**. <br />
+> … <br />
+> In a discussion on the programming community Github, several developers say rejections for apps that they built using Electron — which would were approved in the past. <br />
+> … <br />
+> **Apple has a history of stunting the web’s progress on its platforms**. On iOS, **Apple doesn’t allow fully independent third-party browsers**, requiring all apps to leverage its Safari browser when rendering web-based content. While browsers like Chrome and Opera are available in the App Store, they must use Apple’s Safari browser behind the scenes to render web pages, rather than their own. That means Apple has a monopoly on how iPhone and iPad users access the web. **To push developers toward building native apps on iOS rather than using web technologies, Apple ignores popular parts of the open web specification that other browsers implement, to its own benefit**.
+>
+> **Apple’s subtle, anti-competitive practices don’t look terrible in isolation, but together they form a clear strategy**.
+>
+> A technology called WebRTC, for example, allows video calling in a web browser without additional software. It powers tools like Google Meet. **But Apple was incredibly slow to implement the specification, leaving out key pieces of functionality, and the technology didn’t work when embedded inside apps**.
+>
+> **Apple also handicapped an emerging standard called Progressive Web Apps (PWAs)** — which, like Electron, allows developers to build native-like apps for both desktop and mobile — **by partially implementing it in a way that makes it too inconsistent to rely on. PWA doesn’t have the same problem if users open apps in Chrome or Firefox**, but iPhone and iPad users can’t install third-party browsers, which makes PWA-based technology a non-starter.
+>
+> **Developers use technologies like Electron and PWA because they allow for faster updates across platforms without an array of different codebases**. <br />
+> … <br />
+> **Apple’s subtle, anti-competitive practices don’t look terrible in isolation, but together they form a clear strategy: Make it so painful to build with web-based technology on Apple platforms that developers won’t bother**. <br />
+> … <br />
+> These types of changes may be made in the name of privacy or security, but the reality is that the argument looks weak when both users and developers simply don’t have a choice because Apple controls the platform, browser engine, and the distribution method. Regardless of your opinion of Electron app quality, choice is important. <br />
+> **Apple’s control over its app ecosystem is a new type of monopoly that’s hard to understand for lawmakers, and difficult for us to fight back against — because there simply isn’t a way out of these restrictions when the company controls both the distribution method and the platform itself**.
+> <cite>[Apple is Trying to Kill Web Technology - Owen Williams (November 2019) ](https://onezero.medium.com/apple-is-trying-to-kill-web-technology-a274237c174d) <br />(emphasis added)</cite>
+
+> **It's seemingly deliberate and about protecting App Store revenue**. <br />
+> … <br />
+> With IE now out of the way, the **distinction of ‘most-hated browser’ goes to Apple’s Safari** – which all along had been a close second to IE. <br />
+> … <br />
+> In a similar vein, **Safari has consistently lagged behind competing browsers in supporting modern web APIs and features**, presenting considerable challenges for developers wanting to create products that work consistently across all the major browsers (Chrome, Edge, Firefox, and Safari). <br />
+> … <br />
+> **Apple dragged their feet in adding support for PWAs in Safari**, and when they finally did, **limited the capabilities of a PWA so that native-like app functionality wouldn’t be possible, like notifications or a home screen icon shortcut – to name just a few of the many restrictions imposed by Apple**.
+>
+> But it goes beyond that. On **iOS, the only web rendering engine allowed is Apple’s own WebKit, which runs Safari**. Third-party iOS browsers such as Chrome can only use WebKit, not their own engines (as would be permitted in Windows, Android, or macOS). And it’s WebKit that governs PWA capabilities. <br />
+> … <br />
+> The reason for Apple’s self-imposed limitations on PWA-related web APIs? They’ll tell you they’re for user privacy reasons, which may be valid in certain cases. <br />
+> … <br />
+> **But most of us know the dominant reason is because fully-capable PWAs would compete against the iOS App Store – robbing Apple of 30% cut in revenue it rakes in when an app is purchased, or an in-app purchase is executed**. <br />
+> … <br />
+> **Web developers and engineers have long lamented about slow or lack of support of key web APIs and CSS features** that are commonly available with other browsers. <br />
+> … <br />
+> > Apple don’t give a f\*\*k about any modern APIs. PWA, streams, who the f\*\*k needs that? **Well, dear Apple, a f\*\*king lot of web devs need that nowadays**.
+> > <cite>Reddit User</cite>
+>
+> … <br />
+> Take WebRTC, for example. WebRTC is prominently used in video and audio communications over the web. It’s also used to send files, and share screen content.
+>
+> **Apple took years to finally add WebRTC support to Safari**, far enough behind Chrome and Firefox that it **practically became a running joke among developers** and even industry observers.
+>
+> Despite the support now available, **WebRTC is known to be buggier on Safari desktop compared to other browsers**. Developers have found it a mess to support in iOS that it’s practically not even worth the effort.<br />
+> … <br />
+> I often read about developers frustrated with the many bugs in Safari’s implementation of web APIs and CSS features, and in particular, the slowness of seeing them addressed.
+>
+> > **How are we supposed to keep up with this? Isn’t Apple one of the richest company in the world? Invest in your f\*\*king browser**.
+> > <cite>Reddit user</cite>
+>
+> … <br />
+> But not exactly surprising either, given that **Apple has staked its future on service-based revenue that includes sales generated from the App Store**.
+> <cite>[For developers, Apple’s Safari is crap and outdated - Perry Sun (July 2021)](https://blog.perrysun.com/2021/07/15/for-developers-safari-is-crap-and-outdated/) <br />(emphasis added)</cite>
+
+
+
+## 6. Negative Consequences for Consumers and Businesses
+
+It’s worth taking a moment to discuss why holding back the Web as an application platform, banning the rival browsers and having the iOS App Store be the only viable development platform on iOS is causing real harm to both consumers and businesses.
+
+
+
+### 6.1. Blocks the web from being an interoperable applications platform
+
+The Web could be an **interoperable platform** for applications on mobile devices but due to the lack of competition and key features being withheld it is incredibly hard (if not impossible) for them to compete with the App Stores. Safari has no competition from rival browsers on iOS. All the third-party browsers on iOS are essentially Safari (a specific Apple provided and mandated version of WebKit) under the hood. iOS Safari has a significant mobile web market share around the world (around 50% in the UK and the US, up to 75% in Japan). This is important as bugs and missing features in Safari can not be avoided (as all the browsers on iOS are Safari). Safari has many bugs and seriously lags behind its competitors' feature set.
+
+It's **hard for businesses to justify supporting features that 30-75% of their customers can't use**. This means if Safari doesn't support it then businesses don't want to use it. Additionally iPhone/iPad owners tend to be wealthier and spend more on software, businesses tend to follow revenue so Apple users have an outsized influence. This means that Apple's Browser Ban is not only holding web-apps back on iOS but also on Android.
+
+As a result many businesses feel obligated to reproduce their Web Apps as iOS Native Applications.
+
+
+
+### 6.2. Maintenance/Development Cost for Multi-Platform Applications
+
+Native iOS Apps have to be written in Apple created languages (Swift/Objective C) and system APIs that are specific to iOS. You can not run an iOS Application on an Android device (typically written in Java). Web Apps however only have to be written once, in one language and then can run on any device.
+
+In order to support multiple platforms for their application (without using Web Apps) a business will need to produce separate applications for iOS, Android and Windows. This typically involves expanding the team and having multiple code bases effectively multiplying the workload. Keeping multiple code bases in sync is also difficult and time consumer even for large businesses.
+
+This can increase by 2-5 times the development and maintenance cost. These costs must be passed onto consumers. For some smaller businesses it can cause the product not to be produced at all. Users also suffer lower quality applications because companies have to split their resources for developing and maintaining applications between two or three platforms, while they could have focused them on only one application.
+
+
+
+### 6.3. Small teams might be forced in iOS Exclusives
+
+Due to the cost mentioned in the previous section some small teams may decide to produce an iOS exclusive. This entrenches Apple’s lock-in and makes it harder for developers to reach a wider audience. Apple has a lot of leverage since iOS captures a significantly high amount of user time and attention, iOS users are wealthy and for businesses they represent an audience that cannot afford to under-serve. iOS is not an ecosystem that any developer is likely to be able to ignore.
+
+
+
+### 6.4. Gatekeeper Tax
+
+Additionally the business must then pay 15-30% of their revenue to Apple (further increasing costs by up-to another 44% for users).
+
+For example, imagine you require $10 per user to cover the costs of developing, publishing and maintaining an Application. The Application Store that you are selling your App in decides to add a 30% fee. In order to still receive $10, you now need to charge $14.2, which is a 42% price increase for the end user. However the actual price increase will be higher as when you increase the price by 42% you will lose a percentage of users as you move to a higher position on the demand curve, causing the equilibrium price to be even higher.
+
+
+
+### 6.5. Applications Banned on Apple’s whim
+
+> there’s no safety, security or privacy issue - Apple just doesn’t like those apps.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> It should not surprise you to know that Apple’s interpretation of its text often seems capricious at best and at worst seems like it’s motivated by self-dealing.
+> <cite>[Dieter Bohn - The Verge](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)</cite>
+
+Apple effectively [ban certain categories](https://www.theverge.com/2020/9/18/20912689/apple-cloud-gaming-streaming-xcloud-stadia-app-store-guidelines-rules) of Applications they don't like or that potentially [compete with their own offerings](https://www.theverge.com/2021/9/16/22676706/apple-watch-swipe-keyboard-flicktype-lawsuit-kosta-eleftheriou).
+
+
+
+### 6.6. App Store Review Process
+
+> there are endless horror stories around curation of the store. Apps are rejected in arbitrary, capricious, irrational and inconsistent ways, often for breaking completely unwritten rules.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> There's a lot of talk about the 30% tax that Apple takes from every app on the App Store. The time tax on their developers to deal with this unfriendly behemoth of a system is just as bad if not worse
+> <cite>[Samantha John - CEO Hopscotch](https://twitter.com/samj0hn/status/1431001795904561160)</cite>
+
+The App Store review process can be an extremely stressful and chaotic experience for businesses and developers despite problems with **actually [stopping malware](https://habr.com/en/post/580272/)**.
+
+
+### 6.7. Lawsuits and Criticisms
+
+Apple may choose to boot developers who sue or publicly criticize them. This can make publicly disagreeing with Apple scary, when they can snuff out your access to half your mobile users with little recourse.
+
+> Apple has blacklisted Epic Games from returning to its App Store ecosystem indefinitely despite the games developer saying it would disable its own payments system, according to a series of emails published on Twitter and a blog post by Epic CEO Tim Sweeney. <br />
+> … <br />
+> One of the published emails allegedly sent by Apple's legal representatives -- dated September 21 -- said the games developer's apps, such as its flagship game Fortnite, would not be allowed to return to the App Store until the US lawsuit was finalised.
+> <cite>[Campbell Kwan - ZDNet](https://www.zdnet.com/article/apple-bans-epic-games-from-app-store-until-all-litigation-is-finalised/)</cite>
+
+> In Sweatshop HD’s case, what is in fact a tasteful commentary aiming to raise awareness of modern-day manufacturing commissions through bright, addictive gameplay mechanics — in other words, an artistic statement — is being banned because Apple seemingly doesn’t want that awareness being raised.
+> <cite>[John Brownlee - Cult of Mac](https://www.cultofmac.com/220790/why-apples-reason-for-kicking-a-sweatshop-game-out-of-the-app-store-is-total-hypocrisy/)</cite>
+
+
+
+## 7. Apple's Incentives
+
+### 7.1. Advantages of the status quo for Apple
+
+> Apple gains a lot by slow-walking progressive web apps on the iPhone
+> <cite>[Russell Brandom - The Verge](https://www.theverge.com/2021/5/27/22454959/epic-apple-trial-recap-video-tim-cook-xbox-playstation-business#:~:text=APPLE%20GAINS%20A%20LOT%20BY%20SLOW-WALKING%20PROGRESSIVE%20WEB%20APPS%20ON%20THE%20IPHONE)</cite>
+
+Businesses that want to have applications on Apple mobile devices are forced to develop Apple native applications, which provides the following advantages to Apple:
+
+* **Business Lock-In** <br />
+Businesses have to go through the AppStore and provide Apple 15-30% of their revenue, which represents a significant share of Apple's revenue (estimated at [$64 billion in 2020](https://www.theverge.com/2021/1/8/22220873/apple-2020-app-store-revenue-60-billion-dollars)). Preventing Web Apps from being a viable alternative to native apps also allows Apple to maintain a high commission rate, as it is acknowledged in internal Apple emails that they are [unable to charge such an amount on other systems which have competition](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email) for their App Store. <br />
+Not only is iOS too large of a percentage of the mobile market to ignore, iOS users are typically more valuable because they spend more money. Combined with the high cost of developing a native app for iOS, development companies will often target iOS first and then only optionally build apps for other platforms **if they have the budget, expertise and staffing to do it**. <br />
+This gives Apple an advantage over competing mobile ecosystems by enriching its exclusive application ecosystem which it can then use to push sales of its mobile devices. Web Apps do not offer this lock-in because they work on all devices regardless of manufacturer and operating system.
+* **Consumer Lock-In** <br />
+They prevent Apple devices owners from switching to competitor mobile devices and operating systems as iOS Apps must be written for iOS. Many iOS apps never get rewritten for Android, so they are not available (It's very expensive to write the same App 2-3 times in different languages).
+* **Control** <br />
+Apple can **ban** categories of applications for no reason other than they don’t like them (game streaming for example). <sup>3</sup>
+* **Barriers to Entry** <br />
+They prevent the emergence of competing mobile operating systems, because many applications are only available on iOS and since they are not interoperable, emergent competitors have an insurmountable disadvantage since they don’t have access to a library of useful apps. This is arguably one of the biggest reasons **why Microsoft’s Windows Phone operating system failed** - Microsoft never managed to convince companies to invest in building and maintaining apps for yet another mobile operating system. Even a juggernaut like Microsoft was not able to break into the mobile operating systems market.
+* **Google Search Engine Revenue** <br />
+Apple have a $15B annual deal with Google to set Google as the default search engine on iOS Safari (9% of Apples Annual Gross Profit)
+* **Cost Cutting to boost margins on hardware** <br />
+By only allowing Safari to mint subprocesses Apple can save money on RAM <sup>4</sup>
+
+> <sup>3</sup> But some seem to be just personal preference, or taste - most obviously, the decision in the last few weeks to block streaming games services from Microsoft and Google. This may partly be about revenue, but the real issue seems to be that Apple thinks that games on iOS ’should’ use native APIs, and, perhaps, that they ‘should’ work without you needing to buy a separate games controller. But whatever it is, there’s no safety, security or privacy issue - Apple just doesn’t like those apps.
+>
+> One indication of Apple's control over developers is the fact they stay despite their many complaints.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> <sup>4</sup> Re-using the WebKit binary maximizes the sharing of "code pages" across processes. Practically speaking, this allows more programs to run simultaneously without the need for Apple to add more RAM to their devices. This, in turn, pads Apple's (considerable) margins in the construction of phones
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/08/webkit-ios-deep-dive/#:~:text=re-using%20the%20webkit%20binary%20maximizes%20the%20sharing%20of%20%22code%20pages%22%20across%20processes.%20practically%20speaking%2C%20this%20allows%20more%20programs%20to%20run%20simultaneously%20without%20the%20need%20for%20apple%20to%20add%20more%20ram%20to%20their%20devices.%20this%2C%20in%20turn%2C%20pads%20apple%27s%20(considerable)%20margins%20in%20the%20construction%20of%20phones)</cite>
+
+
+
+### 7.2. Microtransactions and “Whales”
+
+Many have speculated that Safari's lack of funding and functionality is to protect App Store revenue. Apple’s marketing and legal teams push the ideas that it’s their thriving App Store marketplace and curation that brings income to developers as a justification for the 30% tax that is applied but then use privacy and security as reasons they need to block third-party App Stores.
+
+Despite Apple’s marketing claiming a thriving App Store marketplace it recently came to light in the Epic vs Apple trial that **72% of all App Store revenue** comes from **free to play games**.
+
+> 80% of that was from games, mostly in the US and north-east Asia, and mostly on iPhone. There’s no clear reason to think the proportions have changed much since then, except that China is probably bigger (Apple had only just added support for Alipay in 2016).
+>
+So, this is mostly games, and, from other disclosures, over 90% free-to-play.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2021/7/8/app-store)</cite>
+
+This would indicate that the majority of revenue comes from mobile gaming whales, which has **parallels with problematic gambling**.
+
+> A mobile gaming whale is someone who spends a lot of microtransactions. So-called “whales” are the main target for microtransactions in free-to-play games, for example; they're the ones who buy booster packs, cosmetics, etc. Tons of them.
+> <cite>[Mihovil Grguric - CEO of Udonis Inc (A mobile apps marketing agency)](https://www.blog.udonis.co/mobile-marketing/mobile-games/mobile-games-whales)</cite>
+
+Whether or not the motivation is to protect this revenue source, the browser ban and the current state of Safari is having profound negative effects. Apple hides behind security and privacy but [Apple does not even develop features which have no possible security or privacy concerns](https://httptoolkit.tech/blog/safari-is-killing-the-web/).
+
+All of this comes back to competition. Because Apple has effectively banned the competition, they are under no pressure to produce a competitive browser that might threaten the App Store monopoly. Despite Apple’s claim that the App Store provides security and privacy [others](https://www.theverge.com/2021/4/21/22385859/apple-app-store-scams-fraud-review-enforcement-top-grossing-kosta-eleftheriou) have found the review process to be [ineffective](https://www.forbes.com/sites/gordonkelly/2021/04/07/apple-iphone-ipad-app-store-scam-warning-new-iphone-problem/?sh=7231e8a960aa). Web Apps can often provide more security and privacy than their native counterparts.
+
+
+
+### 7.3. Apple’s Pattern of iOS App Store Favoritism
+
+Looking through Apple's actions in iOS and Safari/Webkit a clear pattern of iOS App Store favoritism vs the Open Web emerges. Specifically:
+
+* They [don't develop key features](https://infrequently.org/2021/04/progress-delayed/) Web Apps need to compete with the App Store
+* They have [banned the other browsers](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.), thus blocking any other company from providing these features
+* They have [hidden the installation process](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.9e2hl5xfy1mf) for Web Apps and [refused](https://bugs.webkit.org/show_bug.cgi?id=193959) to improve it
+* They have made [linking](https://9to5mac.com/2021/07/08/developers-will-be-able-to-integrate-app-clips-into-websites-as-a-full-screen-card-with-ios-15/) to and installing native apps from the web much more [fluid and easy](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners)
+* They have astonishingly been [secretly buying advertising](https://www.forbes.com/sites/johnkoetsier/2021/11/12/apple-quietly-buying-ads-via-google-for-high-value-subscription-apps-to-capture-app-publisher-revenue/?sh=67998df71b52) for other companies without permission, deep linking to these companies iOS App Store Offerings and redirecting millions of dollars from these companies to Apple
+
+Far from being an unbiased party, as the gatekeeper of iOS, Apple has a lot to lose if the Web becomes a viable platform vs the iOS App Store. Apple's iOS App Store generated [$41.5 billion](https://www.macrumors.com/2021/06/29/app-store-revenue-h1-2021-42-billion/) revenue globally in the first half of 2021, representing 22.1% growth compared to the same period last year. Currently Apple can extract a [15-30% tax](https://www.bloomberg.com/news/newsletters/2021-05-03/apple-s-30-fee-an-industry-standard-is-showing-cracks) on all App Store purchases and have complete control over what is offered on the App Store. They can ban [both categories of Applications](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores) they don't like and ones that potentially [compete with their own offerings](https://www.businessinsider.com.au/apple-arcade-xbox-stadia-blocked-gaming-services-iphone-app-store-2020-10?r=US&IR=T).
+
+Given all this you might wonder why they bother supporting Web Apps at all. First removing support for Web Apps would look really bad and immediately attract the attention of regulators worldwide, second while it is awkward/impossible for Web Apps to compete with Native they are not a significant threat and finally it has proven to be a useful regulatory/legal shield as shown [here](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf), [here](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) and [here](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple).
+
+It could be argued this is an overly conspiratorial view of how Apple's management team thinks but recently uncovered emails show Apple's line of thinking on another topic, iMessage:
+
+> The #1 most difficult [reason] to leave the Apple universe app is iMessage … iMessage amounts to serious lock-in
+> <cite>[Unnamed Apple Employee](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)</cite>
+
+> iMessage on Android would simply serve to remove [an] obstacle to iPhone families giving their kids Android phones … moving iMessage to Android will hurt us more than help us, this email illustrates why.
+> <cite>[Craig Federighi - Apple's Senior Vice President of Software Engineering](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)</cite>
+
+
+
+## 8. Arguments Against Third-Party Browsers
+
+To our knowledge Apple has never published a detailed defense on why they feel justified in banning all rival third-party browsers from iOS. That said, the following three sections contain arguments that others have made on Apple's behalf.
+
+
+
+### 8.1. The Chromium Argument
+
+There is an idea being advocated that allowing Apple to ban all other rival browsers from iOS is desirable as it stops Google from dictating the future of the web via decisions made in Chromium.
+
+> One proposed solution is to prevent operating systems from banning particular browser engines and/or browsers. However, since the majority of non-iOS browsers are based on Google’s Blink browser engine, the current chair of the HTTP Working Group Mark Nottingham submits that any requirement for Apple to allow third-party browser engines on iOS is likely to result in even greater usage of Google’s Blink and therefore ‘a further concentration of market power by Google'.
+> <cite>[ACCC – Digital Platform Services Enquiry (September 2021)](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20March%202021%20interim%20report.pdf)</cite>
+
+This needs to be broken down to identify whether that is true or not and that depends on:
+
+1. Does Google allow for good governance of the project?
+2. Is Google's governance of the project inclusive?
+3. Does it allow for dissenting opinions?
+4. Can Google leverage its control over governance to introduce features that further it’s own goals?
+5. Can Google slip in features against the wishes of the other browsers which they can’t remove?
+
+This particular defense of Apple's Browser Ban has three issues.
+
+First, this argument implicitly acknowledges that iOS Safari is sufficiently underpowered and buggy that given the choice users would immediately jump ship to a rival browser. It also assumes that with the advent of competition on iOS that Apple wouldn’t invest deeply to make up for the ground they have lost in Safari.
+
+Second, other browsers are allowed on MacOS and Safari still maintains a healthy share of 60.4%, calculated by using StatCounter’s 2021 Oct data by dividing [Safari's market share on desktop](https://gs.statcounter.com/browser-market-share/desktop/worldwide/#monthly-202010-202110) by [macOS' desktop share](https://gs.statcounter.com/os-market-share/desktop/worldwide/#monthly-202010-202110).
+
+Third, the counter argument is that Samsung, Edge, Brave, Opera etc all maintain soft forks of Chromium and can **disable features** they don't like with flags and **add any feature** they want directly on top. They can continue to pull in changes and updates from Chromium they do like. Should governance of the Chromium project become unhealthy, all of these participants retain the credible ability to hard-fork Chromium and Blink the way the Chrome team forked from WebKit, and how Apple forked WebKit from KHTML.
+
+This is **very different** to the iOS Webkit situation where a **very specific version of Webkit** is **forced** on third-party browser vendors. Browser makers have **no recourse to change** the engine feature set, not even to enable or disable features that are available in the source code from which WebKit on the device was built. The **inability to differentiate** effectively, even via soft fork, is a major step down in competition for iOS browsers. Beyond soft and hard forks, in a market with functioning browser choice, there is nothing stopping a third-party from creating their own browser from scratch (beyond development cost).
+
+There is already **direct competition** between the Chromium browsers and they are diverging in what they offer consumers.
+
+Any argument that Apple makes suggesting that the situation with Webkit is equivalent to the situation with Blink / Chromium because Webkit is also open source **is false**. When Browser Vendors use Chromium in their Browser on Android, they decide what features are included. On iOS, only Apple decides. It’s the software that runs on real users' devices that’s important.
+
+Edge, Opera, Brave and other browser makers **freely choose** Chromium as their engine, and have invested in integrating their differentiated features with it, and into its shared development via open-source contributions.
+
+Although Google by accounts does pay Igalia to contribute to Webkit to improve compatibility issues, in general browsers should not be seriously expected to contribute to another rival browser engine and ecosystem that is being forced onto them while having no control over how they can use it and which features, whether adding or removing or modifying, make it onto iOS.
+
+To imply that browsers can simply contribute to WebKit negates the fact that Apple has exclusive control over the Safari WebView on iOS. For browsers on iOS what makes it into WebKit is irrelevant, it’s what functionality that is available within the Safari Webview that's important.
+
+
+
+#### 8.1.1. Microsoft Differentiates Edge from Chrome
+
+For example this is a list of all the features that Microsoft have [removed or replaced](https://9to5google.com/2019/04/09/chromium-edge-browser-disables-google-services/) from Chromium in Edge:
+
+{% image
+  "/images/walled-gardens/34_microsoft-chrome-edge-differences.png",
+  "List of many browser features under the title 'Services we replaced or turned off'"
+%}
+
+Additionally **Brave** has **added many privacy features** into their browser. A [research study](https://www.zdnet.com/article/brave-deemed-most-private-browser-in-terms-of-phoning-home/) analyzing browser privacy by Professor Douglas J. Leith of the University of Dublin reported that **Brave had the highest level of privacy of the browsers tested**.
+
+There is even code being added to the Chromium project that Chrome will not use but other browsers using Chromium want. For example Edge ships the requestStorageAccess API that Safari defined for ITP. Chrome has no intention to ever ship it. Yet code for it [has landed](https://groups.google.com/a/chromium.org/g/blink-dev/c/e5fu5Q06ntA/m/UUqPuA8hEQAJ) in Chromium.
+
+If anything the situation is analogous to Linux on the server where many different versions of Linux compete with each other for market share based on their differing feature sets while still being based and soft-forked from the same underlying entirely free and open-source software.
+
+The [API owners](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/API_OWNERS) of Blink are the ones that can make decisions about what new features are included in the Browser’s main engine. 6 of these owners’s work for Google, but the other 3 work for separate companies (Igalia, Microsoft and Opera). This means that Google has shared the governance of their project with external parties with a fairly [transparent process](https://www.chromium.org/blink/guidelines/api-owners).
+
+Webkit by comparison has an opaque governance structure and it is not clear if anyone outside of Apple has decision making capability when it comes to the project.
+
+
+
+#### 8.1.2. Blink and Webkit - Two Sides of the same Coin?
+
+A second variation of this argument is that, as many browsers on Android are Chromium based (and thus use the Blink layout engine), the situation with Blink on Android and Webkit on iOS is similar. In other words: “Most browsers on Android are Chromium, so why is it a problem that all browsers on iOS are Safari/Webkit?”
+
+For now let's mostly ignore that completely different browser engines (i.e Gecko) are allowed on Android.
+
+The reality could not be more different.
+
+On iOS, third-party browsers:
+
+* Can't pick their own browser engine
+* Can't pick which version of Webkit they wish to us
+* Can't turn browser engine features on or off using flags
+* Can't add entirely new browser engine features
+* Can't edit browser engine features
+* Can't entirely remove browser engine features
+* Don't even get all the features of Webkit that iOS provides Safari
+* Get a more restricted version of Webkit than the one iOS provides Safari (Safari and the WebView that browsers use do not get the same level of access)
+* Use a version of Webkit provided that is tied to iOS system updates as opposed to packaged with the third-party browser
+
+On Android, third-party browsers:
+
+* Can use their own browser engine
+* Can pick which version of Blink they wish to use (if they are using Blink at all)
+* Can turn browser engine features on/off using flags
+* Can add entirely new features to Blink
+* Can edit existing features in Blink
+* Can completely remove features from Blink
+* Don’t have to use Blink at all
+
+On iOS, only Apple has final say on what the web can and can not do, Not users, third-party browsers or developers.
+
+{% image
+  "/images/walled-gardens/35_chrome-non-google-commit-chart.png",
+  "A line chart showing non-google contributions to chrome from 2016 to 2021, averaging around 20%"
+%}
+
+Percentage and Number of non-Google commits in Chromium over the past 5 years
+
+
+
+### 8.2. Security
+
+Apple argues that allowing third-party browsers will worsen security on iOS. The general pitch is that additional browser engines expand the iOS attack surface. If they bring even one security flaw with them, that is one more way for iOS users to be attacked. <sup>5</sup>
+
+Browsers are incredibly complex, and all browsers have bugs and security vulnerabilities. Not all security vulnerabilities are equal, and many discovered by developers and security researchers are patched before they are abused in the wild. Browsers can be thought of as mini-operating systems that sit atop traditional OSes. They are application platforms as well as tools for browsing the web. They are exceptionally powerful and need low-level system access that other apps do not (or should not). Browser bugs can be leveraged to gain access to the device by exploiting security flaws. It is likely that all browsers have and will continue to have security vulnerabilities.
+
+Browser Vendors must be committed to high levels of security investment, reasonable response times for fixing security holes, and should actively maintain their browsers. Google, Mozilla, Microsoft, Opera, Samsung, and others have good track records on security. They promptly patch security flaws and transparently publish what they have done. This give us confidence that they can be trusted with the same sort of low-level API access they enjoy on every other major OS.
+
+**We are not suggesting a free for all**. Indeed, we do not necessarily support expanded API access for non-browsers. What we suggest is that well-staffed and secure rival browsers with proven track records be allowed to compete on a level playing field. Competition on security has driven security innovation in browsers for 20+ years, and responsible vendors are heavily incentivised to fix security issues or lose market share.
+
+When thinking about browser security vulnerabilities it is important to note it's typically very difficult to use a browser exploit against a user **who does not use that browser**. This means that when thinking about security of a system, it needs to be viewed through the lens of what is the weighted average of the severity of vulnerabilities in all the browsers offered, not the sum. Adding a new browser to the system can only make the security worse if its security is worse than the average, even if it increases the total number of vulnerabilities of any given severity. This is important because if you have an operating system with only one browser and then you allow an additional 5 browsers (complete with their engines) the number of vulnerabilities that the "average user" is affected by doesn't change, provided each browser vendor does not have dramatically worse security.
+
+Security is a nuanced and difficult topic. Not all vulnerabilities have equal impact, and in modern browsers, vulnerabilities must often be chained to put users at risk. Simple counts of vulnerabilities are not particularly helpful when comparing browser vendors.
+
+Apple has justified their Webkit restriction by stating they can roll out security patches faster than other browser vendors and that their browser is more secure than rival browsers. In order to persuasively argue a need to ban all rivals, Apple would **need to prove** that iOS Safari **rolls out security patches faster**, has **significantly better security**, and that the harm to users from allowing rival browsers is **significantly worse** than the **harm caused by lack of competition**. Apple must further demonstrate that the risks inherent to a browser monoculture are not material. Users who fear they may be under attack have no alternatives available today, and Apple must show this is net beneficial.
+
+There is reason to believe Safari security is not better than the competition, nor does Safari roll out patches faster.
+
+<sup>5</sup> For now let's exclude intentional [jail-breaking](https://en.wikipedia.org/wiki/IOS_jailbreaking), as that is more of a problem for Apple than it is for their users.
+
+
+
+#### 8.2.1. Safari Users are Exposed for Longer
+
+Safari updates are tied to the operating system ([an antiquated practice](https://en.wikipedia.org/wiki/Internet_Explorer_9)). This means to update the browser, users have to update the entire operating system.
+
+According to the [metrics regarding bugs filed by Google’s Project Zero team](https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html), Safari is the slowest major engine to fix issues and is significantly slower than others as delivering fixes through software updates.
+
+{% image
+  "/images/walled-gardens/42_histogram-of-days-from-fix-landed-to-shipped.png",
+  "A histogram showing how many days it takes Chrome, Firefox and Safari to ship security fixes to users"
+%}
+
+iOS users remain vulnerable to known bugs in Safari longer than users of alternative browsers on every other OS. This picture is made even darker by OS update rates. Since Safari requires a full operating system update, further hassle (and attendant delay) is introduced in getting patches into user’s hands than if the browser updated like a “normal app” (the standard on all other modern OSes). Safari requires the user to update their entire operating system, a process that makes the **device unusable for up-to 20 minutes**.
+
+
+
+#### 8.2.2. Apple does not patch older versions of iOS
+
+Users perform operating system updates less often than application updates (which can happen silently). Additionally users may choose not to update to the next major operating system release ([i.e iOS 14 to iOS 15](https://www.intego.com/mac-security-blog/why-doesnt-apple-want-people-to-upgrade-to-ios-15/)) meaning they can miss out on vital security patches. Because Apple does not always back-port patches to older OS versions, users that fail to endure heavyweight OS updates can fall behind on browser security updates on iOS.
+Of vital importance to security is shortening the length of time between a vulnerability being discovered and being patched for the end user. This is referred to as patch gap.
+
+> Ideally, the window of time between a public patch and a stable release is as small as possible.
+> <cite>[Tim Becker - Security Researcher](https://blog.theori.io/research/webkit-type-confusion/)</cite>
+
+Older versions of iOS do not always get the security patches provided to the latest version. For example [this chart](https://twitter.com/theJoshMeister/status/1454023794578706433) (reproduced below) shows a list of patches (many of them for Webkit) available in iOS 15 and *if* they are available in iOS 14. It is important to note that Apple **has not communicated this information to users**. As users are unable to choose alternative browsers, they are left insecure without warning, even though their browser may be “up to date”.
+
+The article titled "Apple’s Poor Patching Policies Potentially Make Users’ Security and Privacy Precarious” goes [into more detail](https://www.intego.com/mac-security-blog/apples-poor-patching-policies-potentially-make-users-security-and-privacy-precarious/).
+
+Apple says it never intended iOS 14 security updates to last forever, whereas Firefox and Chrome support far older devices. Since Edge, Vivaldi and Brave are built on the same platform as Chrome, they are likely to be identical or very similar in terms of security.
+
+{% image
+  "/images/walled-gardens/36_safari-cve-list.png",
+  "A spreadsheet view of reported vulnerabilities in iOS",
+  "centered"
+%}
+
+
+
+#### 8.2.3. Browser Code Execution Vulnerabilities
+
+{% image
+  "/images/walled-gardens/43_browser-code-execution-vulnerabilities.png",
+  "A histogram showing the number of browser code execution vulnerabilities in Chrome. Firefox and Safari since 2014"
+%}
+
+Code execution vulnerabilities range in severity, and as previously noted, often require “exploit chains” of multiple bugs to use, meaning that raw numbers are not the full story. Regardless, they can help inform a fuller picture.
+
+We look at the publically available data regarding code execution bugs since [the Blink/Webkit fork](https://blog.chromium.org/2013/04/blink-rendering-engine-for-chromium.html). Examining the trends for [Safari](https://www.cvedetails.com/product/2935/Apple-Safari.html?vendor_id=49), [Chrome](https://www.cvedetails.com/product/15031/Google-Chrome.html?vendor_id=1224) and [Firefox](https://www.cvedetails.com/product/3264/Mozilla-Firefox.html?vendor_id=452), we see that **Safari suffered the most reported vulnerabilities** in every year save 2016. The graph above focuses on code execution vulnerabilities because these are the most serious category.
+
+While not a conclusive picture about relative security, this data brings into doubt Apple’s claims that it is significantly better than the competition:
+
+> Chrome/Brave/Firefox are required to use the default WebKit/JS [to run on iOS, making them merely skinned versions of Safari]. If Apple isn't going to put in the work necessary to protect users then they should let others do so.
+> <cite>[Paul Wagenseil - Tom’s Guide](https://www.tomsguide.com/opinion/your-iphone-is-less-safe-than-it-was-yesterday-and-thats-good)</cite>
+
+{% image
+  "/images/walled-gardens/44_browser-code-execution-vulnerabilities.png",
+  "A pie chart showing the ratio of browser code execution vulnerabilities between Chrome. Firefox and Safari since 2014"
+%}
+
+There are many caveats. First, the [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) database only includes vulnerabilities that are reported or named. Vendors may choose not to assign a CVE number to every vulnerability and there have been reports of security engineers who have complained that Apple hasn’t in the past.
+
+It is also possible that Apple’s platform may be under more scrutiny since Apple promotes itself as being security and privacy focused. Apple users also tend to be wealthier, adding to the potential value of an exploit to bad actors, incentivizing more investment by researchers.
+
+The more scrutiny a system recipes, the more likely vulnerabilities are to be found, so looking at bug counts is unreliable. Apple, however, is making extraordinary claims regarding browser security and so **the onus is on Apple to prove it**.
+
+
+
+#### 8.2.4. Apple has a Poor Relationship with External Security Experts
+
+The security of iPhones is one of Apple’s key marketing claims. According to [two dozen security researchers](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/) who spoke on the condition of anonymity, Facebook, Microsoft and Google publicize their programs and highlight security researchers who receive bounties in blog posts and leaderboards. They hold conferences and provide resources to encourage a broad international audience to participate. In contrast, Apple, already known for being tight-lipped, limits communication and feedback on why it chooses to pay or not pay for a bug, according to security researchers who have submitted bugs to the bounty program.
+
+Apple reportedly has a considerable bug backlog:
+
+> You have to have a healthy internal bug fixing mechanism before you can attempt to have a healthy bug vulnerability disclosure program. What do you expect is going to happen if they report a bug that you already knew about but haven’t fixed? Or if they report something that takes you 500 days to fix it?
+> <cite>[Moussouris - Helped create Microsoft's Bug Bounty Program](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> It seems like Apple thinks people reporting bugs are annoying and they want to discourage people from doing so
+> <cite>[Tian Zhang - an iOS software engineer](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> Apple’s closed-off approach hinders its security efforts
+> <cite>[Dave Aitel - co-author of “The Hacker’s Handbook](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> To me, the bigger takeaway is that Apple is shipping iOS with known bugs, And that security researchers are so frustrated by the Apple Bug Bounty program they are literally giving up on it, turning down (potential) money, to post free bugs online. It's not that Apple doesn't have resources or money to fix this, Clearly it's just not a priority to them.
+> <cite>[Patrick Wardle - Security Expert](https://www.theregister.com/2020/07/01/apple_macos_privacy_bypass/)</cite>
+
+> Apple is slow to fix reported bugs and does not always pay hackers what they believe they’re owed. Ultimately, they say, Apple’s insular culture has hurt the program and created a blind spot on security.
+> <cite>[Reed Albergotti - Washington Post](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> I want to share my frustrating experience participating in Apple Security Bounty program. I've reported four 0-day vulnerabilities this year between March 10 and May 4, as of now three of them are still present in the latest iOS version (15.0) and one was fixed in 14.7, but Apple decided to cover it up and not list it on the security content page. When I confronted them, they apologized, assured me it happened due to a processing issue and promised to list it on the security content page of the next update. There were three releases since then and they broke their promise each time.
+> <cite>[Denis Tokarev](https://habr.com/en/post/579714/)</cite>
+
+
+
+#### 8.2.5. Every other OS can manage to allow competing browser Engines
+
+Finally, **every other OS** in wide use – including Windows, ChromeOS, Android, Linux, and Apple’s own macOS, – **allow competing browser engines** while remaining secure. Surely Apple can find alternative measures to remain secure without banning the competition.
+
+
+
+#### 8.2.6. Summary
+
+Based on the information above Apple:
+
+1. Has the longest delay in patching vulnerabilities
+2. Experiences the largest number of code execution vulnerabilities
+3. Doesn’t patch vulnerabilities in their browser for older versions of iOS
+4. Has a poor relationship with external security experts
+
+It is hard to argue that iOS Safari **even matches the security of other major rival browser vendors**. It is impossible in our view for Apple to argue that iOS Safari's security advantage over other vendors is so extreme that it justifies the clear anti-competitive practice of simply banning the competition, considering the negative externalities that it imposes on consumers.
+
+
+
+### 8.3. Privacy
+
+Apple could argue that it can not allow third-party browsers (complete with their own engines) because they will [provide users with functionality](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.u5ygilw20uu2) that Apple believes only Native Apps should have.
+
+Apple's public position on denying these APIs is that they could be used to fingerprint the user. As is extensively argued in <!-- TODO --> [this section](#), Apple's position is wildly inconsistent between Web and Native. There is a strong case that the current protections in other browsers for these features are far stronger than the ones Apple provides for analogous Native features.
+
+Additionally Apple astonishingly holds this position while providing its own [opt-in fingerprinting solution to Native Apps](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.zhli1xk46625) and poorly policing when users who reject being tracked are ignored.
+
+
+
+#### 8.3.1. Native vs the Web
+
+Apple is not doing enough to protect user’s privacy in native apps while at the same time stifling Browsers and Web Apps.
+
+Tracking is far more pervasive and allowed in native than it is on the web. Privacy is incredibly important for users and more needs to be done especially on the native ecosystems however it should not be used as a tool to defend against competition.
+
+> By now you probably know that your apps ask for permission to tap into loads of data. They **request device information, like advertiser IDs**, which companies use to build marketing profiles.
+>
+> **you’re also exposing your sensitive information to dozens** of other technology companies, ad networks, data brokers and aggregators
+>
+> And **every app is potentially leaking data to five or 10 other apps**. Every S.D.K. is taking your data and doing something different — combining it with other data to learn more about you. It’s happening even if the company says we don’t share data. Because they’re not technically sharing it; the S.D.K. is just pulling it out. Nobody has any privacy.
+> <cite>[Charlie Warzel - New York Times](https://www.nytimes.com/2019/09/24/opinion/facebook-google-apps-data.html) <br />(emphasis added)</cite>
+
+> The simple fact is, the data you give to apps powers a massive economy worth hundreds of billions of dollars, which is hundreds of billions of reasons for it not to change — until and unless it’s forced to.
+> <cite>[Sara Morrison - VOX](https://www.vox.com/platform/amp/recode/22587248/grindr-app-location-data-outed-priest-jeffrey-burrill-pillar-data-harvesting) <br />(emphasis added)</cite>
+
+> But this is only the tip of the iceberg. Now the app stores should take the next step: ban SDKs from any data brokers that collect and sell our location information.
+>
+> There is no good reason for apps to collect and sell location data, especially when users have no way of knowing how that data will be used. We implore Apple and Google to end this seedy industry, and make it clear that location data brokers are not welcome on their app stores
+> <cite>[Bennett Cyphers - Electronic Freedom Foundation](https://www.eff.org/deeplinks/2020/06/apples-response-hey-showcases-whats-most-broken-about-apple-app-store)</cite>
+
+Apple is wildly inconsistent in how it approaches privacy on Native and on the Web. Apple is very happy to take measures that break functionality for the Web that they would never even consider for Native Apps (i.e completely removing bluetooth). Additionally Native Apps have comparably weak permissioning compared to that provided by browsers. Finally Apple provides its own opt-in fingerprinting solution for Native Apps for the purpose of advertising.
+
+Apple's commitment to privacy on the web is admirable but the uneven enforcement between the iOS App Store where they command a 15-30% tax and the Web where they have none **implies that it is simply a tactical tool to block competition**.
+
+
+
+## 9. The Web Can Be Capable
+
+> The fact that web apps aren’t able to fully compete with iOS apps **is an Apple problem, not a web problem**
+> <cite>[Richard MacManus - NewsStack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation/) <br />(emphasis added)</cite>
+
+
+
+### 9.1. Photoshop
+
+Using various new standardized web technologies, Adobe has now brought a public beta of [Photoshop to the web](https://web.dev/ps-on-the-web/).
+
+It’s important to note that Adobe did not rebuild Photoshop from scratch. This is real photoshop using their 31 year old code-base along with its decades of investment.
+
+{% image
+  "/images/walled-gardens/37_photoshop-on-web.png",
+  "A screenshot of Photoshop running in a web-browser, featuring a happy looking elephant"
+%}
+
+> The simple power of a URL is that anyone can click it and instantly access it. All you need is a browser. There is no need to install an application or worry about what operating system you are running on. For web applications, that means users can have access to the application and their documents and comments. This makes the web the ideal collaboration platform, something that is becoming more and more essential to creative and marketing teams.
+> <cite>[web.dev](https://web.dev/ps-on-the-web/#:~:text=The%20simple%20power%20of%20a%20URL%20is%20that%20anyone%20can%20click%20it%20and%20instantly%20access%20it.%20All%20you%20need%20is%20a%20browser.)</cite>
+
+This was made possible by a few web standards:
+
+
+
+#### 9.1.1. WebAssembly
+
+[WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is a new type of code that can be run in modern web browsers — it is a low-level assembly-like language with a compact binary format that runs with near-native performance and provides languages such as C/C++, C# and Rust with a compilation target so that they can run on the web. It is also designed to run alongside JavaScript, allowing both to work together.
+
+Using this Photoshop was able to get their decades of C++ code and port it into a sandboxed environment for their Web App.
+
+
+
+#### 9.1.2. WebGL and WebGL2
+
+[WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics. Photoshop needed this to deliver competitive performance for its image compositing system.
+
+
+
+#### 9.1.3. SIMD Instructions
+
+This is a [specialized instruction set](https://developer.mozilla.org/en-US/docs/Glossary/SIMD) that can improve performance for certain types of parallel code. For Photoshop SIMD provides a 3–4× speedup on average and in some cases a 80–160× speedup.
+
+
+
+#### 9.1.4. File System Access API - Private File System
+
+Given how large Photoshop documents can be, Photoshop needs the ability to dynamically move data from on-disk to memory as a user pans around. This new [origin trial](https://web.dev/file-system-access/#accessing-files-optimized-for-performance-from-the-origin-private-file-system) allowed Photoshop to have a high performant private file system that it could access via the API. This allows competitive performance on a wide range of devices.
+
+Photoshop’s reputation as a demanding application demonstrates that nearly any sort of program can be delivered today as a Web App on a capable browser. Given the speed of progress in the best browsers, it’s hard to imagine that the gap between Native and Web in terms of performance/capability will not continue to shrink.
+
+## 10. The Future of the Web
+
+If effective competition was restored to the mobile web then the advantages to users are:
+
+**Considerably lower development and maintenance costs**
+
+Being able to develop a single interoperable application and deploy it to 5 operating systems simultaneously reduces costs by potentially 2-5 times, perhaps more when the costs of waiting for each app store to approve updates are factored in. Maintaining multiple code bases in different languages and navigating the rules of multiple app stores is expensive and time consuming.
+In a well functioning market, these savings should be passed on to users.
+
+**Higher quality**
+
+Less time wasted on duplicated code and keeping different versions of the code base in sync means more time can be focused on quality. This is doubly true for important concerns like accessibility and security reviews which tend to require specialist attention. Concentrating the attention of development teams on a single codebase has a positive effect on these attributes.
+
+**Interoperability**
+
+The same applications, running from the same codebase, deployed the same way can become the norm for mobile application development the way it has been on the desktop for nearly a decade, powered by the web.
+
+**Reduced Lock-In**
+
+If more applications are cross platform then users have less tying them to a particular OS or hardware vendor. Application portability reduces friction between moving OSs and improves competition in that space too.
+
+**More private and secure**
+
+Browsers are heavily sandboxed and historically place less trust in Web Apps than native platforms grant to apps by default. Web APIs, unlike their Native App counterparts, have a long track record of giving as little access as necessary, requiring direct user permission for access to powerful or dangerous capabilities, and deploying anti-abuse mitigations faster than the pace of OS patch uptake.
+
+**Lower platform taxes for commodity capabilities**
+
+If Web Apps were allowed to compete effectively, enormous pressure would be placed on platform taxes for the large majority of applications that do not require truly proprietary or exclusive functionality not available on other devices.
+
+With effective competition App Stores would only be able to charge a tax proportional to the value (in terms of review, cataloging, payment processing, and access to unique hardware) that users perceive they provide. It is unlikely that in this future Apple would have enough market power to maintain a 30% tax, something akin to VISA or Mastercards 2-3% is more likely.
+
+**A level playing field for small developers**
+
+Developing for multiple platforms in different languages almost immediately necessitates larger teams making life difficult if not impossible for smaller developers to provide cross platform support. This reduces the number of firms that can produce and market software effectively.
+
+**More innovation**
+
+Lowering the cost of development allows more market participants and experimentation, leading to increased innovation.
+
+
+
+### 10.1. Multiple Competing Browsers
+
+If Apple allowed multiple rival browsers (complete with their engines) then iOS could actually have browser competition. Having multiple browsers competing on a platform is desirable. Competition is what drives improvements in utility, performance, privacy and security. iOS Safari currently faces almost no competitive pressure.
+
+Apple will likely make arguments that their Safari browser is more privacy focused than other browsers but competition will make the web more private, not less. Browsers, like for example Brave and Firefox could compete on which is the most private. Users not Apple can make decisions on the trade offs between utility, performance, privacy and security. Browsers are by default considerably more private, sandboxed and secure than Native Apps.
+
+Chrome, Edge, Opera, Brave and Samsung Browser are not the same despite being all based on Chromium. They are competing to differentiate themselves in utility, performance, privacy and security on top of a shared underlying open source and free codebase.
+
+Competitive pressure will force iOS Safari to improve or if it doesn't, offer users recourse to switch to alternate browsers. This would provide Apple the incentive to keep pace with the other browsers and give consumers a means of voting with their feet by moving to a competing browser if they fail to do so.
+
+Competition is what drivers innovation and delivers the most value to consumers.
+
+
+
+### 10.2. Competing App Stores without Sacrificing User Safety
+
+There is a [proposed specification](https://m.youtube.com/watch?v=FtVhbLya49w) called the [Web Install API](https://github.com/PEConn/web-install-explainer/blob/main/explainer.md) to allow Web Apps to install other Web Apps (via browser prompts and user interaction). No capability beyond the APIs needed for competing browsers to install PWAs to an OS (currently a private API that Apple does not expose to competing browsers on iOS) are needed.
+
+This is important for two reasons. First, it allows developers to produce installable App Stores that are themselves Web Apps, and therefore safe and secure by default. Also, it would allow companies to offer collections (“suites”) of Web Apps that are seperate products on separate domains; for example, Adobe’s Creative Cloud Suite (Photoshop, Illustrator, Lightroom, Spark, Fonts, etc.).
+
+This specification is at a very early stage, but we believe that in the long term this feature will greatly enhance Web Apps ability to compete with NativeApps. This adds vital functionality to Web Apps in terms of an alternate system to the gatekeepers App Store of user reviews, trust, cataloging and potentially payment.
+
+Ensuring that APIs are made available to competing browsers to facilitate this open, interoperable future should be a goal of regulatory oversight because, unlike sideloading of native apps, it charts a safe and secure middle-way for true competition, low developer taxes, and improved interoperability for users.
+
+{% image
+  "/images/walled-gardens/38_proxx-install-example.png",
+  "A screenshot of the prox.app website on an Android device, with an install banner at the top of the view",
+  "centered"
+%}
+
+
+
+### 10.3. Web App / Native App Feature Parity
+
+For the web to truly provide effective competition to native App Stores the browsers need access to various system APIs to be able to provide feature parity.
+
+For chat and social applications:
+
+* Screen Wakelock
+* Push Notifications and Unread Count badging
+* Stable (non buggy) webRTC
+
+For applications that need to communicate with users devices:
+
+* Web Bluetooth
+* Web USB
+* Web MIDI
+* Web Serial
+
+For gaming and other graphic intensive applications:
+
+* Fullscreen API for `<canvas>` and other non-`<video>` elements
+* WASM Threads, Shared Array Buffers, and SIMD
+* WebXR
+* Offscreen Canvas
+* WebGPU (arriving in other engines this year)
+
+
+
+#### 10.3.1. Integrated Web App Permissions
+
+Finally to make the experience truly equivalent and to enable users to sensibly manage security and permissions, users need per an installed Web App permissioning built into the operating system. Permissions that are exclusive to browsers (i.e. don’t have an Native App equivalent) can be handled by a webview to the browser that installed the application, alternatively each browser could provide an implementation of this page to the OS.
+
+Example of iOS permission settings screen:
+
+{% image
+  "/images/walled-gardens/39_ios-permission-settings.png",
+  "A view of the iOS permission settings screen for WeChat showing toggles for many iOS features",
+  "screenshot", null,
+  [150, 200, 300],
+  "150px"
+%}
+
+
+
+## 11. Potential Regulatory Solutions
+
+To bring effective competition to both browsers on iOS and to allow Web Apps to effectively compete with the App Store (as Apple has suggested they can), regulation should mandate opening up iOS to true third-party browsers, complete with their own engines.
+
+Further, Apple should be prohibited from enforcing restrictions that would prevent competing engines from delivering Web Apps at feature parity with Native Apps. Regulation should provide for prudent privacy and security considerations to be handled in arbitration should parties not be able to come to speedy agreement.
+
+
+
+### 11.1. Mandating iOS Safari support specific standards is the wrong approach
+
+Web Standards evolve quickly, spurred on by competing browser makers working with developers. This involves collaboration in standards bodies to improve compatibility, however if each Browser vendor had to wait until there was complete agreement between every vendor for each of the various standards (and each standards body operates differently), it would be possible for a vendor (e.g. Apple) to game these processes especially in areas where they have an outsized influence to prevent the progression of these standards.
+
+Typically, cutting edge features are deployed by browser makers in their **own engines first**, then, using real world feedback over several years, eventual standards are created. No feature starts out as a web standard.
+
+> Web Standards are voluntary. The force that most powerfully compels their adoption is competition, rather than regulation. This is an inherent property of modern browsers. Vendors participate in standards processes not because they need anyone else to tell them what to do, and not because they are somehow subject to the dictates of standards bodies, but rather to learn from developers and find agreement with competitors in a problem space where compatibility returns outsized gains
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2020/07/why-ui-isnt-specified/)</cite>
+
+No one can predict what web technologies will be important in the future, and disagreements between browser makers on the exact path forward are reasonable and expected. It is very difficult, if not impossible for regulators to predict which standards will be the most important and what their exact definition will end up being. It's a subtle and complex topic.
+
+So rather than (as a regulator) mandating that a gatekeeper must support a particular web standard, a better approach is regulating to enable effective competition on the gatekeepers operating systems **both between rival browsers** and **between Web Apps and Native Apps**. Then allow market forces to push forward the changes (new web standards) most beneficial to end users.
+
+
+
+### 11.2. Predicted Response from Apple
+
+Apple on their iOS platform, has a strong incentive to not allow Third-Party Browsers or capable Web Apps on iOS as this would:
+
+1. Allow open competition with the App Store where Apple currently receives between 15% - 30% of the all revenue.
+2. It would endanger their [15 billion USD](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/) dollar search deal with Google Search (9% of Apple’s 2020 Gross Profit).
+3. Reduce developer lock-in to Apple’s ecosystem as Web Apps are interoperable with other manufacturers devices and reduce the number of developers that are only exclusively targeting iOS as a platform.
+4. Reduce user lock-in to their ecosystem as users could migrate with their apps and data to other devices which also supported the apps they use.
+
+This is covered in more detail in [this section](#apple's-incentives).
+
+Apple is incentivized to use security and privacy as roadblocks to competition including to block Third-Party Browsers, Web Apps and their capabilities. These roadblocks could be spurious and either offer no or exceptionally limited privacy or security benefits to users while depriving them of useful functionality.
+
+When there are privacy or security issues, there could also be mitigations that would allow use of the feature while minimizing any privacy or security issues. Unfortunately due to the highly technical nature of the platform it is possible to present convincing but spurious arguments as a shield to protect against competition, especially if you have a high budget to spend on lobbying. ​​There is a joke doing the rounds of the developer community that Apple has more lobbyists working to prevent competition for the iOS App Store than they have developers working on Safari/Webkit.
+
+> “Apple has been able to intimidate and use a lot of money” to kill legislation
+> <cite>[Arizona Rep. Regina Cobb](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299)</cite>
+
+It is expected that Apple [will fight hard](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299) against these changes as they are likely to dramatically increase competition, affect their Search Engine revenue and curtail their control of the iOS app market, so it is important to break down any argument and separate Apple’s concerns into individual components and address them individually.
+
+
+
+### 11.3. Legitimate Issues
+
+There are legitimate privacy, security, spam, and app quality concerns that gatekeepers will have and these need to be addressed.
+
+The gatekeeper should be able to enforce proportional policies that address these concerns while still enabling open competition between browsers and between proprietary Native Apps and open Web Apps.
+
+
+
+#### 11.3.1. Security
+
+Browsers are complex applications, and all browsers have bugs and security vulnerabilities. Not all security vulnerabilities are equal, and many are discovered and patched before they are abused in the wild.
+
+Browsers can be thought of as mini-operating systems, an application platform as well as a tool for browsing the web. They are very powerful and as such need low-level system access and privileges that no other app on iOS currently receives.
+
+It is important to recognize that browsers can be leveraged to gain access to the device by using security flaws. It is likely that all browsers have and will continue to have security vulnerabilities.
+
+Browser Vendors should be committed to maintaining high security in their browsers, reasonable response times for fixing security holes and should continue active maintenance of their browser. If it can be shown that a Browser Vendor is not providing reasonable efforts to keep their browser secure then the gatekeeper should be allowed to either remove privileges from that browser or remove the browser from their platform.
+
+The gatekeeper should either have to apply to the regulator to have a browser removed OR a browser should be able to appeal removal to the regulator.
+
+
+
+#### 11.3.2. Privacy
+
+User’s should be able to make decisions and choices which include tradeoffs between security, privacy and utility.
+
+Apple, despite their marketing, arguably does not have the “most” private browser and other browsers could offer more privacy than Safari if they had access to the technology to make that possible. Brave is one example, which is built on top of chromium (blink, the same engine Chrome and Edge use), has extensive privacy features and ad-blocking built in.
+
+Enabling particular functionality may in some cases lead to potentially less privacy but more utility, and it’s important that users are allowed to make these judgements and trade-offs by switching their browser.
+
+
+
+#### 11.3.3. Ignoring User Settings / Preferences
+
+The third-party browser might ignore user settings such as parental controls or block lists. It is our opinion that browsers should as much as reasonably possible respect the wishes of the user as expressed through Operating System settings, and that Operating System setting should be available to those browsers through reliable, stable, public APIs.
+
+
+
+#### 11.3.4. Ignore certain privacy and security policies
+
+A user may have applied specific privacy and security policies that they would like enforced. A third-party browser could choose to ignore these preferences or enact stricter preferences as set via their own settings surfaces.
+
+
+
+#### 11.3.5. Abandoned Browsers
+
+A third-party browser may be abandoned by its developer and no longer updated. This means that the browser would no longer get timely security updates. Operating Systems should be within their rights to disable or remove such browsers from wide circulation to protect users.
+
+Regulators should provide enforcement oversight of these mechanisms to ensure they are not abused by Gatekeepers.
+
+
+
+#### 11.3.6. Low Effort Spam Browser
+
+A company could simply package up another browser engine, add functionality to spam users or collect private data.
+
+**Note:** Windows, macOS, Android and Linux already allow Third-Party Browsers and Web Apps. Note that Android has yet to make it easy for third-party browsers to deploy Web Apps properly (specifically because the interface to [mint WebAPKs](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583) are private APIs and are not exposed to competitors).
+
+
+
+### 11.4. Balancing the need for competition with Security/Privacy
+
+The way to address each of these issues is for the Gatekeeper to mandate browser engine choice, open access to private APIs, and require publicly publish extensive documentation for the responsibilities of the Third-Party Browsers with regards to security and privacy.
+
+All rules must be narrow in scope and based on the expectations set by the Gatekeeper’s own Browser or Applications.
+
+Third-Party Browsers that do not abide by these rules can be removed, with appeals to regulatory oversight mechanisms set forth publicly by competent authorities.
+
+*Please note that the authors are software experts not lawyers. We simply want to convey the intent, structure and content of potential regulation.*
+
+
+
+### 11.5. REGULATION
+
+In all aspects of regulatory oversight, we envision that regulators continue to be involved deeply in the enforcement of rules that accompany findings of fact from these enquiries. Such oversight might create mechanisms of appeal for competitors, hands-on regulatory intervention in day-to-day rule-change proposals by Gatekeepers, or mechanisms for statutory relief. We don’t presume to know the correct mix of these remedies, but the goals of enforcement are more clear.
+
+**Gatekeepers should:**
+
+1. Not block the **installation** of **Third-Party Browsers**
+2. Not prevent or restrict Third-Party Browsers from their choice of a Javascript Engine (for example Nitro, V8) or Layout Engine (for example Blink, Gecko, Webkit) <sup>6</sup>
+3. Not block **updates** to **Third-Party Browsers**
+4. Allow Third-Party Browsers to **install** and **manage Web Apps**
+5. **Not limit the capabilities** of Third-Party Browsers and Web Apps and should provide access to relevant device and operating system APIs. Browsers and Web Apps should not be restricted by the operating system from accessing any feature that is provided to the gatekeeper's own browser, native apps or system apps.
+6. Provide users with equivalent ability to manage Web Apps through **system settings** provided for Native Apps, regardless of which Browser installed them.
+7. Provide an easy to use mechanism for users to set their desired **default browser** and should respect this choice in the operating system and their own applications
+
+**Limitations on Third-Party Browsers:**
+
+1. The Gatekeeper can mandate and publish **narrow scope** and **proportional** security/privacy policies for Third-Party Browsers and Web Apps with regulator approval.
+2. All restrictions relating to Third-Party Browsers and Web Apps including those for security and privacy must be individually approved by the regulator.
+3. All restrictions placed on Third-Party Browsers must be publicly documented. Confidential or Secret restrictions should be prohibited.
+4. Proposed changes to these policies must be published and approved by the regulator.
+5. These policies must be in the interest of the **end user**.
+6. These policies can not **inhibit capabilities** of the Third-Party Browser or Web App from the perspective of the end user.
+7. The Gatekeeper must produce documentation for these policies which:
+    1. are thorough;
+    2. contain a high level of technical detail explaining both the need for these policies and exactly what they mean.
+8. These policies and their associated documentation must be made public. Confidential or secret restrictions should be prohibited.
+9. The Gatekeeper must answer all questions and hypotheticals about these policies in a timely fashion. These questions and answers must be made public.
+
+Providing that the Third-Party Browser or Web App latest version is in compliance with the current privacy/security policies the Gatekeeper should not block installation/capabilities or update of it, including if arbitration or litigation is currently in process. The Gatekeeper may apply to the regulator to permanently ban a particular company from providing Third-Party Browser or Web Apps if they can prove the Third-Party Browser is maliciously acting against the interests of end users (i.e it is actually malware/spam).
+
+The desired outcome with these regulations is that browsers and web-apps are delivered unrestricted by the operating system.
+
+These proposed regulations should be subject to an open comment period to allow all stakeholders to provide feedback, however it should be expected that Apple and other special interest groups are heavily incentivized to maintain the status quo.
+
+<sup>6</sup> A browser engine (also known as a layout engine or rendering engine) is a core software component of every major web browser. The primary job of a browser engine is to transform HTML documents and other resources of a web page into an interactive visual representation on a user's device.</sup>
+
+
+
+## 12. Bright Future for Competition
+
+If third-party browsers were allowed, with full access to all the APIs that Apple gives Safari, this would provide Apple the incentive to keep pace with the other browsers and give consumers a means of voting with their feet by moving to a competing browser if they fail to do so.
+
+It would provide a source of competition with the App Store as Tim Cook and others at Apple have suggested. It would place downward pressure on the tax Apple charges companies and by extension users on all purchases made in the App Store.
+
+If Apple was compelled to provide Web Apps an equal footing to Native Apps, companies would be able to develop a wide range of apps for a single standards based platform that would then be interoperable between iOS, macOS, Android, Windows and Linux. This would result in as much as a 2-5 fold drop in development and maintenance cost and result in higher quality Apps for end users.
+
+A ban on third-party browsers benefits Apple and harms users, developers and businesses.
+
+**Competition, not walled gardens, leads to the best outcomes**.
+
+
+
+## 13. Further Reading
+
+### 13.1. Alex Russell - Browser Choice Must Matter
+
+Alex Russell (Former W3C TAG / Google Chrome, Now on the Microsoft Edge team) has written a series of articles labeled “Browser Choice Must Matter” which go into deep technical detail in relation to “Browser Choice”.
+
+**[Progress Delayed is Progress Denied](https://infrequently.org/2021/04/progress-delayed/)** <br />
+A detailed look into Safari on iOS and how it has slipped behind
+
+**[Hobson’s Browser](https://infrequently.org/2021/07/hobsons-browser/)** <br />
+How Apple, Facebook and Google are undermining user choice in browsers
+
+**[iOS Engine Choice in Depth](https://infrequently.org/2021/08/webkit-ios-deep-dive/)** <br />
+A deep dive into browser choice on iOS with technical details
+
+### 13.2. Bruce Lawson
+
+**[Progressive Web Apps and iOS](https://www.youtube.com/watch?v=EOyfMzWqHiY)** <br />
+Bruce Lawson presentation to the UK’s Competition and Markets Authority about issues with Web Apps on iOS
+
+### 13.3. Stuart Langridge
+
+**[Browser choice on Apple's iOS: privacy and security aspects](https://kryogenix.org/code/cma-apple/)** <br />
+Stuart Langridge’s presentation to the UK’s Competition and Markets Authority about various privacy and security aspects on iOS.
+
+
+
+## 14. References
+
+* [Thomas Claburn - The Register - On Safari Underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/)
+
+* [The Ultimate How-to: Build a Bluetooth Swift App With Hardware in 20 Minutes](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)
+
+* [Apple’s iOS App Store is littered with malicious apps](https://www.techradar.com/au/news/apple-app-store-is-apparently-still-littered-with-malicious-apps)
+
+* [Security Researcher on iOS App Store Malware](https://habr.com/en/post/580272/)
+
+* [Matthew Ball - On Apple inhibiting the future Internet](https://www.matthewball.vc/all/applemetaverse)
+
+* [Ben Thompson on why Apple wants to make the web less useful](https://stratechery.com/2020/apple-and-facebook/)
+
+* [Mozilla Documentation on Web Apps (PWAs)](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)
+
+* [Apple claiming PWAs represent a viable distribution alternative to the App Store](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf)
+
+* [Tim Cook making the same claim](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s)
+
+* [Apple lawyers making a similar claim in court vs Uber](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple)
+
+* [Apple rule effectively banning third-party browsers](https://developer.apple.com/app-store/review/guidelines/#2.5.6)
+
+* [Scott Gilbertson - On Safari being the new IE](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/)
+
+* [Dieter Bohn and Tom Warren - The Verge - Talking about Apples Browser Ban](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)
+
+* [Niels Leenheer - HTML5test - On iOS Safari holding back the web](https://nielsleenheer.com/articles/2021/chrome-is-the-new-safari-and-so-are-edge-and-firefox/)
+
+* [Chris Coyier - CSS-TRICKS - On the Apple Browser Ban](https://css-tricks.com/ios-browser-choice)
+
+* [Richard MacManus - The New Stack - On the Apple Browser Ban holding back the web](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)
+
+* [The Verge - Emails from the Epic vs Apple trial](https://www.theverge.com/22611236/epic-v-apple-emails-project-liberty-app-store-schiller-sweeney-cook-jobs)
+
+* [Steve Jobs - Original Announcement of iOS Web Apps](https://www.youtube.com/watch?v=p1nwLilQy64)
+
+* [iOS “Smart App Banners”](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners)
+
+* [Patterns for promoting PWA installation](https://web.dev/promote-install/)
+
+* [MDN - BeforeInstallPromptEvent documentation](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent)
+
+* [Minesweeper like PWA/Web App](https://proxx.app)
+
+* [Bruce Lawson - Talk to the CMA about Web Apps](https://brucelawson.co.uk/2021/briefing-to-the-uk-competition-and-markets-authority-on-apples-ios-browser-monopoly-and-progressive-web-apps/)
+
+* [Apple/Webkit - rejecting request to add BeforeInstallPromptEvent](https://bugs.webkit.org/show_bug.cgi?id=193959)
+
+* [Chromium Ticket on Open WebAPK minting server for third-party browsers](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583)
+
+* [Misha Ketchell - The Conversation - On Dark Pattens](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On Safari Webkit lagging behind](https://infrequently.org/2021/04/progress-delayed/#:~:text=The%20data%20agree%3A%20Apple%27s%20web%20engine%20consistently%20trails%20others%20in%20both%20compatibility%20and%20features%2C%20resulting%20in%20a%20large%20and%20persistent%20gap%20with%20Apple%27s%20native%20platform)
+
+* [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned)
+
+* [Can I Use - Website with data comparing features of different browsers](https://caniuse.com)
+
+* [Mozilla Developer Network Web Developer Needs Assessment 2020 Survey](https://insights.developer.mozilla.org/reports/mdn-web-developer-needs-assessment-2020.html)
+
+* [CSS](https://en.wikipedia.org/wiki/CSS)
+
+* [HTML](https://en.wikipedia.org/wiki/HTML)
+
+* [Javascript](https://en.wikipedia.org/wiki/JavaScript)
+
+* [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly)
+
+* [State of CSS survey](https://stateofcss.com)
+
+* [State of CSS survey - Raw Answers Text](https://gist.github.com/SachaG/cd7cf12623a95d8162ac2b8e340c4724)
+
+* [The Register - On Safari breaking indexedDB](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug)
+
+* [Russell Brandom - The Verge - On Apple holding PWAs back](https://www.theverge.com/2021/5/27/22454959/epic-apple-trial-recap-video-tim-cook-xbox-playstation-business#:~:text=APPLE%20GAINS%20A%20LOT%20BY%20SLOW-WALKING%20PROGRESSIVE%20WEB%20APPS%20ON%20THE%20IPHONE)
+
+* [Benedict Evans - Technology Writer - On Apples arbitrary application of App Store rules](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On Apple saving ram by banning other browsers](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser)
+
+* [Benedict Evans - Technology Writer - On iOS Free to Play Games](https://www.ben-evans.com/benedictevans/2021/7/8/app-store)
+
+* [Mihovil Grguric - CEO of Udonis Inc (A mobile apps marketing agency) - On free-to-play Whales](https://www.blog.udonis.co/mobile-marketing/mobile-games/mobile-games-whales)
+
+* [Tim Perry - Httptoolkit - On Safari not implementing features with no potential security/privacy issues](https://httptoolkit.tech/blog/safari-is-killing-the-web/)
+
+* [Sean Hollister - On Apple inability to spot obvious scams in the iOS App Store](https://www.theverge.com/2021/4/21/22385859/apple-app-store-scams-fraud-review-enforcement-top-grossing-kosta-eleftheriou)
+
+* [Gordon Kelly - On scams and clones on the iOS App Store](https://www.forbes.com/sites/gordonkelly/2021/04/07/apple-iphone-ipad-app-store-scam-warning-new-iphone-problem/?sh=7231e8a960aa)
+
+* [Dr Michael Grenfell - On Effective Competition](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+* [Entrepreneurship Life - Apple users spend more than Android users](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+
+* [Times on India - Apple users spend more than Android users](https://timesofindia.indiatimes.com/gadgets-news/iphone-users-spend-more-money-on-apps-than-android-users-report/articleshow/83947757.cms)
+
+* [Professor Douglas J. Leith - On Brave Privacy](https://www.zdnet.com/article/brave-deemed-most-private-browser-in-terms-of-phoning-home/)
+
+* [A Feature added to Chromium that Edge and other browsers use but Chrome does not](https://groups.google.com/a/chromium.org/g/blink-dev/c/e5fu5Q06ntA/m/UUqPuA8hEQAJ)
+
+* [Benedict Evans - Technology Writer - On iOS App Store](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)
+
+* [Dieter Bohn - The Verge - On Apples Capricious App Store policies](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)
+
+* [Sean Hollister - Verge - On Apples effective ban on streamed games](https://www.theverge.com/2020/9/18/20912689/apple-cloud-gaming-streaming-xcloud-stadia-app-store-guidelines-rules)
+
+* [Sean Hollister - Verge - On Apple copying then banning a keyboard App](https://www.theverge.com/2021/9/16/22676706/apple-watch-swipe-keyboard-flicktype-lawsuit-kosta-eleftheriou)
+
+* [Samantha John - CEO Hopscotch - On iOS App Store Review Policies](https://twitter.com/samj0hn/status/1431001795904561160)
+
+* [Kosta Eleftheriou - On iOS Malware](https://www.xanjero.com/news/developer-kosta-eleftheriou-claims-apples-app-store-is-littered-with-malicious-apps/)
+
+* [Slipping Past the Review - Malware in iOS Native Apps](https://habr.com/en/post/580272/)
+
+* [Campbell Kwan - ZDNet - On Apples indefinite ban of Epic](https://www.zdnet.com/article/apple-bans-epic-games-from-app-store-until-all-litigation-is-finalised/)
+
+* [John Brownlee - Cult of Mac - On Apple banning Sweatshop Labour Rights Game](https://www.cultofmac.com/220790/why-apples-reason-for-kicking-a-sweatshop-game-out-of-the-app-store-is-total-hypocrisy/)
+
+* [Niels Leenheer - HTML5test - On Apple Webkits banning of web device APIs on privacy grounds](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)
+
+* [Apple has rejected certain web standard device APIs](https://webkit.org/tracking-prevention/#anti-fingerprinting)
+
+* [Niels Leenheer - HTML5test - on why web device APIs are really bad at fingerprinting](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)
+
+* [Web Bluetooth Documentation](https://webbluetoothcg.github.io/web-bluetooth/)
+
+* [Microsoft Smartscreen](https://support.microsoft.com/en-us/microsoft-edge/what-is-smartscreen-and-how-can-it-help-protect-me-1c9a874a-6826-be5e-45b1-67fa445a74c8)
+
+* [Google SafeBrowsing](https://safebrowsing.google.com/)
+
+* [iOS Native Bluetooth Guide](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)
+
+* [On malicious tracking of users using iOS Native Apps bluetooth](https://www.fastcompany.com/90386781/ios-13s-new-bluetooth-privacy-feature-is-important-but-confusing)
+
+* [Cory Doctorow - Former European director of the Electronic Frontier Foundation - On Apple's stance on privacy](https://twitter.com/doctorow/status/1459914164152016905)
+
+* [Apple's Advertising Identifier](https://en.wikipedia.org/wiki/Identifier_for_Advertisers)
+
+* [Geoffrey Fowler And Tatum Hunter - Washington Post](https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On IAB and Browser Choice](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser)
+
+* [John Koetsier - Forbes - On Apple secretly buying advertising for other companies](https://www.forbes.com/sites/johnkoetsier/2021/11/12/apple-quietly-buying-ads-via-google-for-high-value-subscription-apps-to-capture-app-publisher-revenue/?sh=67998df71b52)
+
+* [Mac Rumors - On Apple’ 2021 1st half profit](https://www.macrumors.com/2021/06/29/app-store-revenue-h1-2021-42-billion/)
+
+* [Austin Carr - Bloomberg - On Apples 30% Gatekeeper fee](https://www.bloomberg.com/news/newsletters/2021-05-03/apple-s-30-fee-an-industry-standard-is-showing-cracks)
+
+* [Russell Brandom - The Verge - On Apple iMessage](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)
+
+* [Apple Scoop - On why the Mac App Store is not successful](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+* [Photoshop on the web](https://web.dev/ps-on-the-web/)
+
+* [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)
+
+* [SIMD](https://developer.mozilla.org/en-US/docs/Glossary/SIMD)
+
+* [Private File System Origin Trial](https://web.dev/file-system-access/#accessing-files-optimized-for-performance-from-the-origin-private-file-)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On WebStandards](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+* [Apple received 9% of Gross Profit from Google Search Engine deal](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/)
+
+* [Rep. Regina Cobb - A Republican state lawmaker in Arizona - On Apple’s aggressive lobbying](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299)
+
+* [Joshua Long - Apple’s Poor Patching Policies Potentially Make Users’ Security and Privacy Precarious](https://www.intego.com/mac-security-blog/apples-poor-patching-policies-potentially-make-users-security-and-privacy-precarious)
+
+* [Charlie Warzel - New York Times on privacy and native apps tracking](https://www.nytimes.com/2019/09/24/opinion/facebook-google-apps-data.html)
+
+* [Sara Morrison - VOX on harvesting data via native apps](https://www.vox.com/platform/amp/recode/22587248/grindr-app-location-data-outed-priest-jeffrey-burrill-pillar-data-harvesting)
+
+* [Bennett Cyphers - Electronic Freedom Foundation - On harvesting data via native apps](https://www.eff.org/deeplinks/2020/06/apples-response-hey-showcases-whats-most-broken-about-apple-app-store)
+
+* [Google - Announcing the Webkit/Blink Engine Split](https://blog.chromium.org/2013/04/blink-rendering-engine-for-chromium.html)
+
+* [CVEDetails -All Vulnerabilities in Safari](https://www.cvedetails.com/product/2935/Apple-Safari.html?vendor_id=49)
+
+* [CVEDetails - All Vulnerabilities in Chrome](https://www.cvedetails.com/product/15031/Google-Chrome.html?vendor_id=1224)
+
+* [CVEDetails - All Vulnerabilities in Firefox](https://www.cvedetails.com/product/3264/Mozilla-Firefox.html?vendor_id=452)
+
+* [Paul Wagenseil - Tom’s Guide - On hacking the iPhone via Safari/Webkit](https://www.tomsguide.com/opinion/your-iphone-is-less-safe-than-it-was-yesterday-and-thats-good)
+
+* [Wikipedia - CVE - Definition](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures)
+
+* [Google - Project Zero (Security Team) on security browser metrics](https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html)
+
+* [Reed Albergotti - Washington Post - On the poor state of Apple’s bug bounty program](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)
+
+* [Thomas Claburn - The Register - On poor treatment of Security Researchers by Apple](https://www.theregister.com/2020/07/01/apple_macos_privacy_bypass/)
+
+* [Denis Tokarev - Security Researcher - On poor state of Apple’s bug bounty program](https://habr.com/en/post/579714/)

--- a/src/es/posts/Australia-ACCC-Nov-22.md
+++ b/src/es/posts/Australia-ACCC-Nov-22.md
@@ -1,0 +1,54 @@
+---
+title: >-
+  Australian Government considering ACCC proposed anti-competitive conduct
+  legislation changes
+date: '2022-11-30'
+tags:
+  - Policy
+  - Updates
+author: Bruce Lawson
+permalink: /es/blog/Australia-ACCC-Nov-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+G'day, sport! [Bruce](https://brucelawson.co.uk) here, with an update on progress we've made down under with the Australian Competition and Consumer Commission (ACCC).
+
+ACCC published a [Digital Platform Services Inquiry Discussion Paper (PDF)](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry.pdf)  which has great news for competition in browsers and web apps.
+
+They propose:
+
+1. Reversing the Apple browser ban
+2. Requiring equivalent access to hardware and software
+3. Allowing web apps to compete with single-platform "native" apps
+
+> Apple requires all browsers on iOS to be built using its WebKit browser engine. Further, Apple prevents WebKit from accessing certain APIs and iOS functionality, which restricts the functionality of web apps compared to native apps (for example, push notifications can be accessed by native apps but not web apps).
+
+> As a result, Apple iOS users do not have the option to use browsers that can offer a wider range of innovative features and functionality. Instead, they are limited to using browsers built using Apple’s WebKit browser engine. Stakeholders submit that, as a result, Safari faces very limited competitive pressure on iOS. We are also concerned that this limits the ability for web apps … to impose a competitive constraint on native apps.”
+
+> Apple, and to a lesser extent Google, have also restricted interoperability with hardware, software and functionality through their mobile OS for providers of third-party apps and services.
+
+The ACCC is recommending introducing a new regulatory regime that will be able to compel gatekeepers to stop anti-competitive conduct. They note that reforms are underway globally and it would make sense to align Australia's new regulatory regime with ones such as the [EU's Digital Markets Act, the UK's Digital Markets Unit](/blog/cma-dma-nov-22/) and the Japan's Act on Improving Transparency and Fairness of Digital Platforms.
+
+They clearly recognize the harm that the gatekeepers have on competition, businesses and consumers. The ACCC has a lovely shopping list of proposed legislated obligations, most of which will relate to browsers and web apps. The [majority of OWA’s concerns (PDF)](https://www.accc.gov.au/system/files/DPB%20-%20DPSI%20-%20September%202022%20report%20-%20Submission%20-%20Open%20Web%20Advocacy%20-%20Public%20(1).pdf) fit into these categories:
+
+- anti-competitive self-preferencing
+- anti-competitive tying
+- exclusive pre-installation and default agreements that hinder competition
+- impediments to consumer switching
+- impediments to interoperability
+- data-related barriers to entry and expansion, where privacy impacts can be managed
+- a lack of transparency
+- unfair dealings with business users
+-  exclusivity and price parity clauses in contracts with business users.
+
+The Australian Government is considering the ACCC’s recommendations and will consult publicly to seek the views of stakeholders.
+
+We would like to thank [Mozilla (PDF)](https://www.accc.gov.au/system/files/DPB%20-%20DPSI%20-%20September%202022%20report%20-%20Submission%20-%20Mozilla%20-%20Public.pdf) and all of the [individual developers and businesses](https://www.accc.gov.au/focus-areas/inquiries-ongoing/digital-platform-services-inquiry-2020-25/september-2022-interim-report) who wrote to the ACCC in support of browser competition and web apps.
+
+Stay tuned so we can let you know when the governmental consultation begins, so you can have your say if you do business in Australia.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/CMA-DMA-Nov-22.md
+++ b/src/es/posts/CMA-DMA-Nov-22.md
@@ -1,0 +1,46 @@
+---
+title: OWA updates on progress with UK and EU digital competition regulations
+date: '2022-11-28'
+tags:
+  - Policy
+  - Updates
+  - UK
+  - EU
+author: Bruce Lawson
+permalink: /es/blog/CMA-DMA-Nov-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Howdy, [Bruce](https://brucelawson.co.uk) here, with an update on progress we've made in both the EU and with the UK's competition regulator, the Competition and Markets Authority (CMA).
+
+## Browser engines on the agenda
+
+We've had encouraging success at putting browser engines on the regulators' agenda. While rendering engines seem a pretty esoteric subject, it's of paramount importance: Apple has done a great job concealing its anti-competitive behaviour, saying "you can have other browsers on iOS" while glossing over the fact that all other browsers are [Apple's mandated version of WebKit](https://developer.apple.com/app-store/review/guidelines/#performance:~:text=Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.) under the hood. 
+
+Many web developers don't realise this, which is why we made this meme:
+
+{% image "/images/blog/apple-browser-ban.webp", "Fred from Scooby Doo with a masked figure and text 'Firefox on iPhone'. Fred removes the mask to reveal the villain headed 'Apple's Safari'. Then the same with Edge on iPhone and Chrome on iPhone." %}
+
+So we're thrilled that, after we met with those drafting the EU rules, the final text of the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R1925&from=EN) (DMA), browser engines are explicitly referenced:
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users. 
+
+The DMA will be applicable as of [beginning of May 2023](https://ec.europa.eu/info/strategy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en). Non-compliance carries fines of up to 10% of the company’s total worldwide annual turnover, or up to 20% in the event of repeated infringements.
+
+The UK is no longer a member of the EU, so some of us who are citizens of Brexit Island met with the UK's Competition and Markets Authority after it announced an investigation into the Mobile Apps Ecosystem. We explained that it shouldn't be seen as a binary choice between single-platform "native" apps on iOS and Android, but should also be concerned with Progressive Web Apps and, by extension, also look at how Apple hamstrings PWAs by only allowing its WebKit on iOS and iPad.
+
+The CMA agreed, and last week announced [a new a market investigation into cloud gaming and mobile browsers](https://www.gov.uk/government/news/investigation-into-cloud-gaming-and-browsers-to-support-uk-tech-and-consumers) after receiving widespread support for its proposals first published in June:
+
+> Web developers have complained that Apple’s restrictions, combined with suggested underinvestment in its browser technology, lead to added costs and frustration as they have to deal with bugs and glitches when building web pages, and have no choice but to create bespoke mobile apps when a website might be sufficient.
+
+> Ultimately, these restrictions limit choice and may make it more difficult to bring innovative new apps to the hands of UK consumers. At the same time, Apple and Google have argued that restrictions are needed to protect users. The CMA’s market investigation will consider these concerns and consider whether new rules are needed to drive better outcomes.
+
+The [CMA Board Advisory Steer](https://assets.publishing.service.gov.uk/media/637b76478fa8f5771eb23acc/Board_Advisory_Steer_.pdf) gives a good insight into the things they will investigate.
+
+We want to say a huge thank you to all web developers who took the time and trouble to [reply to CMA's consultations](https://www.gov.uk/government/consultations/mobile-browsers-and-cloud-gaming-proposal-to-make-a-market-reference). Big Tech firms have whole departments who leap into action if regulators start sniffing, and the money to set up pseudo-associations to lobby on their behalf. We didn't; you had our backs. Thank you.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/NTIA-report-Feb-22.md
+++ b/src/es/posts/NTIA-report-Feb-22.md
@@ -1,0 +1,33 @@
+---
+title: News from the NTIA report on mobile app ecosystems
+date: '2023-02-03'
+tags:
+  - Policy
+  - Updates
+author: Bruce Lawson
+permalink: /es/blog/NTIA-report-Feb-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[Bruce](https://brucelawson.co.uk) published an [article](https://brucelawson.co.uk/2023/the-ntia-report-on-mobile-app-ecosystems/) where he gives us a summary of the NTIA (National Telecommunications and Information Administration) report on Mobile App Competition.
+
+> The question now is whether Apple will do the right thing, or seek to hurl lawyers with procedural arguments at it instead, as they're doing in the UK now.
+
+> But for every month they delay, they earn a fortune; it's estimated that Google pays Apple $20 Billion to be the default search engine in Safari, and the App Store earned Apple $72.3 Billion in 2020.
+
+Apple's App Store revenue is ~ $72.3 billion, of which they tax app developers between 15% and (likely more often) 30%. If we assume Apple always takes the full 30%, they would receive just shy of $21.7 billion. Apple would still need some of that money to pay for the operating costs of the App Store.
+
+The $20 billion from Google is likely almost all profit.
+
+That's 11% of Apple's yearly profit for doing nothing except banning their competitors from iOS 🤯
+
+**Browser ban = higher market share for safari = Google search engine revenue**
+
+<div class="prom-banner">
+  <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+  <p>If you love what we're doing and would like to support our work, please consider
+    <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a>.</p>
+  <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+    to ensure the future of Browser competition and Web Apps</p>
+</div>

--- a/src/es/posts/New-Digital-Competition-Laws-For-Australia.md
+++ b/src/es/posts/New-Digital-Competition-Laws-For-Australia.md
@@ -1,0 +1,39 @@
+---
+title: New Digital Competition Laws for Australia
+date: '2023-12-08'
+tags:
+  - Policy
+  - Updates
+  - Australia
+author: Alex Moore
+permalink: /es/blog/New-Digital-Competition-Laws-For-Australia/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/NewDigitalLawsAustralia.webp",
+  "Australia - New Laws for Digital Platforms. In-principle agreement reached. The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits. We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS. ACCC - Digital Platform Services Inquiry #5"
+%}
+
+The Australian government has agreed to [new competition laws for digital platforms](https://www.accc.gov.au/media-release/consumers-and-small-businesses-to-benefit-from-proposed-new-regulation-of-digital-platforms)!
+
+This is excellent news and will pave the way for fair and effective browser competition on all operating systems & allow Web Apps to compete on an equal footing with Native Apps.
+
+The new laws will be based on the ACCC's recommendations in their [Digital platform services inquiry - Interim report No. 5](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf) which includes:
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+
+> We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS.
+
+This is important as, Apple has effectively banned third party browsers via [their 2.5.6 rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+We believe that browsers should compete on merit and user choice, not via control of operating systems or other underhanded behaviour. Browser competition is important as it is this competition that pushes browser vendors to secure their products, fix bugs and add new features.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/apple-adopts-6-owa-choice-architecture-recommendations.md
+++ b/src/es/posts/apple-adopts-6-owa-choice-architecture-recommendations.md
@@ -1,0 +1,118 @@
+---
+title: Apple adopts 6 of OWA's Choice Architecture Recommendations
+date: '2024-08-23'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /es/blog/apple-adopts-6-owa-choice-architecture-recommendations/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[Today, in a step forward for user choice and browser competition](https://developer.apple.com/support/browser-choice-screen/), Apple has adopted 6 out of 11 of our recommendations to comply with the EU's Digital Markets Act in relation to browser defaults and choice screens. In addition Apple has fixed [two severe and deliberate deceptive patterns](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) that we campaigned to fix including at the DMA's workshop.
+
+[In March the EU Commission opened an investigation into Apple](https://open-web-advocacy.org/blog/eu-opens-dma-investigations/) for non-compliance with the Digital Markets Act related to user choice obligations. Since that time we have been working to ensure that all gatekeepers comply with the DMA with respect to browsers and Web Apps.
+
+## Implemented Recommendations
+
+1. [Browser vendors should be **granted the hotseat** when being selected as the default browser in the choice screen.](https://open-web-advocacy.org/apple-dma-review/#apples-dark-pattern-exacerbated-by-keeping-hotseat)
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/_m6tQtDpSbM?si=H37IuGP1F_yueGtd' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+2. [Browsers should be able to **display more information** in the choice screen](https://open-web-advocacy.org/apple-dma-review/#browser-should-be-allowed-to-show-more-information-on-choice-screen)
+
+3. [Once chosen, browsers should be **immediately set as the default and downloaded in the background.**](https://open-web-advocacy.org/apple-dma-review/#should-be-a-background-and-direct-download)
+
+4. [Browser vendors **need more data** to measure the effectiveness of the choice screen.](https://open-web-advocacy.org/apple-dma-review/#browser-vendors-need-data-on-the-choice-screen-to-measure-performance)
+
+5. [The choice screen should be shown to users **when syncing or purchasing a new device**.](https://open-web-advocacy.org/apple-dma-review/#periodic-choice-screen)
+
+6. [The option to change default browser should be moved out of the browser settings and into a centralised location.](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+
+According to [Apple’s announcement](https://developer.apple.com/support/browser-choice-screen/) the following recommendations will be implemented on iOS (including on iPads). We will need to observe the implementation for additional issues but this is a positive step forward for browser competition and Apple's compliance with the Digital Markets Act.
+
+## Unimplemented Recommendations
+
+1. [The user’s choice of default browser must be used for In-App Browsing (SFSafariViewController)](https://open-web-advocacy.org/apple-dma-review/#sfsafariviewcontroller-must-respect-browser-choice)
+<br>Currently most In-App browsing on iOS is locked to Safari which provides Apple a very significant advantage and a lot of traffic. It is critical for browser choice that if a user decides on a particular browser, that browser is then used for web browsing by default across the OS including in In-App Browsers.<br><br>
+
+2. [Browsers on the choice screen shouldn't be Locked to the Gatekeeper’s app store](https://open-web-advocacy.org/apple-dma-review/#direct-install-browsers-should-be-included-in-choice-screens)
+<br>Browser vendors should be able to choose if they want to have their browser distributed directly or via the AppStore, including if they also distribute via the AppStore. The choice-screen should not force any browser vendor to have to distribute via Apple’s designated core platform service and thus lock them into Apple’s unfair contracts and rules + 30% of any In-App payments.
+<br><br>Apple has indicated they are open to collaborating on this recommendation however we are concerned that browser vendors are in essence locked into Apple’s app store and [are not able to distribute their browser directly](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation) as they do on desktop operating systems.
+<br><br>Specifically, we believe that the [Core Technology Fee should be removed](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed) as this is a punitive fee on businesses daring to list any of their apps outside of Apple’s app store.  The EU should consider solving the issues of alternative app distribution (including core-technology fee) so that browser vendors have the option of direct distribution. If these issues are not solved before the choice screens are rolled out then a key opportunity for browser vendors to offer their browsers directly to users would have been lost.
+<br><br>Apple should also not be allowed to put up scare screens to dissuade users from directly downloading browsers.<br><br>
+
+3. [Browsers should be allowed to know if they are the current default browser.](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>It is important that browsers can detect whether or not they are the default in order to provide sensible prompts to users to set their browser as the default. Apple has argued that they do not provide this information to Safari but that is irrelevant as Safari is set as the default in factory settings.<br><br>
+
+4. [The option to change default browser should show up in settings search if the user searches for "default", "browser" or "default browser".](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>It should not be difficult for users to work out how to change the default browser. Making it appear in search is a minimum requirement.<br><br>
+
+5. [Browsers should be able to trigger a one-click prompt to be set as the default upon being installed (as is standard on most other operating systems).](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>To be able to easily change from one browser to another, once a user install a new browser they should be able to set it as default from a one-time operating system prompt. This should also include the hotseat.<br>
+
+We will be engaging with the DMA’s investigation into defaults and choice screens about these issues as we believe they are justified and that Apple is obligated to implement them under the text of the DMA.
+
+## Hotseat not granted to already installed browsers and browsers set as default outside the choice screen.
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser **that is not currently installed on their device** from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen
+> <cite>[Apple - On Browser Choice Screens](https://developer.apple.com/support/browser-choice-screen/)<br>
+(emphasis added)</cite>
+
+One issue with Apple's implementation is it does not apply to browsers which are already installed. Apple needs to update this to move an already installed browser onto the hotseat to replace the Safari icon when it is selected in the choice screen.
+
+We believe that browsers that are downloaded outside of the choice screen should also replace Safari in the hotseat upon being set as default browser.
+
+This is important as these are both common scenarios. Any friction that OS gatekeepers can introduce to make it harder for users to use a browser other than theirs undermines browser competition. Friction is a powerful force to block competition.
+
+## Deceptive Patterns
+
+[The two deceptive patterns outlined](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) in this article have both been fixed by Apple. 
+
+The deceptive pattern of hiding the option to change default browser in Safari settings if Safari is the default outlined in this article has also been removed by Apple globally. 
+
+Additionally, the deceptive pattern of triggering the choice screen when Safari is not the default browser (typically because it still occupies the hotseat) has been fixed. That is Apple was triggering the choice screen in the hope that users will change from a third-party browser back to Safari.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+## To Regulators outside the EU
+
+These changes are EU only. Apple's users in other countries do not gain any direct benefit from these remedies. We urge regulators in other countries to carefully examine these changes and consider compelling Apple to implement them in their own jurisdictions. It should be noted that the effort for Apple to implement the choice screen in other jurisdictions will now be minimal.
+
+#### Important Improvements
+
+While the changes the EU have made are excellent, they are limited in pursuing the optimal solution by the [very specific text of the DMA](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=the%20end%20users%E2%80%99-,first%20use%20of%20an%20online%20search%20engine%2C%20virtual%20assistant%20or%20web%20browser,-of%20the%20gatekeeper).
+
+In addition to the unimplemented recommendations above we would recommend several important improvements including:
+* The choice screen should be moved to device setup or upon device update rather than upon first use of the gatekeepers browser. 
+* The gatekeepers browser, if not selected, should be uninstalled from the device
+or virtually uninstalled, i.e. hidden from the user, if the gatekeeper can demonstrate that is not practical because of technical limitations.
+
+## Compliance Monitoring and Unanswered Questions
+
+We have not yet seen the implementation of the choice screen. For OWA, browser vendors and others to provide feedback to the EC we need to be able to see it in action (video) and be able to test it. This needs to be done well in advance of any browser choice screen rollout in the EU so there is time to make changes based on feedback.
+
+#### Outside of AppStore Workflow
+
+The outside of the Apple AppStore workflow for the choice screen is unknown. We'd like to know what the outside of the AppStore install process would look like, and a confirmation that browser developers can opt to have their "non-appstore" version installed if they would like.
+
+So far Apple has just provided the [very vague statement](https://developer.apple.com/support/browser-choice-screen/):
+> Additionally, developers who make their browsers available outside the App Store should contact their Apple representative or dma-data@apple.com to collaborate on including their browser in the choice screen.
+
+For example, can Brave/Firefox/Edge/Opera/DuckDuckGo/Chrome/Vivaldi offer from the choice screen, a version of their browser which is directly distributed from that browser vendor?
+
+#### Testing the Choice Screen
+
+For testing the choice screen, Apple should provide a way to trigger the choice screen multiple times without having to factory reset a device.  A “choice screen” button in settings somewhere would do the trick.  To test it properly we need to launch it many times. 
+
+## What does success for Choice Architecture look like?
+
+There are two forms of success in choice architecture. One is removing behaviour that is blatantly unfair or manipulative, the removal of the behaviour is a success in its own right regardless of any outcome. 
+
+The second is in allowing space for new and smaller browser vendors to thrive. Even the most perfect choice screen will not wildly change user preference over night. The biggest names in browsers are the ones that will be picked the most, the browser of the operating system will still get a significant boost. What choice screens need to do to succeed is let users know that they have a choice and create an opening for smaller browser vendors to get a foothold on mobile. 
+
+If third-party browsers managed to gain an additional 10% of the total market share on iOS or Android that would be a resounding success. As a point of context Google is paying Apple $20 billion USD per a year for being the default search engine. That means every 1% is worth $200 USD million annually. 
+
+That 10% is enough to support 8 Mozilla’s across iOS and Android. That is something worth fighting for. 

--- a/src/es/posts/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface.md
+++ b/src/es/posts/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface.md
@@ -1,0 +1,105 @@
+---
+title: >-
+  Apple appears to mislead UK Regulator over deceptive default browser user
+  interface
+date: '2024-09-04'
+tags:
+  - Policy
+  - CMA
+  - UK
+author:
+  - OWA
+permalink: >-
+  /es/blog/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+TLDR: Apple seems to have tried to mislead the UK regulator that a deceptive pattern they had previously implemented for picking default browsers, in fact, never existed.
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1831247394643800481), [Mastodon](https://mastodon.social/@owa/113078330412825453
+), [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_breaking-apple-appears-to-mislead-uk-regulator-activity-7237018638518509568-Gxrc).
+
+## The Deceptive Pattern
+
+Earlier this year (2024-03-28) [we reported on a deceptive pattern](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) that Apple had coded into iOS which made it harder for users to change their default browser, if your current default browser was already Safari.
+
+<figure>
+    {% image
+        "/images/blog/cma-browser-selection-1.png",
+        "Example of changing the browser on iOS when Safari is not the default.",
+        null, null
+    %}
+    {% image
+        "/images/blog/cma-browser-selection-2.png",
+        "Example of changing the browser on iOS when Safari is the default (the dropdown disappears).",
+        null, null
+    %}
+    {% image
+        "/images/blog/cma-browser-selection-3.png",
+        "Larger example of changing the browser on iOS when Safari is the default (the dropdown disappears).",
+        null, null
+    %}
+    <figcaption>UK Regulator's Screenshots of the Issue - Working Paper 5</figcaption>
+</figure>
+
+> "Apple engineers added code to the Safari's settings page to hide the option to change the default browser if Safari was the default but then to prominently show it if another browser was the default." You can test this on an iPhone by scrolling to Safari under Settings. If Safari is not the default browser, there will be an option for "Default Browser App" where you can easily set Safari as the default. But if Safari is set as the default, this option disappears. For every other browser installed, the option remains to switch the default, whether that browser is set as the default or not.
+> <cite>[Ashley Belanger - Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/2/)</cite>
+
+This interesting design foible was picked up [by Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/2/) 2 weeks later and was subsequently fixed by Apple. We are uncertain exactly which version of iOS Apple fixed it in as they neglected to include it in the release notes. We noted that this had been fixed in [our review of Apple's compliance with the EU's Digital Markets Act](https://open-web-advocacy.org/apple-dma-review/#option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default) on 2024-07-21.
+
+OWA thought: Amazing! One problem down! Well done Apple for fixing it without being directly compelled to and for doing so globally.
+
+However... [according to Apple](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf), none of the above ever happened and we collectively imagined the design!
+
+In [Apple's response](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf) (published 2024-08-01) to the [CMA's working paper 5](https://assets.publishing.service.gov.uk/media/669111d949b9c0597fdafbbb/WP5_-_The_role_of_choice_architecture_on_competition_in_the_supply_of_mobile_browsers.pdf), they respond directly. First, Apple accurately describes the issue both the CMA and OWA indicated:
+
+> The UK's Competition and Markets Authority (CMA) analysis also appears to rely on an OWA report concerning an alleged ‘dark pattern’ involving the use of different UIs in order to preference Safari is set as the default browser (paragraph 3.48) by not displaying the default browser setting in the Settings app’s Safari tab where the default browser is Safari.
+> <cite>[Apple - Response to Working Papers 1 to 5](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf)</cite>
+
+They then state:
+
+> This is not correct. The default browser app setting in the Safari tab is clearly visible when the user has set Safari as the default.
+> <cite>[Apple - Response to Working Papers 1 to 5](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf)</cite>
+
+What does _"This is not correct."_ mean in this context? 
+
+The only realistic interpretation is that statements made by the CMA and OWA on this topic are "not correct" or false. That is, at the time either OWA or the CMA’s statements were written, Apple was not employing a deceptive pattern to hide the option to switch default browser if Safari was the default. This is certainly a bold claim given this was independently verified by us, ArsTechnica and the CMA. This verification included screenshots, documents and [a video of the whole process](https://youtu.be/o6uwiG1nKK4). Apple presumably also retains copies of the original code that implement this "functionality" and can easily replicate the issue.
+
+What Apple could, and should have said, here is that _"This is **no longer** correct, as we fixed it in iOS 17.x"_. Instead they appear to have, bafflingly, chosen to mislead the regulator about the existence of the issue entirely.
+
+Before accusing Apple of seeking to mislead the CMA, it's worth interrogating the alternatives:
+
+**1. Apple is correct and this behaviour never took place.**<br>
+This isn't plausible as multiple parties independently checked this.
+
+**2. Apple's lawyers writing this section didn't check or the staff they asked didn't know.**<br>
+This option at least makes Apple merely incompetent, rather than actively seeking to mislead a regulator but is it really plausible that the lawyers writing this part of the response didn’t  ask the team at Apple that implement/maintain the iOS Safari settings page whether these accusations had any basis in truth and/or that that team didn’t remember that they updated the page, fixing the behaviour, a mere 2-3 months earlier.
+
+Ultimately, what makes this situation egregious is that this is not some off-the-cuff remark in a verbal setting or a carefully constructed non-statement, it is a direct denial of specifically alleged past anti-competitive behaviour presented in a formal (and presumably carefully reviewed) response by a multi-trillion dollar organisation to an ongoing investigation conducted by a regulator. This can have serious consequences.
+
+> In practice, the CMA expects, and normally receives, full co-operation from those involved in an investigation, and does not generally use the formal powers available to it. Where necessary, however, it does do so. It should also be noted that **the provision of false or misleading information to the CMA by a party or its advisers is a criminal offence, punishable by a fine and/or up to two years in prison.**
+> <cite>[Ashurst - Quick guide to competition law investigations by UK authorities](https://www.ashurst.com/en/insights/quickguide-the-use-of-market-studies-and-market-investigations-in-uk-competition-law/#:~:text=It%20should%20also%20be%20noted%20that%20the%20provision%20of%20false%20or%20misleading%20information%20to%20the%20CMA%20by%20a%20party%20or%20its%20advisers%20is%20a%20criminal%20offence%2C%20punishable%20by%20a%20fine%20and/or%20up%20to%20two%20years%20in%20prison.)</cite>
+
+If we were the CMA, we would have a number of questions for Apple, such as:
+
+1. Is Apple claiming that at no point in the past has the behaviour described taken place?
+2. How would Apple account for the various screenshots and videos (some of which were taken by the CMA)?
+3. What steps did Apple take internally to verify this quoted paragraph was neither false nor misleading?
+4. Can we be provided copies of all emails/messages/documentation related to writing the quoted paragraph?
+5. Can we be provided copies of all internal tickets/emails/documentation related to changes to the default browser setting in the iOS Safari setting panel over the last year?
+6. Can we be provided copies of the code related to the default browser setting in the iOS Safari setting panel including all versions and changelogs over the last year?
+
+There was no particular need for a direct response to this line item, so the choice to re-write history seems especially odd. They had after all already globally fixed it at the time of their submission.
+
+We believe that tech giants shouldn't be allowed to lie to or mislead regulators and that appropriate enforcement action should take place when they can be proven to have done so. We intend to continue calling out and questioning behaviour like this. 
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+
+* [Donate to help with our running costs](https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Contact your local government representatives
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/es/posts/apple-backs-off-killing-web-apps.md
+++ b/src/es/posts/apple-backs-off-killing-web-apps.md
@@ -1,0 +1,103 @@
+---
+title: 'Apple backs off killing web apps, but the fight continues'
+date: '2024-03-01'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /es/blog/apple-backs-off-killing-web-apps/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+In a huge relief to developers and supporters of the open web, and under immense backlash, Apple has [cancelled its plan to sabotage Web Apps](https://9to5mac.com/2024/03/01/apple-home-screen-web-apps-ios-17-eu/)!. This ends weeks of fear and uncertainty for developers and users.
+
+We would like to say a massive thank you to the DMA team as Apple's decision is no doubt related to the [investigation they had opened](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc). But our most heartfelt thanks are to the thousands of developers who took the time to fill in our survey and sign the open letter, to show Apple that developers and businesses can't  be used as pawns. We are grateful for your help and no doubt will need it again - know that your voices were heard in Brussels and Cupertino, and have made a difference.
+
+The battle is not over, This simply returns us back to the status quo prior to Apple's plan to sabotage Web Apps for the EU. Apple’s over a decade suppression of the web in favour of the AppStore continues worldwide, and their attempt to destroy web apps in the EU is just their latest attempt. If there is to be any silver lining, it is that this has thoroughly exposed Apple’s genuine fear of a secure, open and interoperable alternative to their proprietary App Store that they can not control or tax.
+
+## How did we get here?
+
+[The Digital Markets Act (DMA)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) became law on 14 September 2022 and designated gatekeepers were given a 6 month grace period to comply with the regulations. Since Apple was certain to be designated this means they had almost one and half years to make the required changes. 
+
+However over the last 5 months, Apple took a different approach, one where it has continuously tried to undermine the DMA at every step, including:
+* [Claiming Safari is multiple browsers](https://www.theregister.com/2023/11/02/apple_safari_browser/)
+* [Separating out iPadOS from iOS](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) even though they are functionally almost identical
+* [Adding extremely onerous, unfair and likely illegal terms to their contract](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#apple%E2%80%99s-new-contract-for-browsers-that-wish-to-use-their-own-engine) for API access for third party browsers using their own engine
+* Deciding to lock any changes to only iPhone and the EU
+* Essentially [banning browsers from listing on alternative app stores on iOS](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#third-party-browsers-will-be-effectively-precluded-from-shipping-their-browsers-on-third-party-app-stores-on-ios)
+
+On 28th of January 2024, they pulled a new trick: break all Web Apps in the EU entirely. We first noticed it in the [first beta for iOS 17.4](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/).
+
+Initially they tried to keep it a secret. Extraordinarily there was no mention of this in [their DMA compliance plan](https://developer.apple.com/support/dma-and-apps-in-the-eu/#browser-alt-eu), [the iOS beta notes](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17_4-release-notes) or [the Safari beta notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#Web-Apps). Given how detailed these typically are and the magnitude of the change, it is impossible that this was an oversight. Clearly Apple was attempting to sneak this past the developers, users and regulators to provide everyone minimal time to respond.
+
+Over the next two weeks, Apple’s silence was deafening. No reply was given to [a Safari/WebKit ticket](https://bugs.webkit.org/show_bug.cgi?id=268643), [Apple developer forums](https://forums.developer.apple.com/forums/thread/745414), [twitter discussions](https://twitter.com/firt/status/1755406923485122615), and no statement was provided to the [many journalists](https://www.theregister.com/2024/02/08/apple_web_apps_eu/) [seeking](https://www.macrumors.com/2024/02/08/ios-17-4-nerfs-web-apps-in-the-eu/) [comment](https://www.theverge.com/2024/2/14/24072764/apple-progressive-web-apps-eu-ios-17-4).
+
+After 2 weeks, in the face of steadily increasing developer and media backlash, Apple was forced to rush out [this statement](https://developer.apple.com/support/dma-and-apps-in-the-eu#8) where they confirmed they were deliberately breaking Web Apps and that it had been planned. Astonishingly the iOS and Safari release notes have still not been updated.
+
+We, of course, had to act. We immediately informed the DMA team and then launched a series of surveys to demonstrate how detrimental this would be to businesses and users in the EU. We had over a thousand responses in a few short days and this allowed us to hand the EU excellent information about the immediate cost of Apple breaking Web Apps.
+
+We then worked shifts around the clock to launch our [incredibly successful open letter to Tim Cook](https://letter.open-web-advocacy.org/). The letter has already garnered worldwide support and has had 4264 individuals and 441 organisations sign. Signatures include two European MEPs (Karen Melchior & Patrick Breyer); a number of significant EU companies such as social media platform Mastodon; and individuals (advocating in their personal capacity) who work for SwissLife, Tchibo, W3C, Mozilla, Google, Microsoft, Vivaldi, BBC, Financial Times, ​​Red Hat, Oracle, Amazon, Wikimedia, Vercel, Netlify, Shopify, Spotify, AirBNB, Berlin University of the Arts, Open State Foundation - Netherlands, Cloudflare, Meta, Chase, Squarespace, Reddit, Atlassian, Maersk, Paypal, Salesforce, block, Adobe, ebay, Zynga, booking.com and thoughtworks; and many other developers and organisations from over 100 countries.
+
+## What happens next?
+
+While this is a stunning victory for the web, it is just one part of a longer battle.
+
+Since iOS’s inception Apple has [essentially banned third party browsers](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) from competing on iOS. All browsers currently on iOS are essentially re-skinned versions of Safari.
+
+Further Apple has set a ceiling on Web App functionality by denying them access to key features they need to compete. Apple has deliberately ensured that web apps are hidden in the operating system, and have not provided the ability to show an install button as they do with native apps.
+
+Combined [with significant bugs](https://open-web-advocacy.org/walled-gardens-report/#ios-safari-is-buggy), this has suppressed the uptake of Web Apps on mobile devices globally. Despite this, a significant number of consumers and organisations use them as a secure, open, interoperable and untaxed alternative to Apple’s and Google’s proprietary App Stores.
+
+This has also been noted by multiple regulators world wide:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+> <cite>[The Australian Competition and Consumer Commission](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf)</cite>
+
+> *Mandatory use of WebKit and reluctance to support web apps in browsers (Apple)*
+> Third-party browsers are forced to provide services based on WebKit, which lacks support for web apps, and competition through ingenuity among browsers may be impeded.
+> <cite>[Japan’s Headquarters for Digital Market Competition](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf)
+</cite>
+
+The reason the DMA states to open up browser engine competition (and iOS is the only major consumer operating system that bans competing engines) was to prevent gatekeepers from stopping third party browsers using their own engines to bring features to “web software applications”. This is stated in the act itself:
+
+> When gatekeepers operate and **impose web browser engines**, they are in a position to **determine the functionality** and standards that will apply not only to their own web browsers, but also to **competing web browsers** and, **in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)<br>
+(emphasis added)
+</cite>
+
+The fight is not over and will not be over until Apple allows both browsers and web apps to compete fairly on all their platforms globally. OWA will continue to work with both the EU Commision and regulators worldwide.
+
+In particular readers should look out for:
+* [The UK’s Market Investigation Reference into Browsers](https://open-web-advocacy.org/blog/cma-reopens-investigation-into-apple/)
+* [The UK’s Digital Markets, Competition and Consumers Bill (DMCC)](https://open-web-advocacy.org/blog/owa-2023-review/#uk) 
+* The [upcoming digital competition law in Japan](https://open-web-advocacy.org/blog/owa-2023-review/#japan) which focuses on 4 areas, one of which is browsers.
+* [Upcoming digital competition laws in Australia](https://open-web-advocacy.org/blog/owa-2023-review/#australia)
+* [Upcoming laws in India, Brazil and Korea](https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india)
+
+## We couldn’t do this without you!
+
+The enormous impact we’ve had over the last few weeks could not have been achieved without your support! Thank you to everyone who submitted a response to a survey, signed the letter or shared our calls to action on social media.  We couldn’t have done this without you.
+
+Behind the scenes, a small team of dedicated volunteers have worked almost non-stop for the past month to build and launch our surveys, open letters, social media campaigns, translate content, provide technical advice and write multiple lengthy regulatory submissions. 
+
+We’d like to personally thank, John Ozbay, Jasper Van den Ende, Lukasz Olejnik, Bruce Lawson, Runos, [Mysk](https://twitter.com/mysk_co), and Stuart Langridge for their support and we’d like to especially thank the open letter team, for putting in near full-time hours to keep the letter up and running 24/7, namely, [Art Müller](https://indieweb.social/@artmllr), [Steven Beshensky](https://hachyderm.io/@sbesh), [Jasper Van den Ende](https://mastodon.social/@Jespertheend), [Nick Chomey](https://mastodon.social/@nickchomey), [Roderick Gadellaa](https://mastodon.social/@rgadellaa) and [Angela Ricci](https://indieweb.social/@gericci). We’d like to say thank you to so many people at different organisations, who also fought hard on our side.
+
+OWA is incredibly grateful for your time and dedication and the web will be forever in your debt.
+
+We’d also like to thank everyone who has donated time or money, and all of our friends, family and colleagues who have allowed us the space and time to dedicate ourselves to this work in this extremely high-pressure moment. Thank you. ❤️
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+
+* [Donate to help with our running costs](https://open-web-advocacy.org/donate/)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Contact your local government representatives
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/es/posts/apple-dma-changes.md
+++ b/src/es/posts/apple-dma-changes.md
@@ -1,0 +1,68 @@
+---
+title: Apple's plan to allow browser competition dubbed unworkable
+date: '2024-01-27'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: James Moore
+relatedLinks:
+  - url: >-
+      https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/
+    title: >-
+      Apple announces changes to iOS, Safari, and the App Store in the European
+      Union
+    date: 2024-01-25T00:00:00.000Z
+permalink: /es/blog/apple-dma-changes/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The #AppleBrowserBan Ends in the EU!
+
+After 3 years of campaigning by @OpenWebAdvocacy and in a victory for developers and consumers, Apple has been forced to allow third-party browsers in the EU.   
+
+The Digital Markets Act compels them to finally allow browser vendors to port their real browsers to iOS by March 7th, 2024, offering users in the EU (for the first time) a legitimate choice.
+
+This news is tempered by the fact that Apple's proposed solution to comply with the DMA rules to allow browser competition has not been well received.
+
+> Apple’s proposals fail to give consumers viable choices by making it as painful as possible for others to provide competitive alternatives to Safari
+<br>&mdash; [Damiano DeMonte - Mozilla spokesperson](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox)
+
+Others in the industry we have spoken to described Apple's compliance plan as it relates to browsers as "unworkable", "a massive problem for us" and "doing everything they can to make the DMA fail".
+
+## Competing via the Web
+{% image
+  "/images/blog/apple-dma-changes.webp",
+  "Apple claims the Web is the alternative.
+  For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too. Of course, there is always the open Internet and web browser apps to reach all users outside of the App Store."
+%}
+
+Apple claims repeatedly, if you don’t like their app store, don’t use it. You can use the web and web apps to reach your customers.
+
+They say this, while at the same time preventing this from happening by not providing the tools needed in their own browser and blocking other browsers from providing them.
+
+It is clear that Apple far from being embarrassed at, for over a decade, having effectively banned all third party browsers will only change this policy where legally compelled to do so.
+
+Further, Apple’s language is rife with fear mongering:
+> “Apple argues (without any particular merit or evidence) that these other engines are a security and performance risk and that only WebKit is truly optimized and safe for iPhone users.”  <br>&mdash; [David Pierce - The Verge](https://www.theverge.com/2024/1/25/24050478/apple-ios-17-4-browser-engines-eu)
+
+Apple's decision to [geo-lock this change](https://developer.apple.com/support/alternative-browser-engines/#:~:text=for%20dedicated%20browser%20apps%20and%20apps%20providing%20in%2Dapp%20browsing%20experiences%20in%20the%20EU) underscores their on-going resistance to a truly open web. We will be actively analysing their compliance solution as well as identifying and challenging any loopholes that hinder fair competition.
+
+We need your help to scrutinise every aspect of the compliance proposal for anything that is designed to undermine the DMA’s intent. You can read about Apple’s proposal for compliance here:
+* [Apple announces changes to iOS, Safari, and the App Store in the European Union - Apple](https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/)
+* [Using alternative browser engines in the European Union - Support - Apple Developer](https://developer.apple.com/support/alternative-browser-engines/)
+* [BrowserEngineKit | Apple Developer Documentation](https://developer.apple.com/documentation/browserenginekit)
+* [Designing your browser architecture | Apple Developer Documentation](https://developer.apple.com/documentation/browserenginekit/designing-your-browser-architecture)
+* [AppStore Guidelines](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20JavaScript.%20You%20may%20apply%20for%20an%20entitlement%20to%20use%20an%20alternative%20web%20browser%20engine%20in%20your%20app.%20Learn%20more%20about%20these%20entitlements.)
+
+**This victory wouldn't have been possible without your unwavering support**. While we celebrate this important step, let's remember the fight for global browser competition continues. Stay tuned, and let's work together to ensure browser choice for all users, everywhere!
+
+**Your browser, your choice!**
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/apple-dma-review.md
+++ b/src/es/posts/apple-dma-review.md
@@ -1,0 +1,462 @@
+---
+title: Apple DMA Review
+date: '2024-06-21'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+relatedLinks: null
+permalink: /es/blog/apple-dma-review/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<p>
+  The Digital Markets Act (DMA) aims to restore contestability, interoperability,
+  choice and fairness back to digital markets in the EU. These fundamental
+  properties of an effectively functioning digital market have been eroded by the
+  extreme power gatekeepers wield via their control of “core platform services”.
+</p>
+<p>
+  The lack of competition on mobile ecosystems is, at its heart, a structural one.
+  Gatekeepers wield vast power due to the security model that these devices are
+  built on. Traditionally, on operating systems such as Windows, macOS and Linux,
+  users can install any application they want, with no interaction from the
+  operating system gatekeeper, either by the business or the end user. Users can
+  then grant these programs the ability to do anything they desire.
+</p>
+<p>
+  Locking down what applications can do, such as restricting which APIs they can
+  access behind user permissions, is not by itself anti-competitive and can bring
+  legitimate security advantages. However, the manner in which it has been
+  implemented on mobile devices is both self-serving and in its current form,
+  significantly damages competition.
+</p>
+<p>
+  This damage surfaces in several forms:
+</p>
+<p>
+  First, the gatekeeper can control what is allowed to be installed on devices
+  they have already sold to consumers, often for a significant profit. They
+  utilize this device-level control to demand a 30% cut of all third-party
+  software that the consumer installs, not on merit, but simply because they
+  control the only mechanisms available to businesses to release that software,
+  and can further block or hinder the consumer from using or acquiring services
+  outside of their app store.
+</p>
+<p>
+  The second is more subtle. In order to deliver their “native” apps to consumers
+  on Android or iOS, developers must create custom applications in specific
+  programming languages for each individual platform. Typically, companies will
+  require separate development teams for each OS. This not only multiplies
+  development and maintenance cost, but puts in place an invisible barrier to
+  interoperability. Even the built up expertise for creating software for a
+  specific platform provides significant lock-in advantages to the platform’s
+  gatekeeper.
+</p>
+<p>
+  Finally, even if a developer has no desire to interact with the gatekeeper, they
+  are forced into a commercial and legally binding relationship with them. This is
+  due to the fact that the gatekeeper inserts itself between the customer and
+  these third party developers. With smartphones now 15 years old, this may seem
+  normal to us now, but imagine if Microsoft demanded that every software provider
+  signed an onerous contract with them or be barred from releasing a product on
+  Windows. What would have been unacceptable, anti-competitive behavior to both
+  consumers, businesses and regulators on desktop, has been tolerated on mobile
+  simply because these computers were considered a “new” category.
+</p>
+<p>
+  Mobile devices are just small computers whose primary input is touch, there is
+  no sacred or magical property that means they have to run on a proprietary app
+  store model. Nothing is stopping mobile computers running on the open model that
+  desktop computers run on, just as there is nothing stopping a desktop computer
+  running the app store model. Inertia and great profits are however powerful
+  forces. Between them, Apple and Google have created a powerful and entrenched
+  duopoly.
+</p>
+<p>
+  Even with the DMA forcing Apple to open up the ecosystem to competition, Apple
+  is still inserting themselves front and center between consumers and app
+  developers. They insist all developers for iOS/iPadOS (including developers who
+  have no intention of using their app store) pay them $100 per year, that they
+  sign the full Apple developer program contract and submit themselves to what is
+  effectively app store review (although nominally locked to security). Worse,
+  they are attaching significant recurring penalty fees to developers who dare to
+  make their software available outside of Apple’s app store. Apple is using every
+  tool at their disposal to dissuade developers from leaving their app store and
+  to undermine the goals of the DMA.
+</p>
+<p>
+  Apple's key excuse to impose this control is security. Apple's argument is, in
+  essence, that only they can be trusted to vet what consumers are allowed to
+  install on their devices. All third parties must submit to their review.
+</p>
+<p>
+  What is needed is a way to securely run interoperable and capable software
+  across all operating systems. Luckily, such a solution already exists and is not
+  only thriving on open desktop platforms but is dominating, and that
+  dominance is growing every year. The solution is of course, the Web and more
+  specifically Web Apps. Today, more than 60% of users' time on desktop is done
+  using web technologies, and that looks set to only grow.
+</p>
+<p>
+  Web Apps have a number of properties that allow them to solve this critical
+  problem. They are run in the security of the browser's sandbox, which <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">even
+    Apple admits is “orders of magnitude more stringent than the sandbox for native
+    iOS apps.”</a>. They are truly interoperable between operating systems. They
+  don't require developers to sign contracts with any of the OS gatekeepers. They
+  are capable of incredible things and 90% of the apps on your phone could be
+  written as one today.
+</p>
+<p>
+  So why aren't they thriving on mobile? The simple answer to this question is
+  lack of browser competition on iOS and active hostility by Apple towards
+  effective Web App support, both by their own browser and by their OS. Apple's
+  own browser faces no competition on iOS, as they have effectively barred the
+  other browsers from competing by prohibiting them from using or modifying their
+  engines, the core part of what allows browser vendors to differentiate in
+  stability, features, security and privacy.
+</p>
+<p>
+  The DMA explicitly sets out to right this wrong by mandating that gatekeepers
+  can no longer enact such a ban:
+</p>
+
+<blockquote>
+  <p>In particular, each browser is built on a web
+    browser engine,
+    which is responsible for key browser functionality such as
+    speed, reliability and web compatibility. When gatekeepers
+    operate and impose web browser engines, they are in a position
+    to determine the functionality and standards that will apply
+    not only to their own web browsers, but also to competing web
+    browsers and, in turn, to &gt;web software applications.
+    Gatekeepers
+    should therefore not use their position to require their
+    dependent business users to use any of the services provided
+    together with, or in support of, core platform services by the
+    gatekeeper itself as part of the provision of services or
+    products by those business users.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital
+        Markets Act - Recital 43</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent stated for this in the DMA is to prevent gatekeepers from dictating
+  the speed, stability, compatibility and feature set of “web software
+  applications”.
+</p>
+<p>
+  Apple has announced new rules that would, at first glance, allow browser vendors
+  to port their real browsers to iOS. However, on closer inspection, this is a
+  mirage. Instead Apple appears intent on making it <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">“as
+    painful as possible” for browser vendors</a> to port their engines to
+  iOS/iPadOS. As we will outline in our paper, Apple's current proposal falls far
+  short of compliance. Apple is not only undermining browser competition on iOS,
+  but appears to be actively attempting to prevent the growth of an entire open
+  and interoperable ecosystem that could feasibly supplant and replace their app
+  store model.
+</p>
+<p>
+  Apple have seen the Web as a threat to their app store as far back as 2011, when
+  Philip Schiller internally sent an email to Eddie Cue titled “HTML5 poses a
+  threat to both Flash and the App Store”.
+</p>
+
+<blockquote>
+  <p>
+    Food for thought: Do we think our 30/70% split will last forever? While I am a
+    staunch supporter of the 30/70% split and keeping it simple and consistent across
+    our stores, I don’t think 30/70 will last unchanged forever. I think someday we will
+    see a challenge from another platform or a web based solution to want to adjust our
+    model.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+        Phil Schiller - Apple Upper Management
+      </a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This attitude appears not to have changed. Faced with the genuine possibility of third-
+  party browsers effectively powering Web Apps, Apple's first instinct appears to have
+  been to <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+    remove Web Apps support entirely with no notice to either businesses or
+    consumers</a>. Luckily, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+    under significant pressure, Apple backed down</a> from this particular
+  stunt at the last moment.
+</p>
+
+<p>
+  Apple is very explicit in its public statement that they initially planned to remove the
+  functionality as the DMA would force them to share it with third-party browsers. Even in
+  their statement backing down, they make it clear they do not intend to allow third-party
+  browsers that use their own engine to be able to install and manage Web Apps. In both
+  statements, Apple cites "security" as the reason for their decisions.
+</p>
+<p>
+  Unfortunately for Apple, it has been unable to prove that Safari or WebKit are actually
+  more secure than its competitors. When obligated by the UK’s Competition and Markets
+  Authority to provide evidence to back up its assertion that WebKit was more secure than
+  Blink or Gecko, Apple failed to do so.
+</p>
+
+<blockquote>
+  <p>... the evidence that we have seen to date does not suggest that there are material
+    differences in the security performance of WebKit and alternative browser engines.
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>Overall, the evidence we have received to date does not suggest that Apple's
+    WebKit restriction allows for quicker and more effective response to security threats
+    for dedicated browser apps on iOS.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Apple's actions not only hurt the Web ecosystem, third-party businesses (be they
+  browser vendors or software developers), but also make their devices worse for their own
+  consumers. By depriving their consumers of the choice and competition that fair and
+  effective browser and Web App competition would bring, they are worsening the
+  functionality, interoperability, stability, security, privacy, and price of services on their
+  devices.
+</p>
+<p>
+  A reasonable person might argue
+  <em>Why would Apple make their own devices worse, surely
+    better devices means more hardware sales?</em> This behavior comes, however, with key
+  advantages for Apple, even if they harm Apple's own consumers.
+</p>
+
+<p>
+  Critically, service revenue is of growing importance for Apple as
+  <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">their hardware sales have
+    peaked and are declining</a>. Apple has not had a “hit” new product for 14 years, namely the
+  iPad, and, if you are being generous, 9 years for the Apple Watch. It does not currently
+  seem likely that Apple’s VR/AR headset
+  <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">will
+    have any significant impact on Apple’s overall
+    hardware sales</a>.
+</p>
+
+<p>
+  The UK regulator cites two incentives: protecting their app store revenue from
+  competition from Web Apps, and protecting their Google search deal from competition
+  from third-party browsers.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple receives significant revenue from Google
+      by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially
+    from high usage
+    of Safari. [...] <strong class="stressed">The WebKit restriction may help to
+      entrench this position</strong> by limiting
+    the scope for other browsers on iOS to differentiate themselves from Safari [...] As
+    a result, it is less likely that users will choose other browsers over Safari, which in
+    turn <strong class="stressed">secures Apple’s revenues from Google</strong>.
+    [...]
+    Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via Apple
+    IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring
+    all browsers on iOS to use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control
+      over the maximum functionality of all browsers on iOS</strong> and, as a consequence,
+    hold up the development and use of web apps. This limits the <strong class="stressed">competitive
+      constraint that web apps pose on native apps</strong>, which in turn protects and benefits
+    Apple’s App Store revenues.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  These two revenue streams are vast, even for a company of Apple’s size. Apple collected
+  <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.">
+    $85 billion USD in App Store fees in 2022</a>,
+  of which it keeps approximately 30%. Apple
+  reportedly receives
+  <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+    $18-20 billion USD</a> a year from their Google Search engine deal,
+  accounting for 14-16 percent of Apple's annual operating profits.
+</p>
+<p>
+  A third and interesting incentive the CMA does not cite, but which the US's Department of
+  Justice does, is that this behavior greatly weakens the interoperability of Apple's devices,
+  making it harder for consumers to switch or multi-home. It also greatly raises the barriers
+  of entry for new mobile operating system entrants by depriving them of a library of
+  interoperable apps.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple has long understood how middleware can help promote
+      competition</strong> and
+    its myriad benefits, including increased innovation and output,
+    <strong class="stressed">by increasing scale and interoperability</strong>.
+    [...]
+    In the context of smartphones, examples of
+    <strong class="stressed">middleware include internet browsers</strong>,
+    internet or cloud-based apps, super apps, and smartwatches, among other products
+    and services.
+    [...]
+    <strong class="stressed">
+      Apple has limited the capabilities of third-party iOS web browsers, including by
+      requiring that they use Apple’s browser engine, WebKit</strong>.
+    [...]
+    Apple has sole discretion to review and approve all apps and app updates.
+    <strong class="stressed">Apple
+      selectively exercises that discretion to its own benefit</strong>, deviating from or changing
+    its guidelines when it suits Apple’s interests and allowing Apple executives to control
+    app reviews and decide whether to approve individual apps or updates. Apple often
+    enforces its App Store rules arbitrarily.
+    <strong class="stressed">And it frequently uses App Store rules and
+      restrictions to penalize and restrict developers that take advantage of
+      technologies that threaten to disrupt, disintermediate, compete with, or erode
+      Apple’s monopoly power</strong>.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+        DOJ Complaint against Apple</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Interoperability via middleware would reduce lock-in for Apple’s devices. Lock-in is a clear
+  reason for Apple to block interoperability, as can be seen in this email exchange where
+  Apple executives dismiss the idea of bringing iMessage to Android.
+</p>
+
+<blockquote>
+  <p>
+    The #1 most difficult [reason] to leave the Apple universe app is iMessage ...
+    iMessage amounts to serious lock-in
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Unnamed Apple Employee</a>
+    </cite>
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>
+    iMessage on Android would simply serve to remove [an] obstacle to iPhone
+    families giving their kids Android phones ... moving iMessage to Android will hurt us
+    more than help us, this email illustrates why.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Craig Federighi - Apple's Senior Vice President of Software Engineering</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>The DMA has the power to fix all of these underlying issues and unleash a powerful,
+  open, interoperable and secure competitor to not only Apple's
+  app store but also Google's. Lack of
+  contestability for mobile app stores and mobile operating systems is
+  a key concern for the DMA that viable Web
+  Apps solve.
+</p>
+
+<p>This will also remove a heavy burden from new entrants into the operating system
+  market; lack of apps. No longer will developers need to develop custom apps
+  for each operating system, any
+  operating system with good web app support and browser competition will support
+  all web apps automatically. Web
+  Apps support operating systems that developers have not even heard of.
+  The impact of allowing them to compete
+  fairly on mobile will be profound.
+</p>
+
+<p>
+  We request the Commission open a proceeding into Apple and investigate what we allege
+  is severe and deliberate non-compliance. The number of ways that Apple is not complying is so myriad that we,
+  recognising that the commision does not have infinite resources to pursue all of them simultaneously, have split
+  them into three tranches of remedies.
+</p>
+<p>Some remedies require time and/or pre-requisite remedies in order to be effective.
+  Remedies in this document are ordered to ensure that either competitive benefits are delivered earlier or to
+  unlock future remedies. In this way, we propose a program of continual improvement in the competitive landscape,
+  delivering wins at every step along the path.
+</p>
+
+<p>While we have attempted to be comprehensive, it is possible, and perhaps even likely,
+  that there will be infringements that we have not included or are not yet aware of.
+</p>
+
+<p>Our proposed remedies include:</p>
+
+<ul>
+  <li>Restricting Apple's API contract for browsers down to strictly necessary,
+    proportionate and justified security measures.</li>
+  <li>Make clear what the security measures are for third party browsers using
+    their own engine by publishing them in a single up-to-date document.</li>
+  <li>Removing any App Store rule that would prevent third party browsers from
+    competing fairly.</li>
+  <li>Allow browser vendors to keep their existing EU consumers when switching
+    to use their own engine.</li>
+  <li>Removing the special placement of Safari.</li>
+  <li>Making Safari uninstallable.</li>
+  <li>Implementing Install Prompts in iOS Safari for Web Apps.</li>
+  <li>Allowing Browser Vendors and Developers to be able to test their browsers
+    and web software outside the EU.</li>
+  <li>Allowing Browsers using their own engine to install and manage Web Apps.</li>
+  <li>Make notarization a fast and automatic process, as on macOS.</li>
+  <li>Allow direct browser installation independently from Apple’s app store.</li>
+  <li>Allow users to switch to different distribution methods of a native
+    app and allow developers to promote that option to the user.</li>
+  <li>Don't break third party browsers for EU residents who are traveling.</li>
+  <li>Opt-Into Rights contract should be removed.</li>
+  <li>Core Technology Fee should be removed.</li>
+  <li>Apple should publish a new more detailed compliance plan.</li>
+</ul>
+
+<p>Apple is obligated under Articles 5(7), 6(3), 6(4) and 6(7) to fix each
+  of the above issues. Apple has failed to achieve effective compliance
+  with these obligations contrary to Article 13(3). Further Apple has
+  taken numerous and significant steps that obstruct and undermine it in
+  contravention of Article 13(4). Apple has introduced conditions and
+  restrictions on DMA-conferred rights that have no legal basis in the
+  DMA and gone far beyond the restrictions that the DMA does allow by
+  introducing rules that have no basis in security or that are not justified,
+  strictly necessary or proportionate.
+</p>
+
+<p>Any intervention that the Commission makes will have global ramifications. Regulators around the world are carefully watching the implementation of the DMA as they plan their own regulatory regimes. Already <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">Japan has become the second jurisdiction in the world to explicitly prohibit banning browser engines</a>. <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">Australia</a>, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">India, Korea and Brazil</a> are all planning on implementing their own versions of the DMA. The UK has just <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">passed the Digital Markets, Competition and Consumers Bill</a> that grants their regulator great power to enforce codes of conduct against tech giants.
+</p>
+
+<p>Successful resolution of these issues have an exceptional chance of becoming de facto global, as no jurisdiction will want to miss out on clear benefits being enjoyed by EU consumers. However, if Apple manages to successfully avoid complying with the DMA, these problems could persist indefinitely.
+</p>
+
+<p>
+  We urge the Commission to enforce the DMA and obligate Apple to allow
+  browsers and Web Apps to compete fairly and effectively on their mobile ecosystem.
+  This will unlock contestability, fairness and interoperability. Companies will then
+  have to compete for users on merit, not via lock-in or control over operating
+  systems. Consumers will benefit from choice, better quality and cheaper software,
+  interoperability, and the genuine ability to multihome across devices and operating
+  systems offered by different companies.
+</p>
+
+<p>
+  These changes can finally fix a mobile ecosystem that has been
+  structurally broken, and artificially hindered, for more than a decade.
+</p>
+
+
+<p>That was the introduction to our report. You can read the <a href="/apple-dma-review/#h.3znysh7">full far more detailed report here.<a></p>

--- a/src/es/posts/apple-filing-eu-appstores.md
+++ b/src/es/posts/apple-filing-eu-appstores.md
@@ -1,0 +1,38 @@
+---
+title: Apple files another challenge to the EU Digital Markets Act
+date: '2024-01-09'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: Frances Berriman
+permalink: /es/blog/apple-filing-eu-appstores/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/apple-appstore-filing-img.webp",
+  "Apple will be allowed to continue not offering alternative browsers to their users via the default mechanism those users get apps - Open Web Advocacy"
+%}
+
+We’ve previously covered filings from Apple [claiming Safari is actually 3 browsers](https://www.macrumors.com/2023/11/04/apple-argued-safari-is-three-different-browsers) and that [iPadOS shouldn’t be regulated under the DMA](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) at all, which are arguments that have not held much water in our minds. But on Monday the EU published Apple's November filing, so we’ve been [able to see a bit more about what they’re requesting](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:C_202400563). 
+
+In this latest filing, Apple claims that:
+
+1. That the EU’s application of the DMA is a disproportionate intervention in response to iOS market distortions. 
+2. The AppStore should be considered five separate entities, one for each OS (iPadOS, iOS, watchOS, tvOS and macOS). We’ve [previously discussed](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) how Apple’s distinction between iPadOS and iOS is tenuous.
+3. That iMessage should not be designated, because iMessage is neither hardware nor subscription dependant.
+
+At OWA, we don’t have a ton of opinions on the third claim, but we do on the first two, as they’re material to the interests of web developers and relevant browser competition.
+
+If Apple is able to convince the EU not to regulate their AppStore, Apple will be allowed to continue effectively banning third party browsers from being available to their users via the default mechanism those users get apps. As [discussed extensively](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) Apple has banned third party browsers on iOS from using their own engine or modifying an existing engine, instead forcing third party browser vendors to build a browser on top of the system supplied WebKit WebView over whose functionality Apple has exclusive control. A possible outcome of avoiding EU regulation of their App Store is that users may only be allowed to later have additional browsers via side-loading, but OWA is sceptical about this as a path to a fairer landscape.
+
+[With 57 days remaining until the Digital Markets Act enforcement begins](https://digital-markets-act.ec.europa.eu/about-dma_en), we expect to see a few more filings from Gatekeepers, as well as responses from the EU. We’ll keep you posted!
+
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/apple-implements-six-of-owas-dma-compliance-requests.md
+++ b/src/es/posts/apple-implements-six-of-owas-dma-compliance-requests.md
@@ -1,0 +1,188 @@
+---
+title: Apple implements six of OWA's DMA compliance requests
+date: '2024-10-25'
+tags:
+  - Policy
+  - Apple
+  - EU
+  - DMA
+author: OWA
+permalink: /es/blog/apple-implements-six-of-owas-dma-compliance-requests/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: Apple has fixed 6 important issues with allowing browsers and Web Apps to compete on iOS (including allowing browser vendors to test their own browsers outside the EU) but a massive list of issues remain to be fixed in order to be in compliance with the DMA.**
+
+**Most importantly, there is no indication that Apple will allow Web Apps to run in a browser's own engine despite the [news](https://www.macrumors.com/2024/10/24/ios-18-2-eu-third-party-browser-web-apps/) [reports](https://9to5mac.com/2024/10/23/ios-18-2-web-apps-browser-engine-in-the-eu/) OR that browsers will be able to use their own engine without being forced to lose their existing customers.**
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1849747949317914780), [Mastodon](https://mastodon.social/@owa/113367403899362760) and [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_apples-ios-182-has-implemented-6-of-owas-activity-7255515996558381056-0nig).
+
+Readers Note: When you see the term "EU Only" in this article it's important to recognize this as a reflection of Apple's anti-competitive practices. Such measures should ideally be implemented on a global scale, promoting fair competition for all their users in all jurisdictions.
+
+## What have they done?
+
+Apple has announced a series of changes in iOS 18.2 related to third-party browsers in the EU.
+
+> Following feedback from the European Commission and from developers, in these releases developers can develop and test EU-specific features, such as alternative browser engines, contactless apps, marketplace installations from web browsers, and marketplace apps, from anywhere in the world. Developers of apps that use alternative browser engines can now use WebKit in those same apps.
+> <cite>[Apple - Blog on iOS 18.2](https://developer.apple.com/news/?id=qs5bol0g)</cite>
+
+### Dual Engine Browsers (EU ONLY)
+
+Due to Apple’s 16 year ban of third-party browser engines, browser vendors will need to gradually phase in their own engines over time using phased roll-outs and multi-variant testing. Deploying an engine to a new operating system is a complex process and has to be done in a slow and methodical manner to identify bugs and performance issues.
+
+As a result, it is essential that all browser vendors be allowed to ship dual engine browsers. That is, browsers that can use both the system provided WKWebView and their own engine within a single binary. The binary would only contain the code for a single engine, the one the browser vendor provides, since the WKWebView is an operating system provided component.
+
+Browser vendors also need to be allowed to keep their existing EU users. Allowing dual engine browsers also makes this simple by letting browser vendors simply toggle their own engine on or off depending on if Apple allows them to use it in a particular jurisdiction.
+
+However, Apple had added a rule in their contract to explicitly ban this:
+
+> Be a separate binary from any Application that uses the system-provided web browser engine;
+> <cite>[Apple Browser Engine Entitlement Contract - 2024-06-24](/files/Apple%20Browser%20Engine%20Entitlement%20Contact%20(2024-06-24).pdf)</cite>
+
+To our knowledge there was no reasonable or rational reason to impose this restriction. It would also appear to be in violation of the DMA which only allows APIs to be restricted on the grounds of strictly necessary, proportionate and justified security grounds.
+
+On October the 23rd, [the contract](/files/Apple%20Browser%20Engine%20Entitlement%20Contact%20(2024-10-23).pdf) was updated to remove that single line. 
+
+Apple also announced the change in this blog post:
+
+> Developers of apps that use alternative browser engines can now use WebKit in those same apps.
+> <cite>[Apple - Blog on iOS 18.2](https://developer.apple.com/news/?id=qs5bol0g)</cite>
+
+Importantly this means that browser vendors currently need two browsers. A Webkit only one for outside the EU and their existing EU customers, and a new one that uses their own engine (and can now also use the WebKit engine). 
+
+### Allowing Browser Vendors to Test their own Browsers Outside the EU
+
+Astonishingly, Apple decided earlier this year to make it impossible for browser vendors to test their own browsers if the developers were not physically located in the EU.
+
+> The Register has learned from those involved in the browser trade that Apple has limited the development and testing of third-party browser engines to devices physically located in the EU. That requirement adds an additional barrier to anyone planning to develop and support a browser with an alternative engine in the EU. <br><br>
+> It effectively geofences the development team. Browser-makers whose dev teams are located in the US will only be able to work on simulators. While some testing can be done in a simulator, there's no substitute for testing on device – which means developers will have to work within Apple's prescribed geographical boundary.
+> <cite>[Thomas Claburn - The Register](https://www.theregister.com/2024/05/17/apple_browser_eu/)</cite>
+
+This was clearly ridiculous. With iOS 18.2, Apple now allows not only browser vendors but all app developers (wherever they are in the world) to test their own apps which use APIs or functionality that Apple currently restricts to the EU.
+
+However, there is still no solution proposed by Apple to allow web developers outside the EU the ability to test and maintain their websites and Web Apps for EU consumers on third-party browsers which use their own engine. This is and will remain a significant barrier to browser competition on iOS.
+
+Our proposal is that web developers outside the EU should be able to download test versions of EU browsers via an Apple Developer Account for the purpose of testing their own products.
+
+### Centralised Defaults (GLOBAL)
+
+For the last 16 years Apple has had no centralised location to change defaults. Up until iOS late 2020 (iOS 14\) it wasn’t even possible to change the default browser. When Apple finally did allow users to change the default browser, they added the [brazen deceptive pattern of hiding the dropdown to change default browser if Safari was already the default](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/). This was only quietly fixed in iOS 17.5 [due to OWA](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) [and later Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/) calling Apple out on the behaviour.
+
+In [our review of Apple’s DMA compliance](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api) we outlined that Apple needed to add a centralised location to change defaults.
+
+[In August](https://www.theverge.com/2024/8/22/24226110/apple-iphone-ipad-default-apps-eu-competition) Apple announced that they were making this change for the EU. Now, this change is being rolled out globally. Our assumption is that Apple struggled to explain to other regulators worldwide why this change, already implemented for EU users, should be withheld from global users.
+
+### Browsers can Detect if Default Browser (EU ONLY)
+
+Browsers can now detect if they are the default browser **once per year**.
+
+> In iOS 18.2 and iPadOS 18.2, a new API will allow a browser app to check if it is currently the default browser app. To reduce the likelihood that users will face continuous requests to set a browser as their default, this API will only tell the browser app if it is the default once per year. This API will be further documented in an upcoming beta release of iOS 18.2 and iPadOS 18.2.
+> <cite>[Apple - Default Apps](https://developer.apple.com/documentation/updates/defaultapps)</cite>
+
+We had previously written about [how browser vendors need the ability to detect whether they are the default browser](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api) in order to allow better onboarding processes and not bother users who have already set their browser as default.
+
+While there is some rationale for preventing browsers from repeatedly asking users, it is not clear that it is necessary to limit the ability to check the current status. Apple has for example felt there is no need to add a limit on the number of times a native app [can check if they have permission to use notifications](https://developer.apple.com/documentation/usernotifications/asking-permission-to-use-notifications#Customize-notifications-based-on-the-current-authorizations).
+
+We’ll be checking in with the browser vendors and pro-consumer groups to see what they think of the once per year limit, to work out our own opinions as to whether this is reasonable consumer protection measure or if it’s simply anti-competitive. Safari pulls in $20 billion USD annually for Apple and 14-16 percent of Apple's annual operating profits, so any decisions like this have to be examined with a fine-tooth comb.
+
+### Prompt for Default Browsers missed in Previous Choice Screen to be Placed in the Hotseat/HomeScreen (EU ONLY)
+
+[In August Apple announced they would implement one of our recommendations](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/) that browsers chosen in the choice seat would get placed in the hotseat/dock/first homescreen replacing Safari.
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser that is not currently installed on their device from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen
+> <cite>[Apple - About the browser choice screen in the EU (2024-08-19)](https://web.archive.org/web/20240919123712/https://developer.apple.com/support/browser-choice-screen/)</cite>
+
+
+One issue with this, [which we wrote about at the time](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/), is it does not apply to browsers which are already installed. Apple needed to update this to move already installed browsers onto the hotseat to replace the Safari icon when it had been selected on the choice screen.
+
+Apple have now update the policy with the following relatively complex paragraphs:
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser that is not currently installed on their device from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen. If the user selects a browser that is currently installed on their device from the choice screen but not on the first page of the Home Screen or the Dock, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen. <br><br>
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user had previously selected another other browser as their default from the choice screen before updating to iOS 18.2, they will be prompted once upon first launch of Safari about whether they want to swap Safari’s icon with the icon of their default browser. This is only if their default browser is not on the first page of the home screen or the Dock.
+> <cite>[Apple - About the browser choice screen in the EU](https://developer.apple.com/support/browser-choice-screen/)</cite>
+
+This means that any browser chosen on the choice screen will replace Safari on the dock/first home screen if it is there.
+
+For browsers that were already installed prior to the previous choice screen, chosen as default on the choice screen (and which Apple decided not to move onto the dock/first home screen), these browsers will now prompt the user if they would like to swap with Safari’s icons location on first launch of Safari.
+
+Prompting the user when they are trying to open Safari feels like an attempt to get the user to dismiss the prompt, as they are likely midway through a task; and it’s hard to see a reason for this other than an anti-competitive attempt to add friction to the user switching which browser they primarily use. This prompt should happen as part of the iOS 18.2 update process.
+
+### Users can uninstall Safari (EU ONLY)
+
+Apple will now let EU users uninstall Safari. This is psychologically important as it indicates to users that Safari is just another app on their phone that can be uninstalled and replaced, just like any other non-Apple app.
+
+This is a change that is required by the DMA and that [we argued in favour of](https://open-web-advocacy.org/apple-dma-review/#safari-is-not-uninstallable) earlier this year. Importantly, the WKWebView and SFSafariViewController should be treated as system components, and it should not be possible to uninstall them.
+
+## What's Left?
+
+### Browsers still can't install Web Apps powered by their Own Engine
+
+> With the release of the first beta of iOS 18.2 to developers on Wednesday, Apple has published documentation for a new API that will let third-party browsers add web apps to the iPhone Home Screen using their own custom engine. **This means that the entire web app experience will run using the same engine as the browser through which it was added.**<br><br>
+> Of course, there’s a catch. Currently, only web browsers distributed in the EU can have a custom engine. In the rest of the world, Apple still requires web browsers for iPhone and iPad to use Safari’s WebKit. Unsurprisingly, the new API for web apps is also only available in the EU.
+> <cite>[Filipe Espósito - 9to5mac](https://9to5mac.com/2024/10/23/ios-18-2-web-apps-browser-engine-in-the-eu/)<br>(emphasis added)</cite>
+
+When we first saw the article headline we were incredibly excited, as this would finally be a key step into unlocking Web Apps. Web Apps are amazing because you only have to code them once, they work on every device, have significantly better security, and don't require you to pay excessive rents to gatekeepers.
+
+However, having looked through Apple's documentation we believe this functionality won't allow third-party browsers to install web apps powered by their own engine, and will simply continue to exclusively offer Apple's WebKit based Web Apps in contravention of the DMA.
+
+We have contacted Filipe Espósito from 9to5mac to request that he verify this statement with Apple and the other major browser vendors. At the time of publishing this article, we have yet to receive a response.
+
+### Browser Vendors are still Obligated to Ship a Brand New App
+
+Apple has chosen to restrict browser competition on iOS to the EU. Apple’s actions seek to force third-party browser vendors to build, develop, and maintain two versions of their apps for iOS while Apple’s own Safari bears no such costs.
+
+Apple’s rules appear to force browser vendors to ship a brand new version of their app in the EU, rather than update existing apps to use their own engines. This will cause browser vendors to lose existing customers, as consumers will need to manually download the new browser.
+
+This complexity and friction is a direct result of Apple’s own anti-competitive actions over the past 16 years. Apple’s insistence that competitors will be allowed to compete on a level playing field (with their own engines) only in the EU is already a high burden, and this rollout plan would levy additional transition costs on competitors. It is reasonable and proportionate that Apple takes steps to mitigate the damage they appear intent on causing.
+
+Forcing browser vendors to ship two distinct products in Europe will lead to end user confusion and significant harm to these browser vendors. We do not believe that such an approach would be either fair or compliant with the DMA.
+
+Apple should not be forcing browser vendors to reacquire existing users. Apple will need to implement a solution where browser vendors can use their own engines and keep their existing EU users.
+
+Absent the real good faith solution of just allowing browser competition globally, there remains a simple solution: to simply allow browser vendors to ship their browsers globally under a single bundle ID with both Webkit and their own engines and let them know if that user is allowed to use the browser’s own engine with a true/false environment variable or equivalent.
+
+Additional complexity and questions arise when users move in and out of the EU, will their browser continue to work when they are on holiday?  How does data transfer work (cookies, Indexeddb, localstorage etc) internally between the WebKit version and the browsers own engine’s version. These are challenging issues that arise from Apple's reluctance to address anti-competitive behaviour except in jurisdictions where they are compelled to do so.
+
+### Other Problems
+
+While today's news are important steps to allowing fair and effective browser and web app competition on iOS, a great many DMA compliance issues remain, including:
+
+* [Allow browser vendors to keep their existing EU consumers when switching to use their own engine.](https://open-web-advocacy.org/apple-dma-review/#allow-browser-vendors-to-keep-their-existing-EU-customers)  
+* [Allowing Developers to be able to test their browsers and web software outside the EU.](https://open-web-advocacy.org/apple-dma-review/#testing-for-browser-vendors-and-developers-outside-the-EU)  
+* [Restricting Apple's API contract for browsers down to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/apple-dma-review/#remove-non-security-terms)  
+* [Make clear what the security measures are for third party browsers using their own engine by publishing them in a single up-to-date document.](https://open-web-advocacy.org/apple-dma-review/#security-rules-must-be-clear)  
+* [Implementing Install Prompts in iOS Safari for Web Apps.](https://open-web-advocacy.org/apple-dma-review/#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers)  
+* [Allowing Browsers using their own engine to install and manage Web Apps.](https://open-web-advocacy.org/apple-dma-review/#web-app-installation-and-management-for-third-party-browsers)  
+* [Removing any App Store rule that would prevent third party browsers from competing fairly.](https://open-web-advocacy.org/apple-dma-review/#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43)  
+* [Make notarization a fast and automatic process, as on macOS.](https://open-web-advocacy.org/apple-dma-review/#apple-should-make-notarization-for-directly-downloaded-browsers-automatic)  
+* [Allow direct browser installation independently from Apple’s app store.](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation)  
+* [Allow users to switch to different distribution methods of a native app and allow developers to promote that option to the user.](https://open-web-advocacy.org/apple-dma-review/#allow-users-to-switch-the-distribution-method-of-native-apps)  
+* [Respect the users choice of default browser in SFSafariViewController](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* [Don’t lock Safari to Apple Pay](https://open-web-advocacy.org/apple-dma-review/#safari-is-locked-to-apple-pay)  
+* [Don't break third party browsers for EU residents who are travelling.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu)  
+* [Opt-Into Rights contract should be removed.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu:~:text=with%20the%20DMA.-,4.3.6.%20Opt%2DIn%20Rights%20Contract%20Should%20Be%20Removed,-All%20businesses%20serving)  
+* [Core Technology Fee should be removed.](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed)  
+* [Publish a new more detailed compliance plan.](https://open-web-advocacy.org/apple-dma-review/#apple-should-publish-a-new-more-detailed-compliance-plan)
+
+## What now?
+
+The EU Commission seems to be a slow-moving, but unstoppable, force. Despite the DMA having no legal power outside of the EU, this is already having a global impact with beneficial changes being exported worldwide such as [Apple allowing game emulators](https://au.pcmag.com/mobile-apps/104689/apple-is-finally-allowing-retro-game-emulators-in-the-app-store) and the [new fairer centralised defaults screen](https://www.theverge.com/2024/10/23/24277926/apple-iphone-default-messaging-apps-ios-18-2).
+
+> When Apple said that iPhone owners in the EU would be able to set new default apps for things like calling and messaging, it sounded a lot like only people in the EU would get that option.<br><br>
+> That’s not the case<br><br>
+> [...]<br><br>
+> But the big stuff, like support for alternative app stores and browser engines, has mostly been confined to the EU. A side effect is that a European iPhone was starting to look quite a bit different from one in the US, which was weird. But by spreading some of these new options across borders, Apple will maintain better consistency in its product. At the very least, it’s a little more fun.
+> <cite>[Allison Johnson - The Verge](https://www.theverge.com/2024/10/23/24277926/apple-iphone-default-messaging-apps-ios-18-2)</cite>
+
+We wholeheartedly agree with the Verge, more competition and more ability for developers to innovate is more fun and, most importantly, it’s what is best for consumers.
+
+With each step the EU takes we are starting to see a future where gatekeepers' anti-competitive hold on their operating systems is broken, and the Web can compete fairly on mobile. These DMA changes are spreading out globally and [regulators in other countries are watching carefully as they plan their own policies to allow for fair and effective competition](https://open-web-advocacy.org/blog/owa-2023-review/). 
+
+Stay tuned and follow us in all the usual places:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/apple-loses-on-appeal.md
+++ b/src/es/posts/apple-loses-on-appeal.md
@@ -1,0 +1,97 @@
+---
+title: 'Apple loses on Appeal, CMA can restart investigation into browsers'
+date: '2023-12-01'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Alex Moore
+permalink: /es/blog/apple-loses-on-appeal/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/AppleLosesonAppeal.webp",
+  "Apple loses on Appeal,  CMA Investigation into browsers to reopen. This ruling gives the CMA the backing it needs to protect consumers and promote competition in UK. As this judgement clearly states, the previous ruling by the CAT would have had ‘serious consequences’ for the CMA’s ability to investigate potential breaches of the law. We launched this investigation over a year ago in order to make sure that UK consumers get the best services and apps on their mobile phones, and that UK developers can invest in innovative new apps. We stand ready to reopen it when the legal process is complete. Sarah Cardell, Chief Executive of the CMA"
+%}
+
+In a victory for consumers and developers, London's Court of Appeal [has ruled against Apple](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445) and in favour of the UK’s Competition and Markets Authority (CMA), allowing the CMA to reopen their [Browser and Cloud Gaming Market Investigation Reference](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming).
+
+This is important as, Apple has effectively banned third party browsers via [their 2.5.6 rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+We believe that browsers should compete on merit and user choice, not via control of operating systems or other underhanded behaviour. Browser competition is important as it is this competition that pushes browser vendors to secure their products, fix bugs and add new features. Without the constant threat of users potentially moving to another browser, browsers have limited incentive to compete. This threat is entirely absent on iOS, the other browsers on iOS have extremely limited ability to compete as Apple has banned them from editing their core, the browser engine. Instead iOS provides a uneditable Webview whose security, features set and stability is entirely under Apple's control. **Under these conditions there is effectively no browser competition on iOS**.
+
+As readers may remember the CMA conducted a Market Study into Mobile Ecosystems.
+
+The CMA [found in their market investigation](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction) that:
+> As a result of the WebKit restriction, **there is no competition in browser engines on iOS and Apple effectively dictates the features that browsers on iOS can offer** (to the extent that they are governed by the browser engine as opposed to by the UI)."
+
+> Importantly, due to the WebKit restriction, **Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS**. This not only restricts competition (as it materially **limits the potential for rival browsers to differentiate themselves** from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, depriving iOS users of useful innovations they might otherwise benefit from.
+
+The report also ruled against Apple’s security arguments. Apple had claimed that Safari’s engine’s security was better than that of third party browsers. This was alluded to in the CMA’s interim report:
+
+> ... in Apple's opinion, WebKit offers a better level of security protection than Blink and Gecko.
+
+The CMA rejected this claim stating:
+>... the evidence that we have seen to date **does not suggest that there are material differences** in the security performance of WebKit and alternative browser engines.
+
+> Overall, the evidence we have received to date **does not suggest that Apple's WebKit restriction allows for quicker and more effective response** to security threats for dedicated browser apps on iOS
+
+Amusingly Apple dropped their claim that Safari’s security was superior to other major browsers in their response to the final report.
+
+The report also notes that Apple has incentives to inhibit third party browser from competing due to its search deal with Google:
+
+> Apple receives **significant revenue from Google by setting Google Search** as the default search engine on Safari, and therefore benefits financially from high usage of Safari. Safari has a strong advantage on iOS over other browsers because it is pre-installed and set as the default browser. The WebKit restriction may help to entrench this position by limiting the scope for other browsers on iOS to differentiate themselves from Safari (for example being less able to accelerate the speed of page loading and not being able to display videos in formats not supported by WebKit). As a result, it is less likely that users will choose other browsers over Safari, which in turn secures Apple’s revenues from Google.
+
+Apple reportedly receives [$18-20 billion USD](https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22) a year from their Google Search engine deal, accounting for 14-16 percent of Apple's annual operating profits. Apple has not published the annual budget for Safari/Webkit but based on anecdotal evidence it is likely significantly less than 2% of this sum.
+
+The report goes on to note:
+
+>Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This **limits the competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+
+That is Apple appears to also have incentives to inhibit the capabilities of the Web on iOS Safari. Apple collected [$85 billion USD in App Store fees in 2022](https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.), of which it keeps approximately 30%. Were Web Apps to have a comparable features set, stability and visibility as Native Apps this revenue would be threatened. 
+
+While it has not published the costs of App Store review, payment processing, refund handling etc, it has been estimated that the iOS App Store has a nearly [80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506). Industries with healthy competition feature leading firms with profit margins between [5 and 20 percent](https://www.brex.com/blog/what-is-a-good-profit-margin). This imbalance strongly implies that Apple’s removal of functional competition in the App Store and beyond have broken the mobile phone market for software and services for more than half of the UK’s consumers.
+
+Based on the findings of their Market Study, the CMA decided to launch a Market Investigation Reference into Browser and Cloud Gaming.
+
+In their [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) they listed the following potential remedies:
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services. 
+
+Unfortunately, they delayed starting the investigation while waiting to see if the UK government was going to pass [new laws](https://bills.parliament.uk/bills/3453) granting them stronger powers to deal with anti-competitive behaviour by tech giants. These laws are currently working their way through parliament and are currently expected to be passed into law in 2024.
+
+Due to this Apple managed to successfully get the MIR dismissed not by arguing before the tribunal that the CMA was substantially wrong about any of its anti-competitive behaviour but on the legal technicality based around the timing of the opening of the investigation.
+
+The CMA appealed this decision and today the London's Court of Appeal has overruled the [Competition Appeal Tribunal's decision](https://www.catribunal.org.uk/cases/157661223-apple-inc-others) and stated that the MIR can be reopened.
+
+It is worth noting that Apple has the right to seek permission to appeal this decision and that the investigation is on hold pending this. Apple is almost certain to appeal to the supreme court. Even if they end up losing, each month browser competition on iOS is delayed is arguably worth billions to them.
+
+Apple reportedly has a legal budget of over $1 billion dollars a year and adopts an exceptionally aggressive stance. If you want to understand Apple’s approach to legal, Bruce Sewell, Apple’s former general counsel discusses it [in a talk](https://www.youtube.com/watch?v=-wuf3KI76Ds) where discussing Apple's legal strategy he says:
+
+> work out how to get closer to a particular risk but be prepared to manage it if it does go nuclear, … steer the ship as close as you can to that line because that's where the competitive advantage occurs. … Apple had to pay a large fine, Tim [Cook]'s reaction was that's the right choice, don't let that scare you, I don't want you to stop pushing the envelope.
+> <cite>[Bruce Sewell, Apple’s former General Counsel](https://www.youtube.com/watch?v=-wuf3KI76Ds)</cite>
+
+This gives some clear insight into Apple’s mindset, and explains a lot of their behaviour.
+
+Despite that, this court victory is a huge step towards restoring browser competition, ending Apple's effective ban of third party browsers and ensuring Web Apps have the ability to compete.
+
+Right now, if competition was restored, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often BETTER than Native Apps. Native Apps will still have a lead in cutting edge graphics and gaming technology but if companies see the web platform as viable this gap will decrease over time.
+
+It is for this reason that allowing browser competition on iOS is critical. Apple’s effective browser ban prevents the emergence of such an open and free universal platform for mobile apps. Unlike desktop, developers cannot build their application once and have it work across all consumer devices. Instead, these policies combine with Apple’s trailing and feature-poor engine to force companies to create separate applications for iOS, significantly raising the cost and complexity of development and maintenance. This severely undermines any interoperability advantages Web Apps have between iOS and Android. A single prominent OS holding back the Web is enough to undermine its entire value proposition as a frictionless, capable and secure distribution mechanism for Web Apps.
+
+The fight to allow browser and Web App competition on iOS is not over. We would like to thank everyone for their support over the last 3 years and ask that consumers, developers and businesses write in and engage with the market investigation reference to arm them with all the data and information they need to successfully restore competition to a broken mobile ecosystem. 
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
+++ b/src/es/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
@@ -1,0 +1,136 @@
+---
+title: Apple on course to break all Web Apps in EU within 20 days
+date: '2024-02-15'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: OWA
+relatedLinks:
+  - url: >-
+      https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
+    title: Safari 17.4 Beta Release Notes
+    date: 2024-02-13T00:00:00.000Z
+permalink: /es/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+
+
+
+{% image
+  "/images/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.png",
+  "OWA Logo and open-web-advocacy.org with the text: Apple on course to break all Web Apps in EU within 20 days. No Fix: Beta 1, Beta 2, Beta 3. New UI indicates deliberate choice. Nothing in release notes. No mention in compliance proposal. No response to bug tickets. No response from Apple. NOT required by the DMA."
+%}
+
+In 2011, Philip Schiller internally sent an email to Eddie Cue to discuss the threat of HTML5 to the Apple App Store titled **“HTML5 poses a threat to both Flash and the App Store”**.
+
+> Food for thought:
+> **Do we think our 30/70% split will last forever?** While I am a staunch supporter of the 30/70% split and keeping it simple and consistent across our stores, I don’t think 30/70 will last unchanged forever. **I think someday we will see a challenge** from another platform or **a web based solution** to want to adjust our model
+> <cite>[Internal Apple Emails](https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html)<br>
+(emphasis added)</cite>
+
+That is, as early as 2011, Apple's management viewed Web Apps as a credible threat to the App Store revenue model. This is perhaps unsurprising as [Steve Jobs originally intended Web Apps to be the only way to deliver third party apps on iOS](https://open-web-advocacy.org/walled-gardens-report/#steve-jobs'-original-vision-for-ios).
+
+Luckily for Apple, they had a powerful tool to keep the Web at bay: ironclad control of iOS and the ability to [block other browser vendors from bringing their more powerful platforms to Apple users](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers).  Meanwhile, Cupertino retained full control over the feature set of the only iOS browser engine, allowing it to suppress potential competition from the web through inaction. By simply failing to add important features, Apple could ensure the web never came within striking distance of being a credible threat.
+
+Regulators around the world have taken note:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+> <cite>[The Australian Competition and Consumer Commission](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf)</cite>
+
+> *Mandatory use of WebKit and reluctance to support web apps in browsers (Apple)*
+> Third-party browsers are forced to provide services based on WebKit, which lacks support for web apps, and competition through ingenuity among browsers may be impeded.
+> <cite>[Japan’s Headquarters for Digital Market Competition](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf)
+</cite>
+
+The Digital Markets Act even stated it as the primary motivation to prohibit banning browser engines:
+
+> When gatekeepers operate and **impose web browser engines**, they are in a position to **determine the functionality** and standards that will apply not only to their own web browsers, but also to **competing web browsers** and, **in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)<br>
+(emphasis added)
+</cite>
+
+We wrote last week [about concerning changes in  iOS 17.4 Beta 1 (EU)](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/). Sites installed to the homescreen failed to launch in their own top-level activities, opening directly in the default browser instead, even when the default browser is the browser that installed it. This demotes Web Apps from first-class citizens to mere shortcuts. Developers have since confirmed this does not occur outside the EU. Two betas later it is becoming more likely that this is a deliberate choice on the part of Apple to remove the ability to install Web Apps.
+
+Beta 2 [contained a more detailed message](https://twitter.com/mysk_co/status/1754978973417672794) to the user stating:
+> "Open 'WEB APP NAME' in Safari. 'WEB APP NAME' will open in your default browser from now on.".
+
+This message occurs even if both the browser that installed the Web App and your default browser is iOS Safari.
+
+{% image
+  "/images/blog/web-apps-turned-into-bookmarks-message.png",
+  "An image of Apple's new pop up informing the user that the web app will now instead open as a webpage in the default browser."
+%}
+
+No mention of this seismic change has been made in the usual places. Not the [Safari release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes) nor in the [iOS Beta release overview](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17_4-release-notes).
+
+Apple’s silence has been deafening. No reply has been provided in  [a WebKit ticket](https://bugs.webkit.org/show_bug.cgi?id=268643), [Apple developer forums](https://forums.developer.apple.com/forums/thread/745414), [twitter discussions](https://twitter.com/firt/status/1755406923485122615), and no statement has been provided to the  [many journalists](https://www.theregister.com/2024/02/08/apple_web_apps_eu/) [seeking](https://www.macrumors.com/2024/02/08/ios-17-4-nerfs-web-apps-in-the-eu/) [comment](https://www.theverge.com/2024/2/14/24072764/apple-progressive-web-apps-eu-ios-17-4).
+
+This cannot be mere oversight. The inability of third-party browsers to compete in the provision of web app functionality was discussed in no less than four regulator's investigations. Potential competition from Web Apps was directly stated in the DMA as the motivation to prohibit banning competing browser engines. it seems highly unlikely that the policy team working for Apple were unaware that they were required to allow third-party browsers to install and power Web Apps using their own browser engines.
+
+Yet when Apple announced their [compliance proposal for the DMA](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/), Web Apps were noticeable by their absence. This is the same Apple that again and again claims that Web Apps are the alternative distribution method for Apps in their mobile ecosystem.
+
+> QUESTION: Apple is the sole decision maker as to whether an app is made available to app users though the Apple Store, isn't that correct?<br>
+> REPLY: If it’s a Native App, yes sir, if it’s a Web App no.
+> <cite>[Tim Cook - Speaking to US Congress](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s)
+</cite>
+
+> Web browsers are used not only as a distribution portal, but also as platforms themselves, hosting “progressive web applications” (PWAs) that eliminate the need to download a developer’s app through the App Store (or other means) at all.
+> <cite>[Apple Lawyers - Court Filing in Australia](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple/)
+</cite>
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+Apple had four choices here:
+
+* **The Good**<br>
+Allow third-party browsers to install Web Apps, powered by the browser that the user chooses to install the Web App with. This is the only near-term viable solution.  This enables browsers to compete in the provision of functionality for web apps.
+
+* **The Broken**<br>
+Allow browsers to install web apps but power them all by the default browser.  While at first glance this may seem like a reasonable solution, it is an unworkable model. Each Web App’s data is stored within its installing browser.  Each browser stores the data in different locations and raw formats.  Due to complexity, no import/export functionality exists to allow a user to “port” a Web App from one browser to another along with its data. This means users would be logged out of and lose all their data for every Web App every time they switched default browser. <br><br>Having every Web App break each time a user switches default browser would be a disaster for the ecosystem. If anyone were to suggest this was a reasonable model, simply ask, would they be happy if all native apps lost their data every time you switched the default App Store.
+
+
+* **The Devious**<br>
+Provide the share menu with third party browsers, burying the ability to install Web Apps powered by Safari’s engine in a high-friction UI. This obviously doesn’t allow third party browsers to compete in the provision of Web App features but may have been sneaky enough for Apple to attempt to slip past.
+
+* **The Outrageous**<br>
+Outright remove support for Web Apps by converting them all to bookmarks. This removes the ability to act like an App from the an operating system and user interface perspective. This fundamentally undermines the already tenuous competitiveness of Web Apps due to Apple policies. Recall that Safari deletes data for any site that the you fail to visit for more than 7 days , but not for installed Web Apps. The outrageous strategy now subjects Web Apps in the EU to the same disadvantage. Apple policy also restricts the availability of Push Notifications to installed Web Apps. This change  looks set to wreck the most requested Web App feature of the last decade. Lastly, this change hobbles homescreen-installed Web Apps that request to run in full-screen mode, such as games. Demoting Web Apps to shortcuts is a triple disability that Apple cannot be ignorant of. Finally Apple can then attempt to refuse to share the ability to install apps with third party browsers, because now Safari can’t, despite the fact it has been able to for 15 years.
+
+We considered that Apple might try something like this, but dismissed it as too blatantly anti-competitive, [even for them](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Now, even as it looks increasingly less likely that Cupertino is acting in good faith, Apple could declare this unfinished or a bug. That would go some way towards alleviating concerns, but if the Beta breakage of Web Apps ever makes it onto users’ devices, it will show that Apple is actively seeking to block the Web from ever competing fairly with their App Store.
+
+Some defend Apple's decision to remove Web Apps as a necessary response to the DMA, but this is misguided.
+
+Apple has had 15 years to facilitate true browser competition worldwide, and nearly two years since the DMA’s final text. It could have used that time to share functionality it historically self-preferenced to Safari with other browsers. Inaction and silence speaks volumes.
+
+The complete absence of Web Apps in Apple's DMA compliance proposal, combined with the omission of this major change from Safari beta release notes, indicates to us a strategy of deliberate obfuscation. Even if Apple were just starting to internalize its responsibilities under the DMA, this behaviour is unacceptable.  A concrete proposal with clear timelines, outlining how third party browsers could install and power Web Apps using their own engines, could prevent formal proceedings, but this looks increasingly unlikely. Nothing in the DMA compels Apple to break developers' Web Apps, and doing so through ineptitude is no excuse.
+
+Apple still has the opportunity to fix this ‘misunderstanding’. An Apple that is confident in its own products could take the following steps:
+
+* Announce that this is indeed a bug.
+* Publish a blog post explaining how they intend to let third party browsers (with their own engines) compete in the provision of functionality for Web Apps.
+* Create an API whereby browsers with the entitlement, subject to narrow scope, proportional and heavily justified security rules could install Web Apps powered by the browser that the user chooses to install them with.
+* Roll out these changes globally.
+
+If Apple truly believed that the Web and Web Apps were no threat to their App Store, why not appease the regulators by letting them compete fairly on their mobile ecosystem.
+
+Apple’s defenders might have been able to argue that [a history of inadequate Web App functionality](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features) and [crippling bugs](https://open-web-advocacy.org/walled-gardens-report/#safari-has-been-buggy-for-a-long-time) were simply benign neglect. Web Apps make no money for Apple, so why expend effort on them? But the suppression of competing engines, attempts to geofence their emergence, and radio silence about complete breaking of Web Apps paints a less benevolent picture of Apple not as a bumbling giant, but as a clear enemy of the Web.
+
+Apple looks to be taking active and provocative steps to scuttle Web Apps and to prevent other browsers from providing them. This suggests that Apple is still fearful of a future where users and developers can simply bypass Apple’s App Store using the power of the Web. OWA welcomes that future and will continue to work to ensure it becomes reality, in Europe and beyond -- just as Steve Jobs promised.
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>

--- a/src/es/posts/apples-one-weird-trick-to-stop-you-changing-your-default-browser.md
+++ b/src/es/posts/apples-one-weird-trick-to-stop-you-changing-your-default-browser.md
@@ -1,0 +1,106 @@
+---
+title: Apple's one weird trick to stop you changing your default browser
+date: '2024-03-28'
+tags:
+  - Policy
+  - Apple
+author: OWA
+permalink: >-
+  /es/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+Long time readers will already know that [Apple has effectively banned all browsers from iOS by preventing them from bringing or modifying their own engines](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). That makes all browsers on iOS essentially skins round Safari. We brought this up in one of our questions to Apple at their DMA workshop where we stated that _"Apple’s 15 year ban of third-party browser engines has effectively removed browser competition from iOS."_, [surprisingly there was no rebuttal from Apple, even veiled, of our assertion](https://www.youtube.com/watch?v=s41Ha8lZ0Zk&t).
+
+But let's put that aside for now to discuss a different topic: defaults.
+
+The Digital Market Act introduces obligations for gatekeepers to make it easy for users to change defaults including obligating a choice screen.
+
+There is a common phrase about following the letter and spirit of the law. The spirit being: are you making good faith efforts to comply with the intent? In the case of the intent of the DMA, you don't need to guess as the act itself contains 26 pages of recitals that in very clear language explain exactly what the act is trying to achieve via the letter of the law as spelt out in the articles.
+
+In the case of the defaults the recitals have this to say:
+
+> Recital 49: **A gatekeeper can use different means to favour its own or third-party services or products on its operating system**, virtual assistant or web browser, to the detriment of the same or similar services that end users could obtain through other third parties.
+> ...
+> **Gatekeepers should also allow end users to easily change the default settings on the operating system**, virtual assistant and web browser **when those default settings favour their own software applications and services. This includes prompting a choice screen** ...
+
+On dark patterns the recitals had this to say:
+>Gatekeepers should not engage in behaviour that would undermine the effectiveness of the prohibitions and obligations laid down in this Regulation. Such behaviour includes the design used by the gatekeeper, the presentation of end-user choices in a non-neutral manner, or using the structure, function or manner of operation of a user interface or a part thereof to subvert or impair user autonomy, decision-making, or choice.
+
+While on defaults Article 6(3) simply says:
+> The gatekeeper shall allow and technically enable end users to easily change default settings on the operating system, virtual assistant and web browser of the gatekeeper that direct or steer end users to products or services provided by the gatekeeper
+
+Recently our own John Ozbay attended a workshop where [Apple could explain how it was complying with the DMA](https://digital-markets-act.ec.europa.eu/events-poolpage/apple-dma-compliance-workshop-2024-03-18_en).
+
+In Apple's opening speech on changing defaults, Apple's spokesperson had this to say:
+> In this session we are going to provide a summary of what we are doing on the web browser choice screen and defaults pursuant to the DMA. Lets start with defaults and specifically the ability to select a default browser. **For a long time Apple have made it easy for users to choose a browser in the settings app**. Many users have already chosen to set a non-Safari default browser even before the DMA. **They can do it in just a few taps.**
+
+This is a little surprising. Apple didn't even let users change the default browser until late 2020. When they did add the ability to do so the design was awkward and confusing. There is no centralised location to change defaults, no way of searching for the option in the OS settings and the option to change the default is inappropriately shown on each browser settings page. Further they provide no API to allow newly installed browsers to prompt the user to switch default browser or even be aware that they are the default browser.
+
+Now, some may think it is unfair to suggest that Apple deliberately designed it to be as awkward as possible to change the default browser but **they went one critical step further that unambiguously shows that they maliciously intended to undermine user choice**.
+
+In an astonishingly brazen dark pattern Apple engineers added code to the Safari's settings page to hide the option to change the default browser if Safari was the default but then to prominently show it if another browser was the default.
+
+This video demonstrates it, and you can test it yourself right now.
+<iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/o6uwiG1nKK4?si=269jgW7xPT_KnlQk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+**There is absolutely no plausible defence for this behaviour.**
+
+We had John ask Apple directly about this at Apple DMA Workshop.
+
+> I am going to continue to focus on one more question regarding the prompt to change the default browser. You mentioned earlier that users are always prompted to change their default browser. At the moment there is no way for browsers to detect if they are the default browser nor a one click system prompt to allow users to set the default browser. This is standard on all other major operating systems except iOS. The friction Apple has added to this process undermines users' switching to a new default browser that needs to be fixed in order for them to be in compliance with 6(3) and 13(4).<br><br>
+> Similarly changing the default browser at the moment is quite difficult as well. Currently Apple does not have a centralised location to change the default browser in the settings. Searching "default" or "default browser" yields no results in settings and you can try it right now. Instead they have inappropriately placed it in each individual browser's settings page.<br><br>
+> Astonishingly Apple has added custom code to hide the option to change default browser in the Safari settings if Safari is the default browser, and prominently show it if a different browser is default. We had thought that Apple would have fixed such an outrageous dark pattern prior to the DMA coming into force but in the latest version of iOS it is still present.<br><br>
+> My question to Apple is, are they planning on addressing these or not?
+
+Apple's spokesperson responded with:
+> In terms of the first question, the choice as required by the DMA is presented once to users. Obviously there are a ton of other ways in which users can choose different browsers, different default browsers if they so choose. We have worked to make this simple and straightforward. And we know from the experience over the last couple of years that millions of users around the world choose alternative browsers all the time. We also know that many of them will choose to make that browser their default one of choice. That happens all the time. In terms of what's being required here by the DMA our focus is on presenting this choice even more clearly to consumers the first time you use Safari. Obviously there are not choices being presented when you use other browsers on iOS. So we are complying from our perspective with the spirit here.
+
+The video of John's question and the reply is at the top of the article.
+
+Let's break down Apple's reply.
+
+> Obviously there are a ton of other ways in which users can choose different browsers, different default browsers if they so choose. **We have worked to make this simple and straightforward.**
+
+This is clearly false, and does not address any of the specifics in John's question.
+
+> And we know from the experience over the last couple of years that millions of users arround the world choose alternative browsers all the time.
+
+This phrasing is very carefully steps arround the fact that Apple only started letting users change the default browser in late 2020. Clearly it's embarrassing that for 13 years it was impossible to change the default browser on iOS.
+
+> We also know that many of them will choose to make that browser their default one of choice. That happens all the time.
+
+Apple doesn't publicly share any aggregated data on browser defaults, so it's hard to check.
+
+> In terms of what's being required here by the DMA our focus is on presenting this choice even more clearly to consumers the first time you use Safari. Obviously there are not choices being presented when you use other browsers on iOS.
+
+The framing here again is false. As Apple stated in their opening speech there are two aspects of the DMA they have to comply with one making it easy to change the default, and two allowing a choice screen. Apple obviously has no defence on the first and so tries to deflect by focusing on the second.
+
+> So we are complying from our perspective with the spirit here.
+
+We disagree and clearly so does the EU Commission, which on 25 March [opened a proceeding against Apple investigating them over Article 6(3)](https://ec.europa.eu/commission/presscorner/detail/en/ip_24_1689).
+
+In their press release they stated:
+> The Commission has opened proceedings against Apple regarding their measures to comply with obligations to (i) enable end users to easily uninstall any software applications on iOS, (ii) easily change default settings on iOS and (iii) prompt users with choice screens which must effectively and easily allow them to select an alternative default service, such as a browser or search engine on their iPhones.<br><br>
+> The Commission is concerned that Apple's measures, including the design of the web browser choice screen, may be preventing users from truly exercising their choice of services within the Apple ecosystem, in contravention of Article 6(3) of the DMA.
+
+This is just one topic among many but we should know more when the EU releases its non-confidential version of its initial findings and invites third parties to comment which according to the act could take up to 3 months.
+
+In order to be compliant with this specific aspect of the DMA we believe Apple should make the following changes:
+1. Remove the dark pattern of hiding the option to switch default browser if the default is Safari.
+2. Move the option to change default browser out of the browser settings and into a centralised location.
+3. Have this option visible even if Safari is the only currently installed browser.
+4. Have this option show up in search if the user searches for "default", "browser" or "default browser".
+5. Allow browsers to know if they are the current default browser
+6. Provide a system prompt to browsers (with the usual anti-nagging protections on all permission prompts) that allows browsers to prompt the user to one click set them as the new default browser as is standard on all other operating systems.
+
+Stay tuned and follow us in all the usual places:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/cma-reopens-investigation-into-apple.md
+++ b/src/es/posts/cma-reopens-investigation-into-apple.md
@@ -1,0 +1,38 @@
+---
+title: UK browser investigation to restart Jan 24 after Apple fail to appeal
+date: '2023-12-18'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Frances Berriman
+permalink: /es/blog/cma-reopens-investigation-into-apple/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/CMA-restarts-investigation.webp",
+  "The deadline for Apple to seek the Court of Appeal’s permission to appeal the Court’s decision has now lapsed, therefore in accordance with the Court’s order dated 30 November 2023, the market investigation will recommence on 24 January 2023. Competition and Markets Authority, UK Government"
+%}
+
+
+Nearly three weeks ago, [we reported that](https://open-web-advocacy.org/blog/apple-loses-on-appeal/) London's Court of Appeal [had ruled against Apple](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445) and in favour of the UK’s Competition and Markets Authority (CMA), allowing the CMA to reopen their [Browser and Cloud Gaming Market Investigation](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming). There was a 21 day grace period before that investigation could restart to allow Apple to respond.
+
+> 30 November 2023: In a [unanimous judgment (available on the National Archives website)](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445), the Court of Appeal has determined that the CMA’s decision to make a market investigation reference in relation to the market for mobile browsers and cloud gaming was lawful, setting aside the CAT’s judgment of 31 March 2023. 
+
+>Consequently, the Court has ordered that the market investigation will continue to be suspended until permission to appeal (if sought) has been determined and an additional 21 days has lapsed. &ndash; [Competition and Markets Authority](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming?utm_medium=email&utm_campaign=govuk-notifications-topic&utm_source=1c322e66-03ab-4704-ba89-5cf1839a587e&utm_content=immediately#court-of-appeal-judgment)
+
+That 21 days has now passed, and no permissions to appeal were received, and as such the CMA will restart their investigation in the new year.
+
+> 18 December 2023: the deadline for Apple to seek the Court of Appeal’s permission to appeal the Court’s decision has now lapsed, therefore in accordance with the Court’s order dated 30 November 2023, the market investigation will recommence on 24 January 2023. Further updates will follow in due course. &ndash; [Competition and Markets Authority](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming?utm_medium=email&utm_campaign=govuk-notifications-topic&utm_source=1c322e66-03ab-4704-ba89-5cf1839a587e&utm_content=immediately#court-of-appeal-judgment)
+
+[Our previous article](https://open-web-advocacy.org/blog/apple-loses-on-appeal/) covers why this investigation is so important for protecting consumers in the UK.
+
+Once the investigation reopens, you can be sure we'll be covering everything the CMA learns, so stay tuned to our social media.
+
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/developers-react-apple-eu-dma-compliance.md
+++ b/src/es/posts/developers-react-apple-eu-dma-compliance.md
@@ -1,0 +1,60 @@
+---
+title: Web Developers React to Apple’s DMA Compliance Proposal
+date: '2024-01-31'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: Frances Berriman
+permalink: /es/blog/developers-react-apple-eu-dma-compliance/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/developers-react.webp",
+  "Image showing three pull quotes, stating: To me, it's an excellent demonstration of why browser choice is crucially important [...] legal compliance are clearly not incentive enough. Brian LeRoux, Begin. Apple has been forced to lift this restriction, but how they react to this will show us their attitude to the web. Jake Archibald, Shopify. It would be quite disappointing if—when the rubber meets the road—browser variability were dependent on the country in which you reside! Zach Leatherman, 11ty, CloudCannon"
+%}
+
+Since [Apple released their plans for compliance](https://open-web-advocacy.org/blog/apple-dma-changes/) with the EU’s DMA regulations on 25th January, we’ve been asking web developers how these changes may affect how they work, their businesses and the web as a whole.
+
+[Jake Archibald](https://jakearchibald.com/), senior developer for Shopify, reflected "It seemed unbelievable to me that users on iOS were restricted to one browser engine, and one that in the past has been slow to fix serious bugs, and lagged behind on features. Apple has been forced to lift this restriction, but how they react to this will show us their attitude to the web"
+
+Begin co-founder [Brian LeRoux](https://brian.io//) said “Lots of us are trying to make sense of the recent EU regulatory rulings and Apples' bad faith letter to the law implementation. To me, it's an excellent demonstration of why browser choice is crucially important as standards participation and legal compliance are clearly not incentive enough.”, continuing his thoughts [in a public thread.](https://indieweb.social/@brianleroux/111828910555229207)
+
+Many spoke to us about concerns that Apple is ring-fencing access to new browsers, especially with regards to testing.
+
+[Jason Grigsby](https://cloudfour.com/is/jason-grigsby/), Co-founder of Cloud Four, asked “What happens if someone in the EU runs into a bug that isn’t happening in other browsers? How do we troubleshoot it? I’m trying to think of a comparable time when we had no way to test in a browser. The closest I can come to is the earliest days of mobile when the Android browser was different on each carrier. But even then, I could go to a carrier store to test and/or buy a phone if I needed more time with it. What do I do now?”
+
+He continued with some thoughts on how he may solve this, “For us, maybe BrowserStack or a similar service will give us a way to see what our European users are seeing? Absent that, I think we're stuck.”
+
+[Peter-Paul Koch,](https://www.quirksmode.org/about/) a long time web standards and browser compatibility expert, echoed these worries, asking, “Will there be a way around this problem? For instance a VPN, or non-EU web devs becoming 'members' of an EU entity that gives them an EU Apple account and thus access to the new browsers?” and although an EU citizen himself, he showed concern for developers in other locales and wondered if this opened opportunities for legal challenges in other countries, “This puts non-EU web devs at a clear competitive disadvantage. Would that be an argument that regulatory authorities are willing to listen to? US web devs are put at a disadvantage by Apple, so Apple has to solve the situation - by also giving them access to the other browsers?”
+
+[Scott Jenson](https://jenson.org/about-scott/), UX strategist, opened on a positive note but quickly turned to scepticism, “Excellent start however but rather shocking that the needs of the EU are totally different from the rest of the world.” and continued with a now familiar concern, “As a developer this is very frustrating as how are we even to test our web pages now between regions?”
+
+Moving on from topics of testing, developers reflected on a future with more browser choice for consumers on iOS.
+
+Beginning “I think that only time will tell..” [Léonie Watson](https://tink.uk/about-leonie/), Director at TetraLogical and W3C board member, was hesitant “iOS only has one screen reader. VoiceOver works well with Safari and reasonably well with Firefox and Chrome, but whether that will continue when those browsers use their own engines is unknown at this stage.” Watson also has fears for diversity, “I also think there is a chance that Chrome could become the dominant browser across the board, and if it should, that we'll have a near unshakable monoculture.”
+
+[Andy Davies](https://andydavies.me/about/), consultant for SpeedCurve, noted that the changes in the EU do open up some opportunities to really get to know Safari better in relation to its competitors, “Probably the most interesting thing for me is we’ll finally be able to do like for like comparisons of web performance in the wild and we’ll be able to compare the speed of sites in Chrome on Android vs Chrome on iOS and so begin to get a real world understanding of the gap between the performance of Android and iOS devices”
+
+Others see more hope in an increase in the competitive landscape. [David Darnes](https://darn.es/), a lead at NordHealth, told us “I guess as a web developer I should see this as a win for the browser landscape. With these changes other browser engines will be able to run on iOS, which in turn creates healthier competition.”
+
+[Zach Leatherman](https://www.zachleat.com/), creator of 11ty and CloudCannon developer, had a similar opinion, “I’m nervous to applaud the changes outright as it seems to introduce additional variability but I am quite happy to celebrate a future of more choices for developers and consumers.”
+
+Both had concerns, however, "That being said from what I’ve seen the amount of red tape to cut and hoops to jump through, one of which being just living in the EU, makes me worried that that silver lining will be lost in it all.”, said Darnes. Leatherman noted, “There has always been some unnerving variability in how iOS has handled in-app web browsers, so much so that I have recommended folks never use an in-app browser spawned from a native app lest they compromise the well established privacy norms usually afforded to them by the web browser.“
+
+[Dave Rupert](https://daverupert.com/), of ShopTalk fame and co-founder of Luro, gave us a position of hopeful curiosity, “It will be interesting to see what happens from here. Will we break out of the Chromium/Webkit duopoly? Or will we fall headlong into a Chromium monopoly? Regardless, the EU ruling is a win for the Open Web because now more users have choice beyond the OS-provided default browser.”
+He expanded these thoughts [on his blog](https://daverupert.com/2024/01/browser-choice/).
+
+Ultimately Zach Leatherman sums up the concerns for most, “It would be quite disappointing if—when the rubber meets the road—browser variability were dependent on the country in which you reside!  I thought web browsers were supposed to be for the world wide web?”
+
+How will these changes affect how you work? Let us know at our social media locations:
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/did-apple-just-break-web-apps-in-ios17.4-beta-eu.md
+++ b/src/es/posts/did-apple-just-break-web-apps-in-ios17.4-beta-eu.md
@@ -1,0 +1,60 @@
+---
+title: Did Apple just break Web Apps in iOS 17.4 Beta (EU)?
+date: '2024-02-03'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: James Moore
+permalink: /es/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[We have been alerted](https://twitter.com/mysk_co/status/1753402489049616427) that Apple has broken Web App (PWA) support in the EU via iOS 17.4 Beta. Sites installed to the homescreen failed to launch in their own top-level activities, opening in Safari instead. This demotes Web Apps from first-class citizens in the OS to mere shortcuts. Developers confirmed the bug did not occur [outside the EU](https://twitter.com/mysk_co/status/1753402489049616427).
+
+This bug should have been picked up within seconds of testing any Web App. So how did this issue slip through? One possibility is Web Apps aren’t routinely tested by the Safari or iOS teams and that automated regression testing is not in place. This might explain the parade of show stopping iOS Web App bugs that shipped to stable over the past 15 years. 
+
+Another explanation might be the complexity posed by Apple’s  [mess of a compliance proposal](/blog/owa-review-apple-dma-compliance-for-web/) which creates a separate version of iOS for the EU. We wrote about [the testing problems Apple’s proposal looks set to cause web developers](/blog/developers-react-apple-eu-dma-compliance/), and perhaps Apple is the first casualty of this self-defeating attempt at geofencing browser progress. 
+
+The author of this article can not even personally test this due to not being physically located in the EU. This is the madness that Apple's malicious and spiteful Digital Markets Act compliance proposal will inflict on web developers and businesses globally.
+
+This is almost certainly a bug, but it gives rise to suspicion among the developer community thanks to Apple’s long history of [neglect and denial of features for iOS Safari](/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features). The choice to underinvest might only be problematic, save for [Apple's effective ban of third party browsers.](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) Because third-party browsers cannot provide their own Web App features, if it doesn't work in iOS Safari, it doesn't work on iOS.
+
+The UK’s Competition and Markets Authority noted Apple’s potential App Store revenue protection motive:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)
+(emphasis added)</cite>
+
+Despite this, Apple has always claimed that Web Apps are the alternative to their app store:
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+Recently, an argument between David Heinemeier Hansson (“DHH”) and Apple erupted over what DHH took to be a threat to eject the HEY email/calendar from their App Store if they didn’t share revenue:
+
+> Apple just called to let us know they're rejecting the HEY Calendar app from the App Store (in current form). Same bullying tactics as last time: Push delicate rejections to a call with a first-name-only person who'll softly inform you it's your wallet or your kneecaps.
+><cite>[David Heinemeier Hansson - Creator of Ruby on Rails and CEO of Hey](https://twitter.com/dhh/status/1743341929675493806)</cite>
+
+When DHH announced that he would promote and build tooling for Web Apps, [Apple quickly backed down and approved the app:](https://twitter.com/dhh/status/1744745276932604413)
+
+> We're going to make Rails 8 the damn best framework for creating full-stack PWAs. Web Push, badges, install prompts, service workers, the works. I was motivated before, but now it's really on. Let's get back to making apps where we don't have to beg for permission or mercy!
+><cite>[David Heinemeier Hansson - Creator of Ruby on Rails and CEO of Hey](https://twitter.com/dhh/status/1743664413964374505)</cite>
+
+Netflix also made waves when it declined to port their app to Apple's new AR/VR headset, the Apple Vision Pro:
+
+> Our members will be able to enjoy Netflix on the web browser on the Vision Pro, similar to how our members can enjoy Netflix on Macs
+><cite>[Netflix](https://variety.com/2024/digital/news/apples-vision-pro-netflix-youtube-spotify-1235877784/)</cite>
+
+
+Upon release it was revealed that Apple had [astonishingly entirely removed the ability to install Web Apps from their headset](https://twitter.com/SteveMoser/status/1749438049300124008). This is a brazen omission in the current regulatory moment
+
+All of this leads to intense suspicion in the developer community.
+
+The simple fact is it doesn't matter if this is incompetence or malice, the end result is the same. Unusably poor support for Web Apps on iOS. Apple does not face effective browser competition, leading to show stopping iOS web bugs with shocking regularity. 
+
+Imagine now that genuine and effective browser competition was allowed on iOS. 
+Under these conditions, showstopping Safari bugs would allow developers to recommend more capable browsers. This, in turn, would force Apple to invest in Safari, reducing the incidence of terrible web experiences for iOS users. This would lead to a vibrant, capable web that would unlock investment by developers and businesses, allowing them to deliver services via the web to iOS users.
+
+Browser competition is critical for security, functionality, stability and privacy. It is this competition that Apple has denied iOS since its inception and that must be restored globally, not just in the EU.

--- a/src/es/posts/eu-opens-dma-investigations.md
+++ b/src/es/posts/eu-opens-dma-investigations.md
@@ -1,0 +1,79 @@
+---
+title: 'EU opens DMA investigations of Apple, Meta, Google'
+date: '2024-03-25'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /es/blog/eu-opens-dma-investigations/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+This morning, the [EU announced](https://ec.europa.eu/commission/presscorner/detail/en/ip_24_1689) that
+
+> the Commission has opened non-compliance investigations under the Digital Markets Act (DMA) into Alphabet's rules on steering in Google Play and self-preferencing on Google Search, Apple's rules on steering in the App Store and the choice screen for Safari and Meta's “pay or consent model”.
+
+> The Commission suspects that the measures put in place by these gatekeepers fall short of effective compliance of their obligations under the DMA.
+
+> In addition, the Commission has launched investigatory steps relating to Apple's new fee structure for alternative app stores and Amazon's ranking practices on its marketplace.
+
+We welcome the investigations, and it's telling that it comes after last week's compliance workshops, when gatekeepers were invited by the EU to answer questions on their compliance plans from stakeholders (but not from the EU themselves).
+
+Certainly, in the case of Apple, we found their responses to questions to be just that: responses, rather than answers. See for yourself! Our very own John Ozbay asked why a user who selects Firefox from the browser choice screen will still see Safari in the 'hot seat' position.
+
+Apple's legal team respond by telling us how customisable the home screen is. But they forget to tell us why they continue to give Safari the hot seat, rather than promote Firefox after the user chose it.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/_m6tQtDpSbM' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 1 - Safari gets exclusive rights to default hot-seat incl via choice screen?"></iframe></div>
+
+John then asks why there is no centralised system on iOS to change the default browser. He notes that each browser's setting page has the option to change the default browser, except for Safari's which does not offer a change default, and asks
+
+> we  had thought that Apple would have fixed such
+a dark pattern prior to the DMA coming into  force but in the latest version of iOS, it seems that it is still present. My question  is, is Apple planning on addressing these or not?
+
+Strangely, again, John's question is not answered. We are told that millions of people have changed their default browser (we know! choice is good!) and
+
+> we are complying from our  perspective with the spirit here.
+
+From <em>our</em> perspective, this is not complying.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+This pattern of forgetting the question continues. John notes Apple's DMA compliance plan includes a Browser Entitlement Contract full of legal traps for competing browsers, effectively making it impossible for competing browser vendors to sign the contract and ship their browser engines on iOS for their EU users. John asked
+
+> Will you at least make them  minimally viable in the EU by enabling browsers to ship their  own engines under a single app ID and rewrite your contract so  that they're both reasonable and compliant with the DMA?
+
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/s41Ha8lZ0Zk' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 4 - Apple's ludicrous contract and impossible conditions for browser vendors"></iframe></div>
+
+Apple's reply was that the changes required under the DMA are "a very massive complicated engineering effort". We don't doubt that; luckily, Apple employs very talented engineers and probably has enough money in the bank to employ a few more.
+
+But after this uplifting tale of Herculean efforts undergone in Cupertino, John's questions were not answered–even after another questionner asked
+
+> Is it admissible that I give my speaking time back
+to refer to the questions that the  colleagues from the Open Web Advocacy had asked about the contracts and the possibility that those are incompatible with DMA,  because those haven't been answered at all?
+
+Another workshop attendee and John asked whether Apple would abide by the DMA and allow Progressive Web Apps (in Apple parlance, Home Screen Apps) to use third-party engines.
+
+Amazingly, the Apple representatives forgot that a direct queston had been asked of them a mere 23 seconds previously, merely noting that Home Screen Apps will work "as before" (only with WebKit, so presumably: "no").
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/yHdG_3sSSqQ' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 6 - Will Apple allow Progressive Web Apps to use other browser engines?"></iframe></div>
+
+Towards the end of the workshop, John noted that Apple's 12 page compliance report was immensely lighter in detail than Microsoft's 421 pages or Google's 271 pages, and asked
+
+> does Apple honestly believe their  12-page document enables third parties like us to comprehensively assess whether they comply with  all of the obligations laid down in the DMA?
+
+This at least got a straight answer:
+
+> I think everyone in this room  understands what Apple has done to comply with the DMA. So I think  we've accomplished our goal there.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/aR83Cs47A-Y' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 5 - Do you think a 12 page compliance report is legal and in good faith?"></iframe></div>
+
+Sadly, however, not everyone in the room understood what Apple has done to comply with the DMA, hence today's announcement.
+
+Ultimately, of course, our hope is that the investigations don't take 12 months and result in fines.
+
+The better outcome would be for Apple to acknowledge that their initial compliance plans do not come near to meeting the intent of the DMA, and for them to re-think and submit detailed plans, with timings, on how they will provide customers with a fair, genuine browser choice.
+
+We would also like to understand if, how and when Apple intends to fix their ridiculous and clearly non-compliant contractual terms that make it [as Mozilla put it "as painful as possible"](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox) for browser vendors to port their real browsers to iOS.

--- a/src/es/posts/google-must-share-the-ability-to-install-web-apps-in-android.md
+++ b/src/es/posts/google-must-share-the-ability-to-install-web-apps-in-android.md
@@ -1,0 +1,87 @@
+---
+title: Google must share the ability to install Web Apps in Android
+date: '2024-09-19'
+tags:
+  - Policy
+  - Google
+  - Australia
+  - EU
+  - Japan
+  - UK
+author: OWA
+permalink: >-
+  /es/blog/google-must-share-the-ability-to-install-web-apps-in-android/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: For 7 years, Google has failed to keep its commitment to share the ability to install Web Apps with third-party browsers on Android, despite [public requests](https://issues.chromium.org/issues/40195497) from Samsung, Microsoft, Brave & Kiwi browser. With regulatory intervention from the EU, Japan and the UK that may be changing.**
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1836647016052724100), [Mastodon](https://mastodon.social/@owa/113162700151879686
+).
+
+In 2015, Google introduced a method on Android to install Web Apps and subsequently replaced it with a better system called "WebAPK minting" in 2017. This system allows Chrome on Android to install Web Apps that integrate well with the operating system. At the time, now more than 7 years ago, [Google promised to share this with third-party browser vendors](https://web.dev/webapks/). However, as of today this functionality is still exclusive to Chrome on most Android devices (Note: Samsung has implemented their own version for Samsung Internet on Samsung devices).
+
+> **QUESTION: I am a developer of another browser on Android, can I have this seamless install process?**<br><br>
+> We are working on it. We are committed to making this available to all browsers on Android and we will have more details soon.
+> <cite>[Google - On WebAPK minting (7 years ago)](https://web.dev/webapks/)</cite>
+
+## What is WebAPK minting?
+A [WebAPK](https://web.dev/webapks/) is a thin wrapper Native App that provides a splash screen, system launcher integration, and system settings configuration points. When launched, a WebAPK essentially starts a tab in the browser which installed the WebAPK, loading the specific URL the Web App developer configures.
+
+All native apps on Android are packaged as APKs, either via an app store such as Google Play or via sideloading. WebAPKs allow Web Apps to be integrated into the OS for the purposes of discoverability, permissions management, shortcut creation, registering url with the operating system (so links will open in the web app instead of a browser tab) and uninstallation. This means that web apps installed as WebAPKs are able to be shown in Android’s app drawer and search, system app pages such as apps, storage, screen time and battery usage, and shown without a browser badge.
+
+<figure>
+    {% image
+        "/images/blog/webapkminting.png",
+        "Example of installing web apps on Android.",
+        null, null
+    %}
+    <figcaption>Left to right: narrow.one installed on Chrome, Firefox & Edge. Only the WebAPK version is able to be shown anywhere other than this homescreen.</figcaption>
+</figure>
+
+Android’s security model is built around signed native APKs. In order for Web Apps to integrate properly on Android without significant architectural changes, Web Apps need to be wrapped in a signed native APK. This allowed Google to support Web Apps across existing versions of Android without having to introduce a new architecture to support Web Apps and wait for years for it to be updated.
+
+## Why is not sharing it bad?
+
+First, this damages competition between browsers on Android. By controlling WebAPK minting, Google stifles innovation in the browser market. Other browsers cannot offer the same seamless and native-like PWA install experience as Chrome on Android, limiting their ability to compete. This behaviour unfairly allows Google to provide better functionality for Chrome than other browsers on Android phones. It also means that only Google can decide what functionality Web Apps should have and makes it impossible for other browsers to effectively compete in the provision of Web App features.
+
+Second, this limits the end user's choice of browser when it comes to Web Apps. They are essentially forced to use Chrome if they want the best Web App experience. Users should be free to choose browsers that offer better Web App functionality, but this is impossible if other browsers are prevented from installing them.
+
+Finally, this damages the Web App ecosystem. Web Apps are the only open and interoperable competitor to the Android and iOS app stores. Allowing them to flourish will apply significant competitive pressure on the mobile app stores.
+
+Opening up WebAPK minting would benefit developers and businesses by making it easier for them to reach a wider audience with their Web Apps. This can result in cheaper, higher quality software that automatically works on all major platforms.
+
+Web Apps installed through other browsers are not as integrated with the Android system as those installed through Chrome. This can lead to a less user-friendly experience for consumers. Some features of Web Apps do not work as well or at all when installed through other browsers. This can limit the functionality and usefulness of Web Apps for consumers.
+
+One of Google's stated goals is to promote open web standards, and [they are a supporter of the open web foundation](https://en.wikipedia.org/wiki/Open_Web_Foundation#:~:text=According%20to%20its%20web%20site,Google), yet they contradict this by keeping WebAPK minting closed and exclusive to Chrome.
+
+## OWA’s Work
+
+We have been campaigning for the last 3 years to fix this issue. We have made our case to multiple regulators including the [Australian Competition and Consumer Commission](https://open-web-advocacy.org/files/OWA%20-%20ACCC%20(Australia)%20-%20Response%20to%20Discussion%20Paper%20for%20Interim%20Report%20No.%205%20-%20v1.0.pdf), [Japan's Head Quarters for Digital Competition](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf), [the UK's Competition and Markets Authority](https://assets.publishing.service.gov.uk/media/66d6d1d5c63bb34da0709f21/OWA_WP_1__2__3__4__5___6_-_TO_BE_PUBLISHED.pdf) and [the EU Commission](https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20Web%20App%20Install%20on%20Android%20-%20v1.0.pdf).
+
+> Google’s refusal to provide competitors a method of minting WebAPK’s prevents competing browsers from producing viable Web Apps.
+> <cite>[Walled Gardens Report (2021)](https://open-web-advocacy.org/walled-gardens-report/#:~:text=Google%E2%80%99s%20refusal%20to%20provide%20competitors%20a%20method%20of%20minting%20WebAPK%E2%80%99s%20prevents%20competing%20browsers%20from%20producing%20viable%20Web%20Apps.)</cite>
+
+This work is showing signs of significant progress.
+
+First, Google's behaviour appears to be explicitly banned by the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) and [Japan's new Smartphone Act](https://competitionlawblog.kluwercompetitionlaw.com/2024/07/02/the-japanese-smartphone-act-teaching-competition-law-new-tricks/). Specifically rules that Gatekeepers such as Google must share APIs with rivals.
+
+Next, the [UK's Market Investigation Reference into Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) has extensively covered this issue:
+
+> **OWA submitted that on Android devices running the Google Play store, only Chrome has the ability to mint (create) WebAPKs (except on Samsung devices). OWA submitted this prevents competing browsers from producing viable web apps.**<br><br>
+> [...]<br><br>
+> Google submitted that the WebAPK minting service provides WebAPK minted apps with certain additional functionality. Google submitted that it has not yet deployed a way for other browsers to use the WebAPK minting service.<br><br>
+> [...]<br><br>
+> Overall, the evidence available to date indicates that Google engages in self-preferencing less, in respect of access to functionalities on Android compared to Apple’s approach on iOS. Lack of access to WebAPKs, which is essential for installing PWAs, is the main issue highlighted by third parties (see paragraphs 4.6 to 4.7). **Whilst Google has acknowledged this restriction, its latest submission to the CMA indicates that it is working to resolve it.**
+> <cite>[UK Browsers and Cloud MIR - WP3)](https://assets.publishing.service.gov.uk/media/667d31fa7d26b2be17a4b3e2/Working_paper_3_Access_to_browser_functionalities_within_the_iOS_and_Android_mobile_ecosystems.pdf) <br>(emphasis added)</cite>
+
+While we are delighted that Google has indicated to the CMA that they will fix the issue, we request that any regulators reading this legally compel Google to do so on a reasonable timeline (within 6 months). We are concerned that this could be strung out for years [or even eventually cancelled](https://www.theregister.com/2024/07/23/google_cookies_third_party_continue/) when the regulatory heat dies down.
+
+Importantly, given this service is provided by Google Play Services, Google should be able to provide this on almost all existing Android devices (Play Services currently goes back to Android 5.0 - 2014, [so includes around 99.6% of users](https://apilevels.com/)). This fix should not be restricted to new Android updates.
+
+To Google, we request that they fix this promptly, globally and fairly. We ask that Google not play any regulatory games by only fixing it where they are legally compelled to do so and at the earliest possible date publicly publish a full plan on how they intend to share this functionality. We ask that they reach out and talk to interested browser vendors directly.
+
+We would also like to thank everyone who supports us for making our work possible. Without it we would not be able to apply this pressure to improve competition for both browsers and Web Apps.
+
+

--- a/src/es/posts/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of.md
+++ b/src/es/posts/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of.md
@@ -1,0 +1,75 @@
+---
+title: 'In-App Browsers: The worst erosion of user choice you haven''t heard of'
+date: '2024-03-26'
+tags:
+  - Policy
+  - Apple
+  - Google
+  - Meta
+  - TikTok
+author: OWA
+permalink: >-
+  /es/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<iframe style="max-width: 100%;" width="560" height="315" src="https://www.youtube-nocookie.com/embed/-6mFC__dMWM?si=dCn6x88fPOox76WL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+In-App Browsers subvert user choice, stifle innovation, trap users into apps, break websites and enable applications to severely undermine user privacy. In-App Browsers hurt consumers, developers and damage the entire web ecosystem.
+
+OWA recently met with both the Digital Markets Act team and the UK's Market Investigation Reference into Cloud Gaming and Browsers team to discuss how tech giants are subverting users' choice of default browser via in-app browsers and the harm this causes.
+
+In-App browsers is a complex topic, so to outline our thoughts we wrote [a detailed 61 page submission](/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf) to the EU Commission which we are now publicly publishing today.
+
+So what are In-App Browsers, and what problems do they cause?
+
+An In-App Browser can open when users tap on links in a non-browser app. Rather than switching out of the app and to the user's default browser, in-app browsers open a pane within the host native app to render web pages. Hence the name, “in-app browser”.
+
+When you click on a link to a third-party website, many popular apps ignore your choice of default browser and instead automatically and silently replace your default browser with their own in-app browser. Many users - likely most users! - are not aware that this switch has taken place.
+
+Worst of all, this switch grants these apps the ability to spy and manipulate third-party websites. Popular apps like Instagram, Facebook Messenger and Facebook [have all been caught injecting JavaScript](https://krausefx.com/blog/ios-privacy-instagram-and-facebook-can-track-anything-you-do-on-any-website-in-their-in-app-browser) via their in-app browsers into third party websites. TikTok was running [commands that were essentially a keylogger](https://krausefx.com/blog/announcing-inappbrowsercom-see-what-javascript-commands-get-executed-in-an-in-app-browser). While we have no proof that this data was used or exfiltrated from the device, the mere presence of JavaScript code collecting this data combined with no plausible explanation is extremely concerning.
+
+It is possible to use in-app browsers in a way that preserves privacy. Both iOS and Android provide a system components (SFSafariViewController and Android Custom Tabs respectively), which do not allow the hosting app to inject JavaScript or otherwise spy on the user. Android Custom Tabs solution also (by default) invokes the users default browser.
+
+Thus, this behavior would be impossible if links were simply opened in the user's default browser or in the system provided in-app browser.
+
+This is the reality users face on their phones today. It doesn't have to be this way. Mandating that apps respect browser choice isn't just a matter of convenience; it's about empowering both consumers and companies to thrive in a more open, stable, feature rich, secure and private digital ecosystem.
+
+Disrespect of users' choice of browser also stifles innovation. The Web thrives when browsers compete on functionality and user experience. In-app browsers, however, don't compete as browsers. Many, perhaps even most, users are unaware they are being foisted upon them. They're also unaware of the quality, security and privacy risks associated with them. In-app browsers operate in a vacuum, immune from competitive pressure to improve.
+
+This stagnation hurts everyone. Users are stuck with forgetful, subpar in-app browsers. Businesses struggle to reach and engage with audiences due to missing features and bugs in browsers that no one made an affirmative choice to use.
+
+**The solution is clear – respect the user's choice of browser.**
+
+Mandating that non-browser apps utilise a users' default browser for third-party websites will unlock a more vibrant and equitable digital landscape. Users will enjoy familiar tools they trust, experiencing websites as they were designed. Businesses and publishers will gain access to earned audiences, free from interference by native app developers.
+
+The intrusion of in-app browsers, along with the significant bugs, missing features and critical privacy and data protection concerns they introduce should be addressed. The Digital Markets Act and the UK's MIR have all of the necessary enforcement powers to right this wrong.
+
+Remote tab in-app browsers such as Android Custom Tabs are a potentially ideal solution for most users. Android Custom Tabs, by default, invokes the user's default browser and prevents the app injecting JavaScript. This is an interesting middle ground where the user (and the app) can benefit from not leaving the app context while still respecting the user's choice of default browser and preserving the user's privacy. However, it is currently possible for the hosting native app to lock Android Custom Tabs to a particular browser and override the user's choice of default browser. This ability needs to be removed.
+
+While iOS's remote tab in-app browser (SFSafariViewController) prevents the app injecting JavaScript, it is locked to Safari (or more specifically the WkWebView) and thus overrides the user's choice of default browser.
+
+We have proposed 6 remedies:
+* Designated Core Platform Services should respect the user's choice of default browser. (DMA specific)
+* App Store rules must mandate non-browser apps use the user's chosen default browser for http/https links to third-party websites/Web Apps.
+* Apple must update SFSafariViewController (Apple's system provided in-app browser for iOS) to respect the user's choice of default browser.
+* Third-Party businesses must be provided an explicit and effective technical opt-out from non-default In-App Browsers.
+* Operating systems must provide a global user opt-out. Apps must also request explicit permission from users in order to override their choice of default browser.
+* Google must remove the ability to override a user's choice of default browser via Android Custom Tabs (Google's system provided in-app browser for Android).
+
+These remedies overlap, addressing different aspects of the problem. When effected, these remedies will prevent gatekeepers from subverting the user choice of browser, provide users enhanced control over their privacy and security, and make technical fixes to the underpinnings of how web pages are loaded. These fixes will project a user's choice of browser in non-browser apps they use, providing users the security, privacy, stability and features on which browser wars are legitimately fought. No longer will apps be allowed to syphon web traffic for their own enrichment at the detriment of the community at large.
+
+We would in particular like to thank Lukasz Olejnik, Felix Krause, Jesper van den Ende, Stuart Langridge, Bruce Lawson and Adrian Holovaty for their work in helping make this case. We are also thankful for the broad support and feedback we have received from the web development and browser development community.
+
+We will continue to pursue this matter until it is fixed globally. Users' choice of browser is only important if that choice is actually respected.
+
+**Your browser, your choice!**
+
+Stay tuned:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/interop-2025-must-drop-secret-vetos.md
+++ b/src/es/posts/interop-2025-must-drop-secret-vetos.md
@@ -1,0 +1,94 @@
+---
+title: Interop 2025 must drop secret vetos
+date: '2024-10-10'
+tags:
+  - Apple
+  - Google
+  - Microsoft
+  - Mozilla
+  - Interop
+author: OWA
+permalink: /es/blog/interop-2025-must-drop-secret-vetos/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: Interop uses secret vetos, mobile NOT included in interop scores, Critical Safari scroll issues need fixing.**
+
+ **Please consider giving a 👍 to these issues:**
+
+1. [Interop Lack of Transparency & Accountability](https://github.com/web-platform-tests/interop/issues/888)  
+2. [Mobile Testing Results for Interop/WPT](https://github.com/web-platform-tests/interop/issues/891)  
+3. [Scrolling on Mobile Devices](https://github.com/web-platform-tests/interop/issues/788)  
+4. [Advanced Web Testing (Web Driver BiDi)](https://github.com/web-platform-tests/interop/issues/763)
+
+The voting process for Interop proposals is done in **secret** and each browser vendor involved can veto any feature without any transparency. Browser Vendors can sift through interop proposals and exclude items they believe are too difficult or don’t match their internal corporate goals. This is bad for the web and against the principle of openness and transparency that web standardization efforts rely on.  
+
+We propose that any votes or vetoes are made public with attribution, and any reasons for not proceeding with a particular feature are posted in the github issue along with attribution.  
+
+**We need your help to push for it to happen\!**
+
+## What is Interop?
+
+Interop is a collaborative project between browser vendors to reduce compatibility issues between browsers so the code we write works the same on all devices and all browsers.
+
+> The web is amazing. It makes collaborating, learning, and connecting easy for billions of people, because it’s intentionally designed to run **on radically different devices**. </br></br>
+> It’s your job as a web developer to ensure your project works in every browser and for every user — and that can be hard to do. It’s a far easier undertaking when browsers have identical implementations of the web technology you use. 
+> <cite>[Webkit blog on the aim of Interop](https://webkit.org/blog/14955/the-web-just-gets-better-with-interop/)</br>(emphasis added)
+</cite>
+
+## Interop Lack of Transparency & Accountability
+
+We believe that standards based efforts between browser vendors such as Interop should be transparent and public.
+
+As mentioned above the current interop veto process is secret, leading to lack of transparency over why issues are not included or not included.
+
+This lack of transparency has already been negatively received by developers and has been a source of mistrust and dissatisfaction with the Interop process:
+
+> Fans of the spec bemoan lack of transparency in Interop 2024 process
+> <cite>[Thomas Claburn \- The Register](https://www.theregister.com/2024/02/03/jpeg_xl_interop_2024/)
+</cite>
+
+> That's it? That's the response to what is, by several times, the most requested feature in Interop 2024? No explanation for rejecting the feature that got 4.5x more support than the runner-up? Really? 
+> <cite>[Tibet Tornaci](https://github.com/web-platform-tests/interop/issues/430#issuecomment-1923216914)
+</cite>
+
+A more open voting process ensures that decisions are made in the best interest of the broader developer and user community, helping to ensure that the web evolves in a way that is fair, inclusive, and sustainable.
+
+Give a **👍** here: [Interop Lack of Transparency & Accountability · Issue \#888](https://github.com/web-platform-tests/interop/issues/888)
+
+## Mobile Testing Results for Interop & WPT
+
+Currently the Interop process misleadingly implies that the scores cover mobile browsers. 
+
+Given that mobile devices make up the vast majority of all personal computers and accounts for the majority of global web traffic, the test results for mobile are significantly more important than the desktop results.
+
+We believe that Interop 2025 should include:
+
+* Building and Running Mobile Test Harnesses for WPT  
+* Include Mobile Test Results in Interop  
+* Upgrading WebDriver
+
+Give a **👍** here: [Mobile Testing Results for Interop/WPT · Issue \#891](https://github.com/web-platform-tests/interop/issues/891)
+
+## Scrolling on Mobile Devices 
+
+The inability to reliably block body scroll in Safari/Webkit and have a consistent scrolling experience across browsers on mobile devices is a very significant long-standing issue which greatly increases the difficulty of building advanced user interfaces and remains a significant compatibility issue between browsers.
+
+This is critical to building native-like or more complex interfaces on iOS.
+
+Give a **👍** here: [Scrolling on Mobile Devices · Issue \#788](https://github.com/web-platform-tests/interop/issues/788)
+
+## Advanced Web Testing (WebDriver BiDi)
+
+This issue isn’t posted by OWA but is an important one to allow for improved browser testing.
+
+WebDriver BiDi is a new protocol for browser automation. It extends the “classic” WebDriver protocol by introducing bidirectional communication. In place of the strict command/response format of WebDriver, this permits events to stream from the browser to the controlling software, better matching the evented nature of the browser.  
+
+Primarily this will lead to better testing for browsers and hopefully less bugs for the rest of us. It is also the only thing that will allow for testing of some of the more advanced browser features.
+
+Give a **👍** here: [WebDriver BiDi · Issue \#763](https://github.com/web-platform-tests/interop/issues/763)
+
+## How can you help?
+
+Please 👍 and/or comment on these tickets. If you have expertise or knowledge that will improve these issues please either email us or comment on the issue.

--- a/src/es/posts/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen.md
+++ b/src/es/posts/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen.md
@@ -1,0 +1,272 @@
+---
+title: 'iOS age restriction blocks all browsers except Safari, breaks choice screen'
+date: '2024-11-15'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: >-
+  /es/blog/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**Share and join the conversation: [X/Twitter](https://x.com/OpenWebAdvocacy/status/1857393321922162818), [Mastodon](https://mastodon.social/@owa/113486859647211896
+), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7263159027944075264) and [Bluesky](https://bsky.app/profile/open-web-advocacy.org/post/3laydcxvns22x).**
+
+_Note: Throughout this article, references to iOS also encompass iPadOS._
+
+Apple is currently failing to comply with its obligations under Article 6(3) of the Digital Markets Act (DMA) regarding the provision of the browser choice screen. The iOS browser choice screen is currently broken for any user with age restrictions for apps enabled, effectively preventing them from selecting any browser other than Safari.
+
+Furthermore, Apple has been preventing the use or installation of third-party browsers when age restrictions for apps are enabled. This is despite the fact that Apple has exempted Safari from these restrictions and that parental content restrictions for the Web are handled by an entirely separate mechanism.
+
+While all browsers on iOS, including Safari, are rated 17+, Safari benefits from two exemptions:
+* As a pre-installed browser, Safari doesn't require users to actively download it.
+* Apple has implemented specific code that exempts Safari from age restrictions, allowing it to be displayed and opened despite being rated 17+. All other browsers are hidden when age restrictions are applied.
+
+We estimate that this issue impacts 11-15% of EU iOS users, significantly undermining the effectiveness of Apple's compliance with Article 6(3).
+
+Finally, Apple has yet to provide an API for third-party browsers using their own engines to support and interoperate with parental control features for web browsing, currently implemented via the WkWebView.
+
+To rectify this situation and be compliant with the DMA we believe that Apple should:
+* Remove the 17+ age rating from browser apps.
+* Allow all browsers listed on the choice screen to be selectable, installable, and usable even if age restrictions for apps is enabled.
+* Create an API that empowers third-party browsers using their own engines to effectively support parental control features.
+* Apply age restrictions for apps equally to Apple’s own apps.
+
+## 1. Age Restriction Controls on iOS
+
+On iOS, there are two independent parental supervision settings available to parents:
+
+1. **Web Content Restrictions**
+   This allows parents to restrict their childrens’ access to adult websites. This setting is respected by **all browsers** across iOS (Safari, and all competing third-party browsers). Currently this is implemented via the WkWebView and thus is automatically applied to all browsers that are currently available on iOS. <br><br> Apple will need to provide an API to third-party browsers using their own engine to allow them to effectively support this feature and for Apple to comply with their Article 6(7) obligations.
+
+2. **Age Restrictions for Apps**
+   This allows parents to restrict their childrens’ access to apps that are rated above the age-limit they've chosen. So if an app in the App Store is rated 17+, and parents set the age restriction to \<17, this effectively makes it so that their child cannot download apps that are 17+, or if these apps are already downloaded, the child can't use/launch these 17+ apps, as their icons are hidden.
+
+On Apple's App Store, all browsers (including Safari, despite it being preinstalled) have a 17+ age restriction, under the justification that they provide "Unrestricted Web Access". So if parents set app age restrictions on their children's devices, they cannot download or launch already installed competing third-party browsers. However, as discussed in the introduction, Safari is exempted from this.
+
+We would like to clarify that on iOS, at the moment, parents are free to set age restrictions for apps to 4+ years old (i.e. only apps that Apple believes are suitable for 4 year olds \- 8 year olds), yet still allow unrestricted internet access to all websites. These two mechanisms are entirely independent of each other.
+
+To emphasize the distinction, the age restrictions for apps setting has nothing to do with unrestricted internet access (i.e. to adult websites etc) — the restriction only affects which apps young users are allowed to download or use.
+
+## 2. Choice Screen Non-Compliance
+
+This issue with age restrictions for apps also breaks the browser choice screen. We've discovered that for iOS users with age restrictions enabled, the browser choice screen is completely broken:
+
+1. The screen displays a list of browsers to choose as the new system default.
+
+2. Upon selecting a third-party browser other than Safari, the system initiates a download process.
+
+3. Once the download reaches 100%, the screen becomes unresponsive, trapping the user without any further actions or navigation options. The user's only choice is to quit the choice screen.
+
+4. Quitting the screen reveals that the chosen browser has not been installed, leaving Safari as the only available browser.
+
+This effectively breaks the choice screen and denies that choice for all European Residents who are iOS users with age restrictions for apps turned on.
+
+## 3. How many users does this affect?
+
+Eurostat data reveals that [5.2% of EU residents are aged 15-19](https://ec.europa.eu/eurostat/cache/interactive-publications/demography/2023/04/index.html?lang=en), [while 15% are under 15](https://ec.europa.eu/eurostat/cache/interactive-publications/demography/2023/04/index.html?lang=en). Considering these figures, it is reasonable to estimate that approximately 15-20% of the EU population is under the age of 17\.
+
+We do not have precise figures on the number of users that switch on age restrictions for apps but the following pieces of data give us a rough idea:
+
+* [This survey](https://www.techradar.com/pro/how-to-put-parental-controls-on-an-iphone) states 39% of parents report using parental controls for blocking, filtering or monitoring their teen’s online activities.
+
+* [This study](https://www.pewresearch.org/internet/2016/01/07/parents-teens-and-digital-monitoring/) states 59.5% of them actively use parental controls on their child’s iPhone.
+
+* [This study](https://digitalwellnesslab.org/research-briefs/safety-and-surveillance-software-practices-as-a-parent-in-the-digital-world/) states 72% use parental controls to restrict time on devices.
+
+By combining the figures we can estimate that Apple is blocking its choice screen from working for approximately 11-15% of EU residents who use iOS, which is a significant percentage of the population.
+
+## 4. Why is this important?
+
+Apple effectively prevents users with age restriction for apps turned on from being able to download and use competing third-party browsers.
+
+Yet, on that same device, despite the fact that Safari itself has the same 17+ age restriction in the App Store, users can continue to use Safari without any restrictions or issues, and so can continue to access the web through Safari with no restrictions, including adult websites.
+
+Conversely, if the parent turned off age restriction for apps but enabled web content restrictions then adult websites would be blocked in all browsers on iOS.
+
+This is due to the fact that, as we mentioned earlier, the web content restriction settings are in fact independent from the age restriction settings.
+
+Currently, Safari having an exception effectively prevents all third-party browser competition on iOS for a significant segment of the European population (approximately 11-15% of EU iOS users). This practice not only significantly undermines the effectiveness of the browser choice screen but also more broadly stifles browser competition. In the next 5 \- 10 years, the effect of these restrictions could mean the majority of young users will grow up without being aware of alternative browsers or the features they offer.
+
+Finally, as an example of how this behavior could impede third parties contesting Apple’s app store, this will likely have a major impact on the online gaming industry. Once third-party browser engines start to make their way onto iOS, it will pave the way for an explosion in the online gaming industry. We can already see this from the vast number of online cloud-streaming game services that rely on web technologies.
+
+By gating young users' access to alternative browsers and browser engines behind an age restriction, Apple effectively forces the future of online gaming to take place in their browser, with its limited number of APIs and features, which nudges developers to instead build native apps and users to choose native games from which Apple can and will profit greatly from.
+
+## 5. Apple Agrees that Users should have at least One Browser
+
+When attempting to delete the only browser on iOS, Apple will display the following message:
+
+> **Download Browser App**
+> At least one browser app is required on iPhone. Download another browser app, then you can delete “Safari”.
+> \[Open App Store\] \[Cancel\]
+
+<figure>
+    {% image
+        "/images/blog/delete-only-browser-error-message.png",
+        "An error message on iOS. Reads At least one browser app is required on iPhone. Download another browser app, then you can delete 'Safari'.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Apple's error message for deleting only browser.</figcaption>
+</figure>
+
+However, Apple currently maintains this requirement by granting Safari a special exemption from its own age restrictions for apps. This exemption highlights the inconsistency in Apple's approach, as it recognizes the need for browser availability while simultaneously imposing barriers on third-party browsers.
+
+It's worth noting that if a user installs a third-party browser, deletes Safari, and then enables age restrictions, they will be left without any browser options, as the icons for all the third-party browsers will be removed and it will be hidden from search. This scenario further emphasizes the limitations of Apple's current system and the need for a more consistent and equitable approach.
+
+## 5. Apple's Inconsistent and Poorly Designed Age Ratings
+
+Apple has the following age rating settings available:
+
+<figure>
+    {% image
+        "/images/blog/age-settings.jpeg",
+        "The age restrictions settings page on iOS. It has the title apps and 5 settings. The settings are Don't Allow, 4+, 9+, 12+, 17+. The 17+ setting is ticked",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/age-rating-explanations.jpeg",
+        "A screenshot of an article by Apple explaining what age ratings apple has.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Apple's age rating settings and explanation.</figcaption>
+</figure>
+
+Bizarrely, Apple lacks an "Everyone" or G rating. This could be a strategic move by Apple to potentially claim that all apps are intended for users aged 4 and over. This approach might shield Apple from potential legal liabilities arising from younger children's use of apps.
+
+They also explain their age rating system [on their website.](https://developer.apple.com/help/app-store-connect/reference/age-ratings/) At the end, they snidely claim that adult content is only accessible on alternative app marketplaces or websites within the European Union.
+
+Possibly this is an attempt to cast alternative app stores as being unsavory but is odd in the context of 18+ ([depending on country](https://www.imdb.com/title/tt6263850/parentalguide/?ref_=tt_stry_pg#certificates)) films such as “Deadpool & Wolverine” being billion dollar box office hits, immensely popular and available on the iOS App Store via Disney+.
+
+### 5.1. 18+ Content on the Apple’s App Store
+
+Disney Plus has a 4+ rating, yet one of the first things advertised on its app store page is the Deadpool & Wolverine film, which is rated for 14+ and 18+ ([varies by country](https://www.imdb.com/title/tt6263850/parentalguide/?ref_=tt_stry_pg#certificates)).
+
+<figure>
+    {% image
+        "/images/blog/disney-plus-ios-app-store.jpeg",
+        "A screenshot of the disney+ iOS app store page. It has the age rating 4+.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/disney-plus-deadpool.jpeg",
+        "A screenshot of the disney+ iOS app store page showing the the new deadpool film is now available.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Disney Plus (4+) and Deadpool & Wolverine.</figcaption>
+</figure>
+
+
+### 5.2. Apps for Kindergarten Children
+
+<figure>
+    {% image
+        "/images/blog/kindergarten-app-1.jpeg",
+        "An screenshot of the bebi teaching app. It has a 4+ rating.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/kindergarten-app-2.jpeg",
+        "An screenshot of the bebi teaching app, it indicates it can help 2,3,4 and even 5 year olds learn.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Teaching App for Babies and Kindergarten with 4+ rating</figcaption>
+</figure>
+
+For example, this app is marketed as being to help “2,3,4 and even 5 year olds” learn. Despite this it has a 4+ rating (the lowest rating that Apple will allow). It is not clear why apps like this should not have a G rating and if they are unsuitable for under 4 year olds, why they should be allowed to market themselves as being for that demographic.
+
+### 5.3. In-App Browsers
+
+Again, adult content is not filtered by the age rating setting for apps. Any apps that contain links (for example messaging and social media apps) will not be blocked by the age rating setting for apps, nor does this affect their age rating.
+
+For example adult websites can be visited in apps with low age ratings (such as Instagram which is rated 12+) by using Apple’s in-app browser SFSafariViewController:
+
+<figure>
+    {% image
+        "/images/blog/instagram-link-1.jpeg",
+        "A message being sent with a link on Instagram.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/instagram-link-2.jpeg",
+        "That link opening into an in-app browser with the warning 18+ splash page for an adult website.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>A link being opened in a 12+ app to an adult website.</figcaption>
+</figure>
+
+This highlights why age ratings on apps with links to the web doesn’t make sense: **it is the web content restriction setting which actually prevents** in-app browsers from visiting known adult websites. The age rating setting is ineffective here, as can be seen in these screenshots.
+
+### 5.4. Inconsistently Applied Ratings
+
+Apple’s age ratings are also wildly inconsistent.
+
+Disney+ is 4+ but Netflix and Apple TV are 12+. However, both contain between 15-18+ content and all three have built-in parental controls.
+
+Most messaging apps are 12+, some are 17+ but iMessage and Facetime are 4+ despite all messaging apps having the ability to transmit 18+ content.
+
+Large numbers of apps that should be G rated are assigned a 4+ rating.
+
+### 5.5. More Apple Apps Outright Ignoring the Rating System
+
+iMessage, Facetime, Apple Books and Apple TV all outright ignore the age restrictions for apps. That is, unlike other apps, they are not hidden and disabled when users turn on age restrictions for apps to an age below their rating.
+
+iMessage and Facetime (both rated 4+ but having the ability to display 18+ content) will continue to function if the age restriction for apps is set to “Don’t Allow” (a setting that seemingly disables all apps), despite being listed on the app store with age ratings.
+
+Apple TV, despite having a rating of 12+ ([and content that is rated between 12+ and 18+ depending on country](https://www.imdb.com/title/tt11280740/)) will continue to function if the age rating is set to 4+. Note: Apple TV does have its [own separate set of controls](https://support.apple.com/en-gb/guide/tvapp/atvb5408f9ae/web) within the app that allow parents to restrict the content.
+
+This is still problematic as [Netflix also has such controls](https://help.netflix.com/en/node/264), but setting the age restrictions for apps to 4+ will remove the icon for the Netflix app and make it impossible to open it. This is clearly an unfair, unhelpful and anti-competitive way to implement age controls.
+
+A more sensible solution, which would actually help parents who want to use such a setting, would be to:
+
+* Have a G-rating (or Everyone rating).
+
+* Acknowledge that the app store has 18+ content, and where necessary assign that rating to apps. Simply pretending it does not exist is not helpful. While films and TV shows vary in rating from country to country, to our knowledge Apple does not block these TV shows/films in countries where they are rated 18+.
+
+* Let apps have the lowest rating of all (or as much as reasonably possible) of the content on the app can be filtered using parental controls within each app.
+
+* Apply the ratings consistently to Apple’s apps. If that is a significant issue, then it's an indication the age rating system is not designed properly.
+
+* Have an allow and block list (like for the web content restriction setting) so that parents can individually allow or block apps that Apple has inappropriately or incorrectly rated.
+
+As it is, Apple, by their misdesign of the system, is not only harming competition, but is actively preventing parents from using these age restriction controls by making them difficult to use. A parent, upon discovering that their Netflix app will no longer function, despite it being set to only allow childrens content, might avoid using the setting altogether.
+
+## 6. Remedies
+
+In order to be in full compliance with Articles 6(3) and 6(7) of the DMA in relation to this issue, Apple must take the following steps:
+
+* **Remove Age Ratings from Browsers**
+  Given that parental controls for web browsing operate independently of app age ratings, Apple should remove age ratings from browsers. The 17+ age rating on browsers serves no significant purpose, **except** **to hinder competition** from third-party browsers, as evidenced by Apple's exemption of Safari from these restrictions.   <br><br>
+
+  All browsers that support Apple’s existing system of web content restrictions (currently all browsers on iOS, as it is implemented via the WkWebView) should be allowed with G rating or given a 4+ rating. EU users should have the option of setting both “web content restrictions” and “age restriction for apps” for their children and still be able to use third-party browsers.
+
+* **Compliant Browser Choice Screen**
+  The browser choice screen must be accessible to all EU residents regardless of their age, or whether they have age restriction for apps turned on, and the users must be able to select, install and use any browser from that choice screen. This must be fixed before the general roll out of the updated choice screen, or in the case it is not, be rerun on all of those devices after the fix has been applied.
+
+* **Third-Party Browser Support for Parent Controls**
+  Apple should develop an API that allows third-party browsers using their own engine to effectively support parental control features. This should be relatively straightforward for Apple to implement.
+
+* **Age Restrictions for Apps should apply equally to Apple’s own Apps**
+  Apple should not exempt its own apps from the setting. Where this causes problems Apple should carefully redesign the system. *Fixing the system, but doing so only for Apple’s apps, is not acceptable under the DMA*.
+
+By compelling Apple to implement these remedies, the EU Commission can help ensure equal treatment of all browsers and remove these barriers to choice. This benefits individual consumers by allowing them to make informed decisions about the software they use. Additionally, it stimulates innovation and competition among browser vendors, leading to a better user experience and a more diverse digital ecosystem.

--- a/src/es/posts/its-official-apple-kills-web-apps-in-the-eu.md
+++ b/src/es/posts/its-official-apple-kills-web-apps-in-the-eu.md
@@ -1,0 +1,65 @@
+---
+title: 'It’s Official, Apple Kills Web Apps in the EU'
+date: '2024-02-16'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: OWA
+relatedLinks:
+  - url: 'https://developer.apple.com/support/dma-and-apps-in-the-eu#8'
+    title: Why don't users in the EU have access to Home Screen web apps?
+    date: 2024-02-19T00:00:00.000Z
+permalink: /es/blog/its-official-apple-kills-web-apps-in-the-eu/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/owa-home-logo.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">
+          Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+Nearly two weeks ago [we discussed a bug](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/) on iOS Beta 17.4 breaking Web App installation in the EU. Yesterday [we raised the alarm](https://open-web-advocacy.org/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days/) that this appeared to be not a bug but a deliberate choice on Apple’s part. Today Apple officially confirmed our suspicions in an update to their compliance proposal.
+
+In a direct attack on the open web, its users, and its developers, [they have decided to kill Web Apps (PWAs) in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu#8):
+
+> And so, to comply with the DMA’s requirements, we had to remove the Home Screen web apps feature in the EU.<br><br>
+> EU users will be able to continue accessing websites directly from their Home Screen through a bookmark with minimal impact to their functionality. We expect this change to affect a small number of users. Still, we regret any impact this change — that was made as part of the work to comply with the DMA — may have on developers of Home Screen web apps and our users.”
+
+This is emphatically not required by the EU’s Digital Markets Act (DMA). It’s a circumvention of both the spirit and the letter of the Act, and if the EU allows it, then the DMA will have failed in its aim to allow fair and effective browser and web app competition.
+
+It’s telling that this is the feature that Apple refused to share. And it makes sense: the idea that users could install safe and secure apps that Apple can’t tax, block or control is terrifying to them.
+
+The legal obligation to allow third-party browsers onto iOS removes their ability to set a ceiling on web app functionality via their control of Safari and the WKWebView. Suddenly Web Apps would be a viable competitor. It is particularly galling for them to cite low adoption when they have had their thumb on the scale suppressing them for over a decade.
+
+The DMA compels them to allow third party app stores, but Apple’s plan is to cripple them with their hardware and software API fee (Core Technology Fee) and their ludicrous “opt-in to your legal rights” at a different price alternative contract.
+
+But web apps are much harder to stop. Even Apple admits WebKit’s sandbox is, [to quote them](https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf) ”orders of magnitude more stringent than the sandbox for native iOS apps”. They tried claiming to the UK regulator that Safari is more secure than other major browsers but decisively lost that argument.
+
+So this is their new tactic: Kill off a competitor while saying the EU made them do it.
+
+Apple has had 15 years to allow third party browsers the ability to compete in web app functionality and nearly 2 since they knew they would be legally compelled to do so.
+
+[Apple also makes tenuous, bordering on laughable, claims regarding web app security.](https://developer.apple.com/support/dma-and-apps-in-the-eu#dev-qa:~:text=Why%20don%27t%20users%20in%20the%20EU%20have%20access%20to%20Home%20Screen%20web%20apps%3F) In addition to unwarranted and unjustifiable attempts to project their own model onto competing browsers, Apple makes claims that ignore the history of web applications and browsers in providing strong privacy and security separation. Apple offers no evidence to back these assertions, and ignores the long track record of superior security of PWAs on other OSes.
+
+Again and again, Apple has offered paper-thin fig-leaf arguments based on security to duck regulation, only to have these ploys rejected in nearly every jurisdiction where evidence is critically examined. This appears to be another instance of the same willfully misleading pattern. If security posturing is the backbone of Apple’s attempt to duck conformance with the DMA, the EU must reject the proposal and find Apple willfully non-compliant.
+
+Apple also makes a self-fulfilling argument regarding the low use of iOS homescreen web apps. This is a situation of Apple’s own making and, indeed, a large part of why OWA has invested so much in reversing Apple’s history of self-preferencing towards native apps that Apple can tax through its App Store monopoly. Instead of offering equivalent affordances for websites looking to compete with App Store alternatives, Apple’s answer is to remove the capability, destroy critical features, and engender data loss for users and businesses that had invested in the web as a platform. Malicious destruction may be Apple’s attempt at an answer, but it is not a solution.
+
+The next question is: Why all the secrecy? There was nothing in their compliance plan, Safari’s release notes or the beta’s release notes. Given that they are now stating they knew all along, it seems they wanted to see if they could sneak this past.
+
+Clearly the backlash has caught them off guard and that’s why they had to rush out this panicked response, the only significant update they have made to their compliance proposal.
+
+We always assumed that the commission would have to fine Apple billions to force them to allow the web to compete fairly and effectively with their App Store but it’s still incredibly disappointing to see Apple behave like this.
+
+This is a message in a bottle to regulators world-wide: Apple will stop at nothing to protect its app distribution monopoly and the rent that comes with it, including removing critical features from its OSes without the slightest care for its users. It will not act in good faith, it must be forced.
+
+We will continue to work with the EC to ensure that Web Apps can remain first-class citizens for iOS users, businesses, and competing browser vendors.

--- a/src/es/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
+++ b/src/es/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
@@ -1,0 +1,94 @@
+---
+title: 'It''s time for a fairer, more competitive app ecosystem'
+date: '2024-10-24'
+tags:
+  - Policy
+  - EU
+  - DMA
+  - Apple
+  - Google
+  - Microsoft
+  - Meta
+  - Bytedance
+author: OWA
+permalink: /es/blog/its-time-for-a-fairer-more-competitive-app-ecosystem/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Today, together with many others, we have co-signed [this important letter](/files/Open%20Letter%20-%20DMA%20enforcement.pdf) addressing the urgent need for DMA enforcement.  
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1849318246358667748), [Mastodon](https://mastodon.social/@owa/113360687739265649), [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_its-time-for-a-fairer-more-competitive-activity-7255092980787593219-88eF).
+
+The Digital Markets Act (DMA) aims to restore contestability, interoperability, choice, and fairness to digital markets within the EU. These fundamental principles of a well-functioning digital market have been compromised by the excessive power gatekeepers exert through their control of "core platform services."
+
+The lack of competition in mobile ecosystems is fundamentally structural. Gatekeepers wield immense power due to the security model upon which these devices are built. Traditionally, on operating systems like Windows, macOS, and Linux, users can install any application they choose without interaction from the operating system gatekeeper, either by the business or the end user. Users can then grant these programs the necessary permissions to perform their desired functions.
+
+While restricting what applications can do, such as limiting their access to certain APIs behind user permissions, is not inherently anti-competitive and can offer legitimate security benefits, its implementation on mobile devices is both self-serving and significantly damaging to competition in its current form.
+
+This anti-competitive behaviour, hindering both browser and Web App competition, has and continues to cost consumers billions of dollars annually.
+
+This is not an exaggeration; if the Web were able to compete fairly and effectively with native app stores, these gatekeepers would not be able to demand a 30% cut of all third-party software. Gatekeepers obtain this cut not through merit but simply by blocking all alternative means of running third-party software, such as Web Apps.
+
+The harm extends beyond these taxes extracted through lock-in. It also damages the ecosystem in four other key ways:
+
+* Increased development costs  
+* The ability to block competitors or entire categories of apps  
+* Higher costs and friction associated with market entry, leading to fewer apps  
+* Deprivation of new mobile device ecosystems from a library of apps, blocking a new competitor to iOS and Android from emerging.
+
+The DMA was passed into law on 1st of November 2022 and its grace period for gatekeepers ended on March 7th 2024, more than 6 months ago. Despite this, gatekeepers (in particular Apple) are still not fully complying with either the letter or spirit of the DMA.
+
+While the DMA has had some significant success in obligating both Apple and Google to introduce reasonably designed browser choice screens, [fix this outrageous deceptive pattern](/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/), [allow game emulators](https://au.pcmag.com/mobile-apps/104689/apple-is-finally-allowing-retro-game-emulators-in-the-app-store), [fairer default choice](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/) and have [three non-compliance investigations into Apple](https://www.theguardian.com/technology/article/2024/jun/24/apple-breach-eu-competition-rules-digital-markets-act), there is still much to be done.
+
+The following issues remain unresolved:
+
+**Apple:**
+
+* [Allow browser vendors to keep their existing EU consumers when switching to use their own engine.](https://open-web-advocacy.org/apple-dma-review/#allow-browser-vendors-to-keep-their-existing-EU-customers)  
+* [Allowing Browser Vendors and Developers to be able to test their browsers and web software outside the EU.](https://open-web-advocacy.org/apple-dma-review/#testing-for-browser-vendors-and-developers-outside-the-EU)  
+* [Restricting Apple's API contract for browsers down to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/apple-dma-review/#remove-non-security-terms)  
+* [Make clear what the security measures are for third party browsers using their own engine by publishing them in a single up-to-date document.](https://open-web-advocacy.org/apple-dma-review/#security-rules-must-be-clear)  
+* [Implementing Install Prompts in iOS Safari for Web Apps.](https://open-web-advocacy.org/apple-dma-review/#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers)  
+* [Allowing Browsers using their own engine to install and manage Web Apps.](https://open-web-advocacy.org/apple-dma-review/#web-app-installation-and-management-for-third-party-browsers)  
+* [Removing any App Store rule that would prevent third party browsers from competing fairly.](https://open-web-advocacy.org/apple-dma-review/#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43)  
+* [Make Safari uninstallable.](https://open-web-advocacy.org/apple-dma-review/#safari-is-not-uninstallable)  
+* [Make notarization a fast and automatic process, as on macOS.](https://open-web-advocacy.org/apple-dma-review/#apple-should-make-notarization-for-directly-downloaded-browsers-automatic)  
+* [Allow direct browser installation independently from Apple’s app store.](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation)  
+* [Allow users to switch to different distribution methods of a native app and allow developers to promote that option to the user.](https://open-web-advocacy.org/apple-dma-review/#allow-users-to-switch-the-distribution-method-of-native-apps)  
+* [Respect the user's choice of default browser in SFSafariViewController.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* [Don’t lock Safari to Apple Pay](https://open-web-advocacy.org/apple-dma-review/#safari-is-locked-to-apple-pay)  
+* [Don't break third party browsers for EU residents who are travelling.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu)  
+* [Opt-Into Rights contract should be removed.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu:~:text=with%20the%20DMA.-,4.3.6.%20Opt%2DIn%20Rights%20Contract%20Should%20Be%20Removed,-All%20businesses%20serving)  
+* [Core Technology Fee should be removed.](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed)  
+* [Publish a new more detailed compliance plan.](https://open-web-advocacy.org/apple-dma-review/#apple-should-publish-a-new-more-detailed-compliance-plan)
+
+**Google:**
+
+* [Share WebAPK Minting with third-party browser vendors subject to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/blog/google-must-share-the-ability-to-install-web-apps-in-android/)  
+* [Respect the user's choice of default browser in the Android Google Search App and the Google App.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* Make Chrome uninstallable on Android.
+
+**Microsoft:**
+
+* [Remove edge-links and instead respect the user's choice of default browser in various Microsoft apps.](https://www.tomshardware.com/news/microsoft-confirms-windows-11-edge-default-browser)  
+* [Remove and permanently disable various popups, banners in Windows, Bing and Edge that aim to discourage users from switching browser.](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf)  
+* [Allow filetype defaults for browsers to be changed more easily.](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf)  
+* Allow users to switch browser in S-Mode, subject to strictly necessary, proportionate and justified security measures.
+
+**Meta:**
+
+* [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
+
+**Bytedance:**
+
+* [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
+
+For this reason we are adding our voice to many others asking for a fairer, more competitive app ecosystem. Enforcing the DMA is the quickest way to get there.  
+
+We urge MEPs of the ECON and IMCO Committees to hold the gatekeepers accountable for compliance with the DMA.
+
+Read [our joint letter here](/files/Open%20Letter%20-%20DMA%20enforcement.pdf).
+
+
+

--- a/src/es/posts/japan-ends-the-apple-browser-ban.md
+++ b/src/es/posts/japan-ends-the-apple-browser-ban.md
@@ -1,0 +1,60 @@
+---
+title: 'Japan ends the #AppleBrowserBan'
+date: '2024-06-13'
+tags:
+  - Apple
+  - Japan
+  - Safari
+author: OWA
+relatedLinks: null
+permalink: /es/blog/japan-ends-the-apple-browser-ban/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Yesterday, Japan’s parliament [passed into law a bill](https://www.nippon.com/en/news/yjj2024061200145/) to promote fair competition on smartphone operating systems, similar to the [EU’s Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) and the [UK’s Digital Markets, Competition and Consumers Bill](https://publications.parliament.uk/pa/bills/cbill/58-04/0003/230003.pdf).
+
+In particular, it prohibits Apple’s ban of third party browser engines on iOS, which is an [effective ban on browsers like Firefox, Chrome, Edge, Opera, Brave & Vivaldi](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Apple bans these browser vendors from choosing and modifying their own engines, and instead forces them to use Apple’s browser engine which they can’t modify and have no control over. This then ensures that there is no effective browser competition on iOS and deprives Web Apps of the functionality they need to compete with native apps. 
+
+This is the second jurisdiction (after the EU in the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)) to explicitly codify this into law.
+
+> Article 1: In light of the role that smartphones play in Japan as the foundation of people's lives and economic activity, this Act aims to promote fair and free competition in the field of specific software by providing prohibitions on businesses that provide specific software that is particularly necessary for smartphone use from exploiting their position as businesses that provide specific software to give the products or services they provide a competitive advantage and from causing disadvantage to the business activities of businesses that use specific software, thereby contributing to the improvement of people's lives and the sound development of the national economy.
+> <cite>[Bill on the Promotion of Competition for Specified Software Used in Smartphones
+](https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/houan/g21309062.htm)</br>
+(machine translated)</cite>
+
+> The EU has pioneered new regulations in this field, and in order for the digital markets of the EU, US, and Japan to work in lockstep to set fair competition practices for platform operators, a new legal framework is also needed in the Japanese market to confront digital platform operators.
+> <cite>[Japan Fair Trade Commision
+](https://www.jftc.go.jp/file/240612EN3.pdf)</cite>
+
+This bill was based on the [Japan's Head Quarters for Digital Competition's Final Report](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_230616.pdf) which OWA consulted on. You can [read our paper here](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf).
+
+The bill aims to promote fair and free competition on smartphones by preventing large tech companies from abusing their position as providers of platforms to block or advantage their own services.
+
+Violators will face fines equivalent to 20% of the domestic revenue of the service that violated the law. The rate of the fine can be increased to 30% for repeated violations.
+
+The final bill contains a number of interesting articles relevant to browsers and Web Apps:
+* Banning browser engines is prohibited.
+* Must share APIs and services of the operating system to the same level as the services used by the designated providers. Justifiable measures may be applied.
+* Designated providers shall make it easy to change the default settings of the operating system.
+* Designated providers shall provide a choice screen for browsers.
+* When a designated business operator sets or changes the specifications, sets or changes the conditions for use, it must take necessary measures, such as securing a period for the business operator specified in each item to smoothly respond to the measure, disclosing information, and establishing a necessary system, as specified by the Fair Trade Commission rules.
+
+This law will go into effect at a date chosen by the government at least 1.5 years from signing. This would put the earliest date of being in force as December 12, 2025.
+
+This is an important step to restoring browser competition to iOS and enabling Web Apps to succeed on mobile as the world's only truly interoperable app development platform. Each jurisdiction that enforces rules to enable browsers and Web Apps to compete fairly is an important step on the road to a global solution. Apple has taken some [rather extreme measures](https://www.theregister.com/2024/05/17/apple_browser_eu/) [to geo-fence](https://support.apple.com/en-us/118110#:~:text=If%20you%20leave%20the%20European,apps%20from%20alternative%20app%20marketplaces.) [and undermine](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/) the Digital Markets Act in the EU but as the number of jurisdictions grow, the benefits to consumers and business become clear and the scare tactics are shown to be groundless, the harder it will be to maintain and justify such tactics.
+
+Next up, [the UK](https://open-web-advocacy.org/blog/uk-passes-dmcc/), [the USA](https://open-web-advocacy.org/blog/us-doj-files-apple-antitrust-case/) [and Australia](https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/)…
+
+</br>
+
+**This victory wouldn't have been possible without your unwavering support**. While we celebrate this important step, let's remember the fight for global browser competition continues. Stay tuned, and let's work together to ensure browser choice for all users, everywhere!
+
+**Your browser, your choice!**
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/our-response-cma-interim-report.md
+++ b/src/es/posts/our-response-cma-interim-report.md
@@ -1,0 +1,593 @@
+---
+title: OWA response to the CMA interim report
+date: '2022-03-08'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Alex Moore
+permalink: /es/blog/our-response-cma-interim-report/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The CMA invited responses to its [interim report](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study).
+You can read our [response with suggested browser and web-app remedies (PDF)](/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf).
+
+<a href="/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf" class="action-button">Download response</a>
+
+<!--
+1. Table of Contents
+2. Introduction
+   2.1. Interim Report Remedies
+3. Effective Competition?
+4. Remedies
+   4.1. Require equivalent API access for rival browsers
+       4.1.1. iOS
+       4.1.2. Android
+       4.1.3. Effectiveness of Remedy
+   4.2. Require Safari/Webkit to support key Web App Features
+   4.3. Require iOS to Allow Third Party Browser Engines
+   4.4. Require Broad Web App Support
+5. Security and Privacy
+6. International Outreach
+7. Summary
+8. References
+9. Open Web Advocacy-->
+
+
+## 2. Introduction
+We agree overwhelmingly with the findings of fact and, with comments, agree that the
+proposed interventions contained within the CMA’s December 14th, 2021 “[Mobile ecosystems
+market study interim report](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)”
+are both warranted and timely.
+
+
+iOS Safari faces no effective competition as Apple has not provided access to private APIs that
+competing browsers need and has banned competing engines. The CMA have highlighted the
+second aspect (labelling it "the Webkit Restriction") accurately and extensively in their report
+and [write](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction):
+
+
+> &ldquo;As a result of the WebKit restriction, there is no competition in browser engines on iOS
+> and Apple effectively dictates the features that browsers on iOS can offer (to the extent
+> that they are governed by the browser engine as opposed to by the UI).&rdquo;
+
+> &ldquo;Importantly, due to the WebKit restriction, Apple makes decisions on whether to support
+> features not only for its own browser, but for all browsers on iOS. This not only restricts
+> competition (as it materially limits the potential for rival browsers to differentiate
+> themselves from Safari on factors such as speed and functionality) but also limits the
+> capability of all browsers on iOS devices, depriving iOS users of useful innovations they
+> might otherwise benefit from.&rdquo;
+
+
+They also note that Apple has [two perverse incentives](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Potential%20strategic%20reasons%20for%20Apple%E2%80%99s%20WebKit%20restriction) to hold back Webkit and to hinder Web
+Apps ability to compete with the iOS App Store:
+
+
+> &ldquo;First, Apple receives significant revenue from Google by setting Google Search as the
+> default search engine on Safari, and therefore benefits financially from high usage of
+> Safari. Safari has a strong advantage on iOS over other browsers because it is
+> pre-installed and set as the default browser. The WebKit restriction may help to entrench
+> this position by limiting the scope for other browsers on iOS to differentiate themselves
+> from Safari (for example being less able to accelerate the speed of page loading and not
+> being able to display videos in formats not supported by WebKit). As a result, it is less
+> likely that users will choose other browsers over Safari, which in turn secures Apple’s
+> revenues from Google.&rdquo;
+
+> &ldquo;Second, and as discussed in Competition in the distribution of native apps, Apple
+> generates revenue through its App Store, both by charging developers for access to the
+> App Store and by taking a commission for payments made via Apple IAP. Apple therefore
+> benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use
+> the WebKit browser engine, Apple is able to exert control over the maximum functionality
+> of all browsers on iOS and, as a consequence, hold up the development and use of web
+> apps. This limits the competitive constraint that web apps pose on native apps, which in
+> turn protects and benefits Apple’s App Store revenues.&rdquo;
+
+Apple’s incentives and behaviour bear additional scrutiny.
+
+Apple receives [$15 billion USD a year](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/) from their Google Search engine deal, representing 9% of
+Apple’s 2019 gross profit. Apple has not published the annual budget for Safari/Webkit but
+based on [anecdotal evidence](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug#:~:text=whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition) it is likely significantly less than 2% of this sum.
+
+Apple collected [$72.3 billion USD in App Store fees](https://appleinsider.com/articles/21/01/05/app-store-earns-723-billion-in-2020-almost-double-google-play-revenues)
+in 2020. While it has not published the
+costs of App Store review, payment processing, refund handling etc, it has been estimated that
+the iOS App Store has a nearly [80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506).
+Industries with healthy competition feature
+leading firms with profit margins between [5 and 20 percent](https://www.brex.com/blog/what-is-a-good-profit-margin).
+This imbalance strongly implies
+that Apple’s removal of functional competition in the App Store and beyond have broken the
+mobile phone market for software and services for more than half of the UK’s consumers.
+
+If Safari/Webkit had competition on iOS, Apple would have great incentive to retain users on
+their browser by making a better, more functional browser. A competitive web ecosystem may
+also put pressure on rent extracting behaviour without sacrificing user safety as browser
+makers compete aggressively on security, privacy, and user-empowering features such as
+extensions. If Web Apps are competitive with Native Apps, without sacrificing safety,
+system-default app stores may become less important to both users and software makers.
+
+Our primary submission **“[Bringing Competition to Walled Gardens](https://open-web-advocacy.org/walled-gardens-report/)”**
+outlines our arguments in detail.
+
+### 2.1. Interim Report Remedies
+
+The interim report proposes [three potential remedies](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Remedies%20designed%20to%20enhance%20functionality%20and%20interoperability%20of%20browsers):
+
+1.   Require equivalent API access for rival browsers
+
+2. Require that iOS and the version of Webkit provided by iOS support specific features
+  required by Web Apps
+
+3. Require that iOS allows third party browser engines
+
+We believe and argue below that while Remedy 2 (Requiring Webkit Features) may provide
+some value in the short term, in the long term it will ultimately be unworkable as a replacement
+for Remedy 1 (Equivalent API) and Remedy 3 (Third Party Engines), and only both Remedy 1
+(Equivalent API) and Remedy 3 (Third Party Engines) will restore competition between
+browsers on iOS and between Web Apps and Native Apps on iOS.
+
+We also propose a 4th Remedy “Require Broad Web App Support” which has specific technical
+aspects not covered by Remedy 1 (Equivalent API) and Remedy 2 (Requiring Webkit Features).
+
+In addition we believe that Remedy 1 (Equivalent API) needs to be significantly strengthened to
+prevent gaming by Apple.
+
+## 3. Effective Competition?
+
+> &ldquo;Businesses that face effective competition dare not raise prices, or cut down on quality
+> standards, for fear of losing customers to their competitors (and so losing money)&rdquo;
+>
+> &mdash; [Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+> &ldquo;For the foreseeable future, iOS will be the dominant access pathway, passport,
+> monetizer and platform for not just digital life, but virtual ones. Apple holds this role
+> because it makes best-in-class hardware, offers the best apps, and operates the most
+> lucrative app store.&rdquo;
+>
+> &mdash; [Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)
+
+iOS Safari faces no effective competition as Apple has banned competing engines. These
+engines, in turn, differentiate other browsers. Without substantive competition in browsers,
+consumers have little recourse short of buying another phone. Businesses and developers,
+meanwhile, are forced to consider the Web as an uncompetitive environment in which to launch
+services, as Apple’s neglect has ensured that for more than half of UK users, browsers cannot
+be a reasonable replacement for Apple’s proprietary App Store and APIs.
+
+The development, maintenance and lost opportunity costs of supporting a buggy browser that
+misses key features are mostly hidden from end users. It is hard for consumers to see a missing
+feature or an entire Web App that didn’t get built (due to poor support in iOS Safari). When they
+do encounter a bug caused by Safari they are more likely to blame the Web App than the
+browser. The user may get the impression that the Web is buggy, slow and that Native Apps
+are better, which then has negative flow on effects for the entire web ecosystem.
+
+Businesses have little recourse as they can not suggest their customers install another real
+browser (there are none) and they are unwilling to lose more than half their mobile customers
+(51% in the UK, 66% in Japan, 56% in Australia, 46% in the US). Additionally iOS users tend to
+be wealthier and [spend more](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+making them a higher priority for companies. In the end the
+majority of large businesses simply throw in the towel and make an iOS Native App and in doing
+so agree to pay Apple 15-30% of their revenue.
+
+As such, Apple faces little effective competitive pressure to improve the quality of their iOS
+Safari browser and has incentives to inhibit it from competing with native. Thus Apple’s decade
+long prohibition on competition for Safari on iOS has a compounding anti-competitive effect as
+companies sink money into non-interoperable native iOS applications instead of Web Apps.
+
+Even Apple executives appear to be aware only their stranglehold on iOS installation is allowing
+their 30% tax on revenue, something they can not achieve on Mac OS.
+
+> &ldquo;Neither is on the store because they don't have to be. They can be on Mac and
+> distribute to users without sharing the revenue with us.&rdquo;
+>
+> &mdash; Philip Schiller - Apple Upper Management - [On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+## 4. Remedies
+
+### 4.1. Require equivalent API access for rival browsers
+
+We believe that Third Party Apps access to operating system APIs and features should be, at a
+minimum, equivalent to the access provided to Apps and functions provided by the Gatekeeper
+or its business partners. Currently on iOS and Android there exist features that are exclusive to
+the browsers owned by the gatekeeper of the operating system.
+
+#### 4.1.1. iOS
+
+Apple's hobbling of third party browsers doesn't stop at mandating a specific version of
+Webkit, Apple provides Safari significant unfair advantages.
+
+The major issues include:
+
+   1.   **Full Screen**
+
+        iOS Safari allows video elements to become full screen, but frustratingly, not other
+        element types. This hobbles many gaming scenarios on the Web. The HTML5 canvas
+        element is essential for games (where Apple derives the lion’s share of App Store
+        revenue) which cannot be made full screen.
+
+        Competing browsers, based on other engines, have long pro**vided reasonable behaviour
+        in this regard, including on Android.
+
+   2. **No Web Apps**
+
+        Only Safari is allowed to install Web Apps to the iOS home screen via private APIs that
+        are not available to competing browsers, even if they are set as the user’s default.
+        Should competing engines become available for iOS browsers, it’s essential that
+        expansion of Web App installation also allow those competing engines to “back” the
+        Apps they install so that developers do not experience Web Apps as being held back by
+        Apple’s trailing-edge engine technology.
+
+   3. **Extensions**
+
+        Only Safari can use extensions which are used by many users, including to block ads
+        and improve privacy.
+
+   4. **Apple Pay**
+
+        Apple forces competing browsers to provide only Apple Pay as a payment mechanism
+        for use within the Web Payments API. This is blatantly anti-competitive.
+
+  5. **In-App Browsers**
+
+       Regardless of the user’s default browser setting, iOS developers that invoke the
+       SFSafariViewController tool for creating Remote Tab-based In-App Browsers are always
+       forced to invoke Safari, rather than a user’s default browser (
+       <em>Please see our other submission regarding In-App Browsers and how they negatively affect
+      browser competition</em>).
+
+#### 4.1.2. Android
+
+While Android browsers other than Chrome can install PWAs, Google has [not yet provided
+access to the latest mechanism](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583).
+This can lead to bugs, and far poorer operating system
+integration and user experience. This remedy would compel Google to fix this and we support
+the CMA’s proposal in this regard.
+
+#### 4.1.3. Effectiveness of Remedy
+Consider a fictional scenario where Apple removed the ability to install Web Apps via Safari.
+
+Under the proposed language identifying this remedy, Apple would no longer need to provide
+this functionality to other rival browsers. This is an extreme example as it would immediately
+draw the ire of regulators, but it highlights how Apple can (more subtly) hinder the
+development of all browsers on iOS by removing or not adding certain iOS integrations via
+Safari and then use regulatory conformance as a shield, contra the spirit of the law. Protecting
+App Store profits from Web Apps requires nothing more than keeping the Web at bay. A safe,
+user-respecting platform that mobile Operating System platform vendors cannot collect rents
+from is a transparent threat to their oligopoly interests.
+
+The CMA should prepare for subtle, underhanded behaviour from Apple.
+
+With this in mind, we believe this remedy needs to be strengthened to overcome this sort of
+gaming. One alternative might be to require Gatekeepers provide browser vendors access to
+**all functionality** available to **any** App or function provided by the Gatekeeper or their business
+partners (subject to very narrow, and heavily justified privacy/security concerns with
+consideration given to the level of unmitigatable risk vs the loss of useful functionality for end
+users).
+
+An example of this is iOS Safari does not technically require access to Bluetooth, as they do not
+intend to provide Web Bluetooth (but many other Apps on iOS do). Under the existing remedy
+Apple would not be required to grant rival browsers access to the iOS Bluetooth APIs if Apple
+chose to not provide it to iOS Safari. Thus Apple could limit the functionality of rival browsers
+by not providing access to particular iOS system features to iOS Safari.
+
+Finally there exist Web App specific features that no App currently has on iOS, that would not
+be effectively covered by this remedy. As such we have proposed a 4th remedy to cover these
+narrow cases.
+
+This is a useful remedy and will improve browser competition. That said, we do not believe it is
+sufficient individually to enable effective competition, as without the other remedies such as
+allowing third party engines the same perverse incentives to either underinvest or withhold key
+features from Webkit (the version provided with iOS) persist.
+
+### 4.2. Require Safari/Webkit to support key Web App Features
+
+Web Standards evolve quickly, spurred on by competing browser makers working with
+developers. This involves collaboration in standards bodies to improve compatibility, however if
+each Browser vendor had to wait until there was complete agreement between every vendor
+for each of the various standards (and each standards body operates differently), it would be
+possible for a single vendor (e.g. Apple) to game these processes to halt progress, especially in
+areas where they have an interest in preserving the proprietary nature of their own solutions.
+
+Typically, cutting edge features are deployed by browser makers' own engines first. Real world
+feedback from developers (typically over several years) informs eventual standardisation. No
+feature starts out as a web standard.
+
+> “Web Standards are voluntary. The force that most powerfully compels their adoption is
+> competition, rather than regulation. This is an inherent property of modern browsers.
+> Vendors participate in standards processes not because they need anyone else to tell
+> them what to do, and not because they are somehow subject to the dictates of
+> standards bodies, but rather to learn from developers and find agreement with
+> competitors in a problem space where compatibility returns outsized gains.”
+>
+> &mdash; Alex Russell - Program Manager on Microsoft Edge &ndash; [Why Browser Security UI Isn't Specified](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+No one can predict what web technologies will be important in the future, and disagreements
+between browser makers on the exact path forward are reasonable and expected. It is very
+difficult, if not impossible for regulators to predict which standards will be the most important
+and what their exact definition will end up being. It's a subtle and complex topic.
+
+The [perverse incentives for Apple](http://localhost:8080/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf#h.450o3cyx9zpm)
+are not removed by this remedy and consumers have no
+recourse should Apple choose not to include a feature in Webkit (the version provided with
+iOS). If the case for adding the feature is not overwhelming then the regulator may not feel
+enabled to force them to add it.
+
+The primary issue is competition. When there is a [severe bug](https://bugs.webkit.org/show_bug.cgi?id=198277),
+there are no panicked meetings
+at Apple within the iOS Safari team about how to quickly fix the issue, because Web App
+developers are urging their users to switch to Edge, Firefox and Chrome on iOS. Developers
+know that all browsers on iOS are essentially identical, so the competitive pressure that forces
+Apple to stem users on iOS fleeing to other browsers is removed. There is no real fear of
+losing browser market share because there is almost zero risk of users changing phone brand
+over broken/missing browser features.
+
+The next issue with this measure is that it requires Apple to attempt to comply in good faith.
+Recently, Dutch regulators mandated that Apple must allow dating app providers in the
+Netherlands to [use alternative payment methods](https://www.reuters.com/technology/dutch-watchdog-fines-apple-5-mln-euros-failure-comply-app-store-2022-01-24/).
+
+Apple's response shows [utter contempt](https://world.hey.com/dhh/apple-turns-the-legislative-contempt-up-to-11-7c65eeec)
+for the regulator and at every step appears designed
+to undermine the regulator's ruling with the aim of making it all but impossible (and pointless)
+for developers to use alternative payment methods. Apple's [documentation](https://developer.apple.com/support/storekit-external-entitlement/)
+is really quite
+incredible in the degree and brazen way they seek to avoid complying with the regulator. It is
+clear that regulators must operate under the assumption that Apple will act in bad faith and
+plan their regulatory regimes accordingly.
+
+Mandating Web App features is complex and subtle. Apple will have plenty of ambiguity to hide
+behind in undermining, slow rolling and crippling key Web App features. Additionally, it's very
+hard to regulate that software must be stable and not have bugs. All Browser Engines have
+bugs, it is competition that is the force that compels fixing them.
+
+Thus while there may be significant benefit from compelling Apple to add the clearest and most
+needed Web App features in the short term, **we believe that this remedy will be unworkable in
+the long term** given these adversarial dynamics.
+
+Rather than mandating Gatekeepers support particular standards, a better approach is to
+regulate such that effective competition is possible without direct intervention of regulators
+regarding every single proposed API. Policies that create a space for browser vendors to
+compete and deliver features enhances competition **both between rival browsers** and
+**between Web Apps and Native Apps**. Such a regime is possible – it is the status quo in every
+other popular operating system, including Apple’s macOS – and most effectively harnesses the
+spirit of competition to respond to both user and developer needs.
+
+### 4.3. Require iOS to Allow Third Party Browser Engines
+
+We strongly support the CMA’s findings of fact and proposed remedies in this area. This is the
+most vital proposed remedy to enable unlocking truly competitive browsers.
+
+Apple enjoys iron control over what features make it into Webkit, the specific version of Webkit
+provided by iOS, and the feature set of iOS Safari. Without allowing third party browsers
+engines it is not possible (or excessively difficult) for third parties to provide these features to
+consumers.
+
+Currently if Apple wishes to block a feature from appearing on iOS Safari they do not need to
+fear that their users will switch to another browser, as the other browsers on iOS will also be
+missing this feature (as they are required to use a specific version of Webkit).
+
+If both remedy 1 and 3 were applied, that is browser vendors can supply browsers with their
+own engines on iOS and be provided all the same system APIs that Safari and iOS are provided,
+then competition would be restored.
+
+Were Apple to choose not to add a particular feature to their browser, then other companies
+would have the option of adding that feature (or their version of that feature) to their browser.
+Users could be alerted by websites and Web Apps that a particular required feature was
+missing in iOS Safari and that they could switch to one of the other browsers.
+
+This is important in four ways:
+
+1. Browsers would be free to experiment on what the correct new Web Standard should
+   be
+
+2. Users would have recourse to switch to another browser (if iOS Safari was missing key
+   features)
+
+3. If these features were truly useful/popular, Apple would now have an incentive to
+   implement them on its own browser (even if these features enabled Web Apps to
+   compete more effectively with the App Store) or risk losing browser share on iOS
+
+4. Additionally, Apple would now have a powerful incentive to properly fund their browser
+
+Thus, the perverse incentives highlighted earlier completely evaporate and the regulator is not
+put in the difficult position of having to write and enforce Web Standard Specifications.
+
+### 4.4. Require Broad Web App Support
+
+We are grateful to the CMA’s attention to the state of Web Apps on iOS vs. competing OSes.
+
+We believe gatekeepers must provide sufficient functionality, integration and APIs to enable
+browser vendors (where possible) to provide Web Apps feature parity with Native Apps. For the
+most part the changes required to allow this are not significant relative to the **competitive
+benefits this will unlock (outlined in detail within “[Bringing Competition to Walled Gardens](https://open-web-advocacy.org/walled-gardens-report/)”)**.
+
+We propose this be a **fourth remedy** that the CMA considers in combination with the other
+remedies.
+
+To ensure long-term parity between Apple’s proprietary APIs and competition potentially
+provided by Web Apps and competing browsers, it’s important that controlling regulations
+create an expectation that Web Apps will not be restricted from integrating deeply into OSes,
+even if that means exposing currently private APIs to Browsers.
+
+For example:
+
+- In general, Web Apps should act like Native Apps from the users perspective once installed
+- iOS Permissions for Web Apps should not be harder to manage than those of Native Apps
+- Integration into OS-level management surfaces should be required
+- Web Apps should not face hurdles to accessing sufficient system resources to enable
+important applications (e.g., storage space and durability)
+- Integration with system-provided services (application backup/sync, AI assistant
+ services, etc.) should be possible for both third-party browsers and Web Apps
+
+Additionally we believe that there are significant competitive benefits from compelling Apple to
+allow Web Apps to be directly listed on the iOS App Store.
+
+Currently iOS Apps on the iOS App Store must be written in programming languages specific to
+Apple. This acts as a form of lock-in by requiring that developers write their Apps multiple
+times. Proper Web App support would allow developers to bypass the iOS App Store, but some
+(particularly larger developers) may see value in the listing there.
+
+This will increase competition and benefit users:
+
+- These Apps will be interoperable across operating systems (with a single code base)
+- Developers could advertise to users via the App Store or avoid the App Store entirely,
+gather their own users via the Web or **both** at the same time.
+- Browser environments and its APIs are significantly more locked down and sandboxed
+than Native equivalents. Users could benefit from this improved security.
+
+## 5. Security and Privacy
+
+It’s important to note here that we are not lawyers and anything in this section is merely to
+provide ideas to solve potential technical problems with enforcement.
+
+All of the measures could be balanced by a security and privacy provision, perhaps similar to
+the one found in the proposed [Open App Markets Act](https://www.congress.gov/bill/117th-congress/senate-bill/2710/text):
+
+<ol class="alpha">
+  <li>**In General** &mdash;Subject to section (b), a Covered Company shall not be in violation of a
+subsection of section 3 for an action that is&mdash;
+  <ol>
+    <li>necessary to achieve user privacy, security, or digital safety;</li>
+    <li>taken to prevent spam or fraud; or</li>
+    <li>taken to prevent a violation of, or comply with, Federal or State law.</li>
+    </ol>
+  </li>
+  <li>**Requirements** &mdash;Section (a) shall only apply if the Covered Company establishes by
+clear and convincing evidence that the action described is&mdash;
+  <ol>
+    <li>applied on a demonstrably consistent basis to Apps of the Covered Company or its
+business partners and to other Apps;</li>
+    <li>not used as a pretext to exclude, or impose unnecessary or discriminatory terms
+on, third-party Apps, In-App Payment Systems, or App Stores; and</li>
+    <li>narrowly tailored and could not be achieved through a less discriminatory and
+technically possible means.</li>
+  </ol></li>
+</ol>
+
+One important feature of this is, that it allows gatekeepers to take necessary steps to protect
+the security/privacy of their users while requiring them to **prove with convincing evidence** that
+the measures are consistent, narrow and non-malicious in intent.
+
+It may be useful to add Web Apps to the list in 2 b).
+
+Additionally we believe it is important that the Gatekeeper must prove with clear and
+convincing evidence that the **benefits to users** of any privacy or security measure outweigh
+the costs to users of the measure. This is to preclude **very fringe but non-zero security
+issues** being used to block users from useful functionality.
+
+Finally we would like to see provisions that **ban any secret measures** and allow companies to
+compel the gatekeeper to **provide detailed technical answers** to reasonable questions related
+to these measures.
+
+## 6. International Outreach
+
+The issues that affect competition in the UK within mobile ecosystems are the same issues
+globally. If a UK company wishes to sell their product internationally, which most do, then
+these remedies have to be global remedies.
+
+We believe it is **essential** that the CMA work together with other regulatory and legislative
+bodies so that these remedies become global and not only applied to the UK. As part of the
+market study and the work of the Digital Markets Unit, close collaboration with other regulators
+should be considered a high priority.
+
+That said, there are still some benefits from the UK leading the way in this regulation as it will
+provide data and leverage to regulators in other countries, who can point to the UKs successes
+and use them as a blueprint for their own regulations. Additionally even in the complete
+absence of global support for such regulations UK customers will still benefit significantly.
+
+## 7. Summary
+
+We are heartened by the depth of research and thoughtfulness embodied in the CMA’s interim
+report. We concur with the findings of fact and strongly support many of the proposed
+remedies.
+
+To recap, we believe that the following remedies are necessary:
+
+   1. Gatekeepers must provide browser vendors access to all functionality available to any
+      App or function provided by the Gatekeeper or their business partners.
+   2. iOS must allow third party browser engines
+   3. Mobile OSes must provide broad and deep Web App support
+
+While we feel there may be some significant short term benefit by requiring Webkit and iOS
+Safari support particular Web App features, we believe that in the long term this will be
+unworkable. True, meaningful competition is the only long-term and durable fix.
+
+All of the measures could be balanced by a [security and privacy provision](http://localhost:8080/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf#h.jvpdxnx9j3v2).
+
+The above measures combined will restore competition between browsers on iOS and between
+Web Apps and Native Apps on iOS.
+
+This has a number of benefits to consumers including:
+
+- Cost savings (in the billions annually)
+- Higher quality software
+- More private and secure software
+- Greater control by end users
+- Greater interoperability with devices from other manufacturers
+
+A ban on third-party browsers benefits Apple and harms users, developers and businesses.
+
+**Competition not walled gardens leads to the best outcomes.**
+
+## 8. References
+
+- CMA - [Impact of the Webkit Restriction](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction)
+
+- CMA - [Possible incentives for the Webkit Restriction](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Potential%20strategic%20reasons%20for%20Apple%E2%80%99s%20WebKit%20restriction)
+
+- Forbes - [iOS Google Search deal worth $15 Billion](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/)
+
+- The Register - [Is Safari underfunded?](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug#:~:text=whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition)
+
+- Apple Insider - [$72.3 billion USD in App Store fees in 2020](https://appleinsider.com/articles/21/01/05/app-store-earns-723-billion-in-2020-almost-double-google-play-revenues)
+
+- [iOS App Store is estimated to have an 80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506)
+
+- [5-20% profit margin is normal for successful companies](https://www.brex.com/blog/what-is-a-good-profit-margin)
+
+- CMA - [Potential Remedies to enhance functionality and interoperability of browsers](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Remedies%20designed%20to%20enhance%20functionality%20and%20interoperability%20of%20browsers)
+
+- Dr Michael Grenfell - [On Effective Competition](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+- Matthew Ball - Venture Capitalist, Writer -[On the dominance of iOS](https://www.matthewball.vc/all/applemetaverse)
+
+- [iPhone Users spend more than Android Users](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+
+- Philip Schiller - Apple Upper Management - [On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+- Google - [Missing PWA install functionality for browsers other than Chrome on Android](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583)
+
+- Alex Russell - Program Manager on Microsoft Edge - [On Web Standards](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+- [Apple must allow dating app providers in the Netherlands to use alternative payment methods](https://www.reuters.com/technology/dutch-watchdog-fines-apple-5-mln-euros-failure-comply-app-store-2022-01-24/)
+
+- [Apple's response shows utter contempt for the dutch regulator](https://world.hey.com/dhh/apple-turns-the-legislative-contempt-up-to-11-7c65eeec)
+
+- Apple - [Distributing dating apps in the Netherlands](https://developer.apple.com/support/storekit-external-entitlement/)
+
+
+## 9. Open Web Advocacy
+
+Open Web Advocacy is a loose group of software engineers from all over the world, who work
+for many different companies who have come together to fight for the future of the open web
+by providing regulators, legislators and policy makers the intricate technical details that they
+need to understand the major anti-competitive issues in our industry and potential ways to
+solve them.
+
+It should be noted that all the authors and reviewers of this document are software engineers
+and not economists, lawyers or regulatory experts. The aim is to explain the current situation,
+outline the specific problems, how this affects consumers and suggest potential regulatory
+remedies.
+
+This is a grassroots effort by software engineers as individuals and not on behalf of their
+employers or any of the browser vendors.
+
+We are available to regulators, legislators and policy makers for presentations / Q&A and we
+can provide expert technical analysis on topics in this area.
+
+For those who would like to help or join us in fighting for a free and open future for the web,
+please contact us at:
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/owa-2023-review.md
+++ b/src/es/posts/owa-2023-review.md
@@ -1,0 +1,179 @@
+---
+title: Open Web Advocacy 2023 in Review
+date: '2023-12-31'
+tags:
+  - Policy
+  - Updates
+author:
+  - Alex Moore
+permalink: /es/blog/owa-2023-review/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/owa-2023-review.webp",
+  "Let’s ring in the new year with a review of everything OWA achieved in 2023. The whole team would like to thank our kind volunteers and donors. We couldn’t do it without you! Happy New Year! Open-Web-Advocacy.org"
+%}
+
+We’re living through a moment of real potential for change. For over a decade the Web has been prevented from fairly competing. That’s changing, and we’re working without fear or favor to direct change toward a safe, open future for computing and a better Web for all.
+
+Competition is the engine of progress and OWA is working hard to spread the word on anti-competitive practices holding the Web back, how to fix them and the Web’s incredible potential to improve consumers' lives further.  By meeting with regulators, giving talks, writing countless technical papers and advocating online, we’re going to take the fight for a better Web to every corner of the globe.
+
+We hope you’ll [join us in 2024](/get-involved/) as we continue to convert potential into reality. Speak up and demand a web that works for everyone.
+
+It’s been an incredibly busy year, so here’s just the highlights of 2023 by region:
+
+## European Union
+
+The European Union is a key focus of ours, not only due to its economic size, but also due to its new digital competition regulation the Digital Markets Act.
+
+This act was passed into law on [November 1st 2022](https://www.europarl.europa.eu/RegData/etudes/ATAG/2022/739226/EPRS-AaG-739226-DMA-Application-timeline-FINAL.pdf). To our delight it included explicit wording prohibiting companies such as Apple from banning rival companies porting their real browsers with their own browser engines. 
+
+Specifically the following section:
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users.<br>&mdash; [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+
+
+In addition it contains a host of clauses that will enable the Web and third parties via the Web to compete fairly on all operating systems. Specifically it has clauses that:
+
+* Browsers must be allowed to port their own engines
+* Third parties services such as browsers must be given access to operating system APIs and hardware subject to narrow scope and strictly necessary security requirements
+* Operating system and browser gatekeepers will not be able to self preference their own services in a number of ways
+
+In **March** we had the opportunity to present at the [EU’s Digital Markets Act Workshop ](https://www.youtube.com/watch?v=S6oETjUprlQ) to express our viewpoints on this new act and how it should be implemented. We also had the opportunity to meet the DMA team in person and talk through our concerns. Since then we have extensively engaged with their team seeking to aid them in effectively applying the DMA to fix anti-competitive issues related to browsers and Web Apps.
+
+On **September** 6th 2023 the [European Commission designated six gatekeepers](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) - Alphabet, Amazon, Apple, ByteDance, Meta, Microsoft under the Digital Markets Act (DMA). Under these 6 gatekeepers 22 core platform services provided by gatekeepers were designated. It is these that must comply with the rules of the DMA. These companies have 6 months to be in compliance with the act from this date.
+
+In September, Apple hilariously tried to claim with a straight face to the EU, that it offers not one, but [three distinct web browsers all coincidentally named Safari](https://www.theregister.com/2023/11/02/apple_safari_browser/).
+
+Apple made this attempt despite the Digital Markets Act containing specific clauses to address this exact behavior:
+
+> Article 13(1): An undertaking providing core platform services shall not segment, divide, subdivide, fragment or split those services through contractual, commercial, technical or any other means in order to circumvent the quantitative thresholds laid down in Article 3(2). No such practice of an undertaking shall prevent the Commission from designating it as a gatekeeper pursuant to Article 3(4).
+
+Lucky for us the team at the EC [dismissed this ludicrous gambit](https://ec.europa.eu/competition/digital_markets_act/cases/202344/DMA_100025_228.pdf) and painstakingly ripped Apple's argument to shreds. It is baffling to us why Apple's legal team is willing to sacrifice their credibility on something that has such a low chance of success.
+
+Unfortunately they [had better luck with iPadOS](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) and were able to convince the EU that it was distinct from iOS. However, the EU has determined that iPadOS has sufficient market share and power to [warrant an investigation as to whether iPadOS should be considered a gatekeeper](https://ec.europa.eu/competition/digital_markets_act/cases/202343/DMA_100047_5136.pdf) on a standalone basis. OWA had the opportunity to respond as to why we believe that iPadOS must be designated a Gatekeeper and should not be considered separate from iOS in general.
+
+In our [own submission](https://open-web-advocacy.org/files/OWA%20-%20Response%20to%20EU%20regarding_Apple_iPadOS_-_v1.1.pdf) we argued that iPadOS is a subset of iOS and that even if it were not it, it has sufficient market power to be designated core platform service.   
+
+
+**2024 will be an exciting year in the EU for browser and Web App competition. We are engaging closely with the regulator on a range of topics including:**
+
+* Allowing third party browsers to be ported to iOS
+* Allowing browsers fair and effective access to system and hardware APIs
+* Allowing Web Apps to compete fairly and effectively with their Native App counterparts
+* Stopping companies from overriding users choice of default browser
+* Preventing unfair self-preferencing of gatekeepers browsers
+
+**March 6th 2024 is the key date by which all gatekeepers must be in compliance**, but the changes required by the act are many and there is great technical complexity that various gatekeepers can hide behind. Given that literally billions are at stake, expect fireworks and lawsuits. We will be doing our best to keep the regulator, developers and the general public informed with all the key technical details and outline a path to a future where the Web can compete fairly.
+
+## UK
+
+As readers may remember the CMA conducted a Market Study into Mobile Ecosystems.
+
+The CMA [found in their market investigation](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction) that:
+
+> As a result of the WebKit restriction, there is no competition in browser engines on iOS and Apple effectively dictates the features that browsers on iOS can offer (to the extent that they are governed by the browser engine as opposed to by the UI).
+
+> Importantly, due to the WebKit restriction, Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS. This not only restricts competition (as it materially limits the potential for rival browsers to differentiate themselves from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, depriving iOS users of useful innovations they might otherwise benefit from.
+
+Based on the findings of their Market Study in which OWA heavily consulted, the CMA decided to launch a Market Investigation Reference into Browser and Cloud Gaming.
+
+In their [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) they listed the following potential remedies:
+
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services.
+
+In **April** 2023 Apple [won a judgment against the government](https://theplatformlaw.blog/2022/11/28/the-cmas-investigation-of-competition-restrictions-regarding-browsers/) in the [Competition Appeal Tribunal](https://www.catribunal.org.uk/), halting an [already delayed Market Investigation Reference that included examination of Apple’s iOS browser policies](https://theplatformlaw.blog/2022/11/28/the-cmas-investigation-of-competition-restrictions-regarding-browsers/). 
+
+
+The decision was both unexpected and [disappointing](https://mastodon.social/@owa/110120581945462519). Apple hadn’t argued that its policies were fair, or that the Competition and Markets Authority (CMA) was wrong in its findings. Rather, Apple argued that the CMA hadn’t regulated fast enough after [finding in June 2022](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study) that Apple and Google’s App Store and browser policies harmed UK businesses and consumers.
+
+
+This judgment put progress on real browser choice in the UK on hold for an indeterminate amount of time. The only remaining hope was an appeal through the courts that could take months or years, or that the long-proposed [Digital Markets, Competition and Consumers Bill](https://bills.parliament.uk/bills/3453) (DMCC) might make progress through Parliament without being gutted by lobbyists. 
+
+The DMCC would give the CMA’s successor statutory authority to regulate more quickly. Even if that came to pass, at least a year of delay would have been won by Apple, as the CMA’s Market Investigation was the (slow) “fast path”. Our hopes were not high.
+
+After months of radio silence, *good news arrived from the UK on two fronts*.
+
+First, the [the DMCC Bill](https://theplatformlaw.blog/2023/11/17/digital-markets-competition-and-consumers-bill/) was [passed through the House of Commons](https://bills.parliament.uk/bills/3453/stages) without fatal changes, and now looks set to become law in early 2024.
+
+Then, at the end of the month, we learned that the CMA’s appeal to overturn the April judgment [had succeeded](/blog/apple-loses-on-appeal/), with the caveat that Apple could still appeal the loss to the UK’s Supreme Court. The findings from the Court of Appeal were nothing short of excoriating, with the Court rebuking the Competition Appeal Tribunal for [having lost sight of the law’s goals to protect businesses and consumers.](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445)
+
+
+In **December**, [Apple declined to appeal the November finding by the three week deadline,](/blog/cma-reopens-investigation-into-apple/) ensuring that the CMA’s Market Investigation will restart in January from where it was frozen in April.
+
+**Meanwhile**, the DMCC Bill has [progressed in the House of Lords without incident](https://bills.parliament.uk/bills/3453/stages), setting the stage for a beefed up UK digital regulator in 2024 with expanded powers to intervene in unfair browser competition.
+
+
+## Japan
+
+In **April 2022**, the Headquarters for Digital Market Competition published [a report](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf) where they recommend reversing Apple’s ban on rival browser engines and allowing third party browser vendors to port their real browsers to iOS. OWA heavily consulted with the HDMC on the topic of browser and web app competition, see this report for our [detailed viewpoints](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf).
+
+
+Then in **February 2023**, the Japan Fair Trade Commission (JFTC) published [an exhaustive report examining the mobile app and browser ecosystem.](https://www.jftc.go.jp/en/pressreleases/yearly-2023/February/230209.html) The report summary finds that Apple and Google have an effective duopoly over the mobile market, and that (contra Apple’s claims) there’s little pressure on App Stores from Web Apps, in part, due to suppression of key features via browser engine policy and prevention of discovery of Web Apps within App Stores.
+
+And **just this week** [the Japanese government is preparing to move legislation to give the JFTC powers to directly intervene in mobile OSes](https://asia.nikkei.com/Business/Technology/Japan-to-crack-down-on-Apple-and-Google-app-store-monopolies). The new legislation will have 4 main priorities:
+
+* App Stores and Payments
+* Search
+* Browsers
+* Operating Systems
+
+OWA will continue to engage with the JFTC and the HDMC to ensure that browsers and Web Apps can compete effectively and fairly.
+
+
+## Australia
+
+**Last year** the Competition & Consumer Commission (ACCC) [published a report](https://www.accc.gov.au/inquiries-and-consultations/digital-platform-services-inquiry-2020-25/september-2022-interim-report) outlining competition issues in digital markets. OWA is heavily quoted in the report. The report contains a number of considered remedies including:
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+
+> We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS.
+
+In **September** we [outlined our vision for a web that can truly compete at Web Directions Summit in Sydney](https://webdirections.org/summit/speakers/alex-moore.php).
+
+We also had the opportunity to meet with the ACCC, [and brief them in person](https://mastodon.social/@owa/111304830543180059)
+
+In **December**, [promising legislative action has finally emerged](/blog/new-digital-competition-laws-for-australia/) from the ACCC’s inquiry. The laws will be based on the ACCC recommendations in their 5th report. It specifically calls for meaningful browser choice, including engine competition, which OWA believes to be critical for the health of the web.
+
+## Korea, Brazil, India
+In **July**, the Indian Parliament recommended the introduction of an ex-ante regime through a new ‘[Digital Competition Act](https://www.cnbctv18.com/technology/explained--indias-upcoming-digital-competition-act-and-what-is-the-debate-around-it-all-about-17222501.htm)’ (DCA), to ensure a fair and transparent digital ecosystem in India.
+
+In **September**, Brazil [announced Bill 2768](https://www.ipea.gov.br/cts/en/all-contents/articles/articles/381-regulation-of-markets-mediated-by-digital-platforms-in-brazil-an-open-discussion), a new law related to improving digital competition and interoperability.
+
+In **December**, the Korea Fair Trade Commission (“KFTC”) announced its proposal to enact the “Platform Competition Promotion Act” (“PCPA”) for [ex-ante regulation of platforms](https://www.lexology.com/library/detail.aspx?g=d4a4ff96-2a6a-45d1-980a-a4786e3834a2) by designating “dominant platform operators”. 
+
+
+## 2024: A Big Year for Browser Competition
+
+Even if nothing happens beyond the already locked-in statutory and process deadlines in the EU and the UK, **2024 is shaping up to be the biggest year for digital competition regulation in a generation**.
+
+On **January 22nd**, the UK’s House of Lords is set to bring the amended [Digital Markets, Competition & Consumers Bill](https://bills.parliament.uk/bills/3453/stages) to [Committee stage](https://www.parliament.uk/about/how/laws/passage-bill/lords/lrds-lords-committee-stage/), one of the final steps before the Bill becomes an Act. OWA understands the quick progress of the DMCC in recent months to indicate high potential for a competent regulator on the job with expanded powers and a mandate to act swiftly. While it will take months beyond Bill passage for the proposed Digital Markets Unit (DMU) to be stood up, OWA is excited to see both the expansion of capacity to regulate questions related to browser choice, as well as the strong support in the legislative process for redressing the market distortions of the status quo.
+
+Next, the UK’s CMA will regain its power to continue a Market Investigation into [Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) beginning **January 24th**. This restart of the mothballed investigation will once again begin the clock ticking down to intervention by the CMA using statutory powers it already has, with a possible outcome mandating true browser engine choice on iOS. Such a ruling would be a sea change, stands to bring the UK into alignment with emerging EU regulation, and will let the Web truly compete with native apps. 
+
+On **March 6th, 2024** the 6-month countdown from the [EU’s Digital Markets Act (DMA) designation decisions](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) will conclude, requiring that Apple, Alphabet/Google, Amazon, ByteDance, Meta, and Microsoft to be in compliance of the terms of the DMA.
+
+OWA anticipates that the plain language of the DMA will compel true browser choice and an end to Apple’s ban on competing browsers, along with a pile of other improvements to browser competition across Android and Windows. The penalties for non-compliance are severe, and so we remain hopeful that [rumors of browser ports from Chromium and Gecko](https://www.theregister.com/2023/02/07/mozilla_google_apple_webkit/) will become real products early next year. Where competitors aren’t able to bring their best products to designated OSes, OWA will continue to facilitate information sharing between all parties to ensure that the lines are clear and that compliance is toothsome.
+
+If nothing else were to happen in 2024, OWA’s docket would be full. Each regulator (empowered by new legislation) that opens investigations into browsers, web apps and digital competition involves hundreds of hours of preparation for briefings to highlight issues that impact consumers, competitors and web developers, and as the EU and UK move into implementation, the workload will only increase.
+
+In addition to OWA’s continued direct advocacy toward browser and OS vendors, we have remained in constant contact with regulators around the world, responding to dozens of requests for information and briefing this year alone. This behind-the-scenes work only occasionally becomes public, but it’s the in-the-weeds problem-description and guidance-giving that changes the agenda and has enabled so many regulators to emphasize the importance to consumers of effective browser and Web App competition.
+
+It’s only through the [generous support of donors and volunteers](/donate/) that we’re able to continue this work, and we hope you’ll [get involved](/get-involved/) to help us continue to shape the future of digital competition. **We would like to say a special thank you to particularly generous donations from [startsmall](https://mastodon.social/@owa/111218243374658469) and [store.app](https://store.app/).** 
+
+Together we can fix these anti-competitive issues and allow the Web to fairly compete to its full potential. 
+
+**Happy New Year from everyone at Open Web Advocacy!**
+
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/owa-eu-dma-submission-apple-ipados.md
+++ b/src/es/posts/owa-eu-dma-submission-apple-ipados.md
@@ -1,0 +1,39 @@
+---
+title: OWA submits response to EU DMA investigation into Apple iPadOS
+date: '2023-11-21'
+tags:
+  - Policy
+  - Updates
+  - EU
+author: Frances Berriman
+permalink: /es/blog/owa-eu-dma-submission-apple-ipados/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+As the EU further rolls out the Digital Marketing Act, they have designated a variety of companies and their platforms as “Gatekeepers”. You can see the [complete list of Gatekeepers](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) and some really useful explainers on what being a [Gatekeeper means on the EU’s very informative website](https://commission.europa.eu/strategy-and-policy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en).
+
+Now that Gatekeepers have been designated, the companies that operate those services have had the opportunity to rebut their designations. 
+
+A particularly interesting response was from Apple, who have made the case that iPadOS is an entirely separate operating system from iOS, both of which are currently designated as platforms subject to the DMA, along with the Apple App Store. Their arguments boil down to:
+* iPadOS has some unique features
+* iPadOS has an optional secondary input (the Apple Pencil)
+* The most popular apps on iPad are different from the most popular apps on iPhone
+
+We disagree with this claim. iPadOS is a subset of the iOS ecosystem. Indeed it was called iOS up until 2019 and very little has happened since then to significantly distinguish it. Unfortunately the EU has for now accepted the argument that iPadOS is a separate OS from iOS.
+
+Further, according to statistics supplied by Apple, iPadOS has less than the 45 million users required to be automatically designated a Gatekeeper. The EU has determined that iPadOS has sufficient market share and power to [warrant an investigation as to whether iPadOS should be considered a gatekeeper on a standalone basis](https://ec.europa.eu/competition/digital_markets_act/cases/202343/DMA_100047_5136.pdf). OWA had the opportunity to respond as to why we believe that iPadOS must be designated a Gatekeeper and should not be considered separate from iOS in general.
+
+In broad strokes, OWA argued that:
+
+* Apple’s argument about the size of the EU iPad market is in dispute. [IDC](https://www.idc.com/getdoc.jsp?containerId=IDC_P36344), for example, shows the iPad market in Europe (the UK inclusive) to be about 43 million devices. This suggests the bar for arguing that iPadOS should be declared a gatekeeper by bridging the gap between actual and required quantitative threshold should not be high. Further Apple's calculations as to active users need to be scrutinised.
+
+* The distinction between iOS and iPadOS is minor, the primary difference being a number of features to take advantage of the larger screen. For most of the history of the iPad, iOS was it’s operating system, and the launch schedules and differences in feature sets have not substantially diverged [since the 2019 marketing change](https://en.wikipedia.org/wiki/IPadOS#History). 
+
+* The cross-device impacts of Apple’s wealthier customer base influence technology choices and investments far in excess of the install base. Discounting the network effects of the iOS/iPadOS App Store-based logic of software development and distribution is to focus on the trees, rather than the forest. 
+
+* The DMA contains clauses explictly designed to reject the attempts at artificial subdivision that Apple has put forward here. Further iPadOS is a critical part of the iOS ecosystem and it is essential to recognise the anticompetitive architecture of Apple’s influence over app stores, and the interlocking ways they do so across the Apple ecosystem. Allowing Apple to evade its DMA obligations for so significant segment of its ecosystem, will allow Apple great power to not only increaselock-in, reduce interoperability and hobble competition on iPad but also to curtail the effectiveness of the DMA with regards to Apple’s obligations on iPhone.
+
+Apple gates proprietary API access on iOS in exactly the same ways, and through the same terms and conditions, with the same anti-competitive restraints on browser and applications choice, on iOS as it does on the lately-rebranded iPadOS. This is a sizable entrypoint to wealthy consumers across the EU, which amplifies the effects of the restrictions.
+
+You can read both [Apple’s submission to the EU here](https://ec.europa.eu/competition/digital_markets_act/cases/202344/DMA_100025_228.pdf) (sections 74 - 94), and, of course, you can also read OWA’s [full report](/files/OWA%20-%20Response%20to%20EU%20regarding_Apple_iPadOS_-_v1.1.pdf).

--- a/src/es/posts/owa-review-apple-dma-compliance-for-web.md
+++ b/src/es/posts/owa-review-apple-dma-compliance-for-web.md
@@ -1,0 +1,299 @@
+---
+title: OWA’s Review of Apple’s DMA Compliance Proposal for the Web
+date: '2024-01-29'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /es/blog/owa-review-apple-dma-compliance-for-web/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+## Will Apple ever let browsers and Web Apps compete fairly?
+
+We believe that third party browsers should be allowed to compete fairly on iOS using the same engines they safely deliver to every other platform. Further, that Web Apps enabled by the functionality, stability and security delivered via intense competition between browsers should allow developers to bypass and contest the gatekeepers App Store via the world's only truly interoperable platform, the Web.
+
+With this in mind OWA has been looking over [Apple’s proposals for compliance with the EU’s Digital Markets Act](https://developer.apple.com/support/dma-and-apps-in-the-eu/#browser-alt-eu) to determine whether Apple intends to genuinely comply with its legal obligations regarding browsers and web apps. As OWA has [argued at length](/walled-gardens-report/), true choice in browsers is the most important counterbalance to gatekeeper monopoly power, so the answer to this question matters enormously. 
+
+**Unfortunately so far it appears that the answer is "no".**
+
+Let’s dig into our three bigger point of interests:
+
+1. Will browser vendors be effectively able to bring their own engine to iOS?
+2. Will browser vendors be able to implement proper web app support on iOS?
+3. Will browser vendors be able to compete fairly with Safari?
+
+
+## Will browser vendors be effectively able to bring their own engine to iOS?
+
+As OWA anticipated, Apple is proposing a new [Web Browser Engine Entitlement](https://developer.apple.com/support/alternative-browser-engines/#web-entitlement) that allows browser apps some of the extended privileges any modern, safe browser requires. Apple also proposes requirements browser vendors must meet to be eligible. Some deal with functional aspects of web content rendering, ensuring that browser engines are minimally standards compliant. Others deal with security aspects of web browsing, and yet others impose specific constraints related (in Apple’s view) to privacy. 
+
+The security requirements are the least objectionable, and major browsers are already compliant with the [NIST guidelines for critical software supply chains.](https://www.nist.gov/itl/executive-order-improving-nations-cybersecurity/security-measures-eo-critical-software-use-2) and thus, presumably, with Apple’s looser restatements of those processes. OWA's stance is that it is reasonable (and allowed by the act) for Apple to set a minimum bar on the proviso that the rules are reasonable, proportional, and do not preclude smaller browser vendors that take security seriously from competing on iOS with their own engine.
+
+
+The DMA only grants Apple the right to _“strictly necessary and proportionate, measures to ensure that third-party software applications or software application stores do not endanger the integrity of the hardware or operating system”,_ with the burden of proof as to their necessity and proportionality resting on Apple. We concur with the intent of the act, but believe aspects such as performance and functionality should be left to competition.
+
+Apple requires that browsers secure a _“90% from Web Platform Tests”,_ but this is nonsensical, requiring immediate clarification. The [Web Platform Tests project](https://wpt.fyi/about) is a comprehensive corpus of tests for browser engines, but there is no generally accepted set out of which 90% can be measured, as each engine project enables or disables test groups based on features that are minimally implemented. An engine that implements very few features could easily maintain a 90% pass rate _of the features it provides_, while falling well short of the goal of broad standards conformance. The test corpus also changes between the desktop and mobile versions of browsers. Without clarification about which group of tests the 90% will be calculated from, developers live under a cloud of doubt. It’s also problematic that Apple’s language potentially demands pass-rate statistics that cannot be produced, as no set of WPT tests are run on iOS for any browser, using any engine (although Android browsers are tested) &mdash; including Safari. 
+
+The privacy requirements in Apple's policy give rise to deep concerns. Instead of enabling market competition to improve privacy, Apple is demanding specific technical mechanisms that its own products do not abide (e.g., “boostrap” cookies for Web App installation to the homescreen). It also creates vague, unenforceable terms about “informed user activation” that read like a blank check for Apple’s reviewers to reject browsers based on vibes, rather than analysis. Even with a very brief investigation, we found Apple [does not yet follow these guidelines](https://webkit.org/blog/8311/intelligent-tracking-prevention-2-0/#:~:text=Temporary%20Compatibility%20Fix%3A%20Automatic%20Storage%20Access%20for%20Popups). Apple’s own track record regarding many of the issues it is performatively demanding conformance with is poor, and OWA believes that much of this language needs to be trimmed and made more objective. The primary concern here is that Apple may use this rule as a tool to deny third party browsers the ability to implement important Web App functionality with the aim of keeping that functionality exclusive to Native Apps sold via their App Store.
+
+Requirements demanding alternative browsers implement specific APIs related to input are even more worrying. Apple requires specific iOS APIs to be used for features such as text input, scrolling, dragging, and contextual menus. This may seem appropriate to provide iOS users with a uniform experience, but consistency can be achieved in many ways. Indeed, most browser engines work extremely hard to integrate well into their host OSes and provide the best possible experience. Hard requirements in this area seem hard to justify given macOS Safari’s long history of private API abuse for competitive advantage.
+
+One of the aims of the act is to allow third parties such as browser vendors to provide users with more choice and higher quality software than that of the gatekeeper. Third party browsers already have their own code for performing much of this functionality (such as scrolling) built into their own browsers. Web developers [have](https://open-web-advocacy.org/walled-gardens-report/#:~:text=of%20the%20time-,Safari%20is%20always%20years%20behind%20Edge/Chrome%20and%20has%20many%20many%20many%20bugs%20related%20to%20viewheight/scroll.,-iOS%20Safari%20is) [long](https://open-web-advocacy.org/walled-gardens-report/#:~:text=Safari%20is%20always%20years%20behind%20Edge/Chrome%20and%20has%20many%20many%20many%20bugs%20related%20to%20viewheight/scroll.%20iOS%20Safari%20is%20the%20biggest%20limiting%20factor%20in%20all%20web%20development.) complained that iOS [Safari is riddled with scrolling bugs](https://github.com/web-platform-tests/interop/issues/84) for all but the simplest of use cases. Mandating that third party browsers must replace this code with Apple’s libraries when they have their own, arguably superior, libraries blunts competition and may impose significant additional work with no legal justification or user benefit.
+
+Mandating that browser vendors adopt these APIs may, perversely, hurt quality and delay release of competing browsers for months without materially improving consistency. This is particularly egregious in light of the [last-minute](https://www.europarl.europa.eu/RegData/etudes/ATAG/2022/739226/EPRS-AaG-739226-DMA-Application-timeline-FINAL.pdf)(pdf) announcement of these APIs, Apple’s attempt at limiting their use to the EU, and Cupertino’s years-long campaign of delay. The wrongs the DMA seeks to right are multiplied by time, and terms that prevent competitors from entering the market in a timely way run counter to the spirit of the law.
+
+Indeed, some of these APIs have deep implications for competing engine codebases. It is therefore likely to increase the complexity of competing engines and make further development and its maintenance harder for browser teams. When Apple [shipped Safari on non-Apple platforms](https://www.apple.com/newsroom/2007/06/11Apple-Introduces-Safari-for-Windows/), it was not subject to similar restrictions and would be highly unlikely to accept them for iOS Safari itself. Adoption of such APIs should be optional, leaving vendors free to incorporate them as they see fit, and at their own pace.
+
+## Will browser vendors be able to implement proper web app support on iOS?
+
+While some APIs have been made available (and mandatory) for browser engines to implement specific features, others are notable by their absence. 
+
+Since the first iPhone in 2007, Safari has had access to private APIs for installing and managing Web Apps, and yet this core, long-standing API is missing from Apple’s compliance proposal. Just like Safari, alternate browsers must be able to add Web Apps to the home screen, to the app library, and have them appear in the system settings so users can see and modify each individual Web App settings. They must also be able to run in the same engine as the browser that installs them &mdash; just as Safari-installed Web Apps have for 15 years. Our reading of the documentation made available thus far suggests alternate browsers will not have access to such capabilities.
+
+
+The DMA explicitly mentions browser competition (including the ability to use your own engine) as being important to prevent gatekeepers from determining the functionality available to Web Apps.
+
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. **When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality** and standards that will apply not only to their own web browsers, but also **to competing web browsers and, in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+(emphasis added)</cite>
+
+
+The UK Competition and Markets Authority noted that Apple had incentive to prevent Web Apps from fairly competing:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)
+(emphasis added)</cite>
+
+Finally, Apple states in the opening paragraph of their App Store Guidelines that the Web (i.e Web Apps) is the alternative to their App Store.
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+
+With all of these in mind, combined with [Apple’s refusal to implement key features in iOS Safari such as install prompts](https://open-web-advocacy.org/walled-gardens-report/#ios-web-app-installation---a-well-hidden-safari-exclusive) (keeping Web Apps hidden from the public), [other missing features](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features), and [significant and crippling bugs](https://open-web-advocacy.org/walled-gardens-report/#safari-has-been-buggy-for-a-long-time), the question of whether third party browsers could offer Web Apps something better becomes critical. As it stands there is nothing in Apple’s proposal to suggest that they ever intend to let third party browsers install Web Apps powered by their own engine.
+
+Alternate browsers should also be able to handle Push Notifications for Web Apps, as well as badging when they are installed. There is no mention of APIs allowing the implementation of such features in Apple’s documentation.
+
+Web Apps should also be allowed to open when the user taps a link to a URL related to it anywhere on the OS. This is a pattern that Apple calls “universal links”, and according to the documentation, browsers cannot implement an equivalent for Web Apps: _[“Apps that have the com.apple.developer.web-browser managed entitlement may not claim to respond to Universal Links for specific domains.”](https://developer.apple.com/documentation/xcode/preparing-your-app-to-be-the-default-browser#Adhere-to-browser-restrictions)_ [Specifications for enabling this](https://wicg.github.io/web-app-launch/) for Web Apps [have been implemented by other browsers,](https://chromestatus.com/feature/5722383233056768) and Apple’s prohibition on the capability represents an undue restraint on competitors and will undermine the ability of Web Apps to compete on a level playing field.
+
+The DMA states that gatekeepers cannot prevent third-parties from accessing OS or device features, and if these issues are simply oversights, we hope the Commission and Apple will resolve them rapidly. Time is of the essence.
+
+## Will browser vendors be able to compete fairly with Safari?
+
+### Apple’s proposed browser choice screen
+
+As mandated by the DMA, Apple plans to introduce a choice screen for default browsers the first time a user opens Safari. We have little information about the design of the choice screen at this point, [except that it will present the 12 most popular browsers in the user’s EU country in random order](https://9to5mac.com/2024/01/26/apple-shares-more-details-about-the-new-default-web-browser-prompt-in-ios-17-4/). There are a number of ways Apple can manipulate that choice screen to make it ineffective, so we will watch carefully how it ends up being implemented. 
+
+
+The extent of Apple’s anti-competitive behavior towards third party browsers is hard to overstate. For **a dozen years**, it _wasn’t even possible_ to set a different browser as default. This thumb on the scales has spotted Safari an extensive market lead. The impact of choice screens against this sort of aggressive, persistent, long-standing self-preferencing is debatable, but OWA welcomes the attempt and urges the commission to scrupulously oversee the process. It should also not rule out re-running a choice ballot for users who have already been subject to one if the previous version is ruled out of compliance.
+
+### Apple system provided In-App Browser ignores the users choice of default browser
+
+Apple also self-preferences towards Safari through the [OS-provided “in-app browser” mechanism](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller). OWA expected to see mention of APIs for default competing browsers to handle navigation from apps through this facility, but it is missing. The cumulative effect of Apple’s ongoing self-preferencing in this regard is to make the web forgetful. Even when users make a competitor their default, that browser is not used to handle a sizable portion of browsing. This is a competitive restraint and is incompatible with the spirit of the DMA, and Apple’s proposal ignores the users choice of default browser.
+
+
+### Apple will restrict these changes to the EU
+
+Apple proposes only to allow competitors to ship their own engines inside the EU. This is an attempt to add poison pills, driving up costs for competitors to maintain multiple iOS browsers (one for Europe, another for the rest of the world), and to impose costs that Apple does not bear and would never stand for if imposed by a competitor. OWA expected some amount of awful-but-lawful malicious compliance, but continued restrictions on engine choice outside the EU are egregious.
+
+
+This additional burden can be unbearable for small browsers and will handicap all of them compared to Safari, adding to the harm done by 15 years of anti-competitive behavior that OWA has repeatedly described in reports and regulatory filings. [Mozilla is already on record citing these terms as _“creating barriers to prevent true browser competition on iOS”,](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox)_ and OWA agrees.
+
+Another implication of Apple’s gating of this change to the EU is the difficulty for web developers to test their Web Apps and websites across that boundary. EU web developers won’t be able to test their work with the WebKit-based versions of alternate browsers. These iOS browsers are already hard to test “frankenbrowsers” owing to Apple’s WebKit restrictions, and this adds further cost and complication.
+
+Users outside of the EU will be using different versions of “Firefox”, “Chrome”, “Opera”, and given the difficulty in bringing modern experiences up to par on Apple’s browsers, adding to this work increases the pain for businesses attempting to build competitive web experiences in lieu of native apps.
+
+Likewise, developers outside of the EU won’t be able to test their sites on browsers only available in the EU. This will result in major issues and bugs both for EU users and users of EU Web Apps and websites outside of it, further harming EU businesses and users. These issues, however, will only affect users of alternate browsers. Safari will have a significant advantage, its engine being the same everywhere in the world.
+
+
+Obviously, the Commission does not have jurisdiction outside the EU and cannot mandate that its terms adhere worldwide, but Apple’s proposal to limit true browser choice to the EU shows that far from being embarrassed at having effectively banned third party browsers from iOS for over a decade, Apple will persist in this behavior till legally compelled not to in each and every major jurisdiction on the planet.. 
+
+### Apple will preclude third party browsers from competing on iPad
+
+Apple has chosen to restrict these browser changes to iPhone, and not to share them with iPad for users. This is currently allowed due to an [ongoing dispute with the EU as to whether or not iPadOS is covered by the DMA](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/). In our submission, we argued that iPadOS is a subset of iOS with minor changes and that even were it not it is of sufficient market size and power in the EU to be a designated core platform service in its own right.
+
+There is no legitimate reason as to why browsers should be allowed to compete on iPhone but not iPad. This is simply a case of Apple trying to do the bare minimum possible which comes with the added bonus of scuttling browser or web app competition on iPad.
+
+
+### Will browser vendors be able to update their existing browsers?
+
+> Be a separate binary from any app that uses the system-provided web browser engine
+><cite>[Apple Documentation](https://developer.apple.com/support/alternative-browser-engines/)</cite>
+
+Apple is disconcertingly vague on how updating existing browser apps to now use their own engine will work and it is not clear whether:
+
+* Browser vendors must ship a separate app using their own browser engine.
+* Browser vendors can seamlessly swap over their existing users to the updated browser now using its own browser engine.
+
+
+If it is the first, that is deeply problematic as it essentially resets every third party browser that wants to use its own engine back to zero users. Given that the choice screen will take place prior to browser vendors having the opportunity to ship their real browsers, it is critical that this is not the case.
+
+Browser vendors need to be able to roll out their engines in a stable, predictable manner.  This means complete control over swapping webkit with their own engine including the ability to do browser engine phased releases and to be able to rollback.
+
+
+### Apple’s new contract for browsers that wish to use their own engine
+
+No one on our team is a lawyer, but to our un-lawyerly eyes a number of clauses in Apple’s contract seem not only unfair, but also in direct violation of the DMA. 
+
+To our knowledge a specific contract to be “allowed” to use bring a browser engine is unique to Apple in the history of successful consumer operating systems.
+
+> While in no way limiting Apple’s other rights under this Addendum or the Developer Agreement, or any other remedies at law or equity, if Apple has reason to believe You or Your Alternative Web Browser Engine App (EU) have failed to comply with the requirements of this Addendum or the Developer Agreement, Apple reserves the right to revoke to Your access to any or all of the Alternative Web Browser Engine APIs immediately upon notice to You; require You to remove Your Entitlement Profile from Your Alternative Web Browser Engine Application (EU); terminate this Addendum; block updates of, hide, or remove Your Alternative Web Browser Engine App (EU) and/or other Applications from the App Store; block Your Applications from distribution on Apple platforms; and/or to suspend or remove You from the Apple Developer Program.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+
+This clause basically says that if you fail to abide by all of Apple’s terms (some of which are pretty vague and possibly in contravention of the DMA), that they can not only reject that update, block your app until it is fixed, ban your app but that they can actually permanently remove and ban every single app your company has from distributions on all Apple platforms (presumably including macOS).
+
+
+Another clause states that browsers must also abide by the Apple App Store Guidelines ("guidelines" being a delightfully Orwellian phrase  for ironclad rules). Apple does not have the best reputation as to being a fair judge of what counts as a violation of its app store rules.
+
+> It should not surprise you to know that Apple’s interpretation of its text often seems capricious at best and at worst seems like it’s motivated by self-dealing.
+><cite>[Dieter Bohn - The Verge](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)</cite>
+
+> Nothing herein shall imply that Apple will accept Your Alternative Web Browser Engine App (EU) for distribution on the App Store, and You acknowledge and agree that Apple may, in its sole discretion, reject, or cease distributing Your Alternative Web Browser Engine App (EU) for any reason. For clarity, once Your Alternative Web Browser Engine App (EU) has been selected for distribution via the App Store it will be considered a “Licensed Application” under the Developer Agreement.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+This clause basically says they can reject your browser for any reason. 
+
+Luckily the DMA does not allow this. The rules need to be fair, reasonable, and non-discriminatory. Further browser vendors will be able to appeal app store rulings to an alternative dispute settlement mechanism.
+
+> The gatekeeper shall apply fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).
+> For that purpose, the gatekeeper shall publish general conditions of access, including an alternative dispute settlement mechanism.
+> The Commission shall assess whether the published general conditions of access comply with this paragraph.
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Any%20practice%20that%20would%20in%20any%20way%20inhibit%20or%20hinder%20those%20users%20in%20raising%20their%20concerns%20or%20in%20seeking%20available%20redress%2C%20for%20instance%20by%20means%20of%20confidentiality%20clauses%20in%20agreements%20or%20other%20written%20terms%2C%20should%20therefore%20be%20prohibited.)</cite>
+
+
+> Apple may at any time, and from time to time, with or without prior notice to You, modify, remove, or reissue the Apple Materials or the Alternative Web Browser Engine APIs, or any part thereof. You understand that any such modifications may require You to change or update Your Alternative Web Browser Engine App (EU) at Your own cost and that features and functionality of such App may cease to function. Except as required by applicable law, Apple has no express or implied obligation to provide, or continue to provide, the Apple Materials or Alternative Web Browser Engine APIs, and may suspend or discontinue all or any portion of Your access to them at any time.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+This clause says that Apple can break, remove or change any API without any notice. This hardly seems fair or reasonable.
+
+> Confidentiality
+> You agree that any non-public information regarding the Alternative Web Browser Engine APIs or Alternative Web Browser Engine (EU) Entitlement Profile shall be considered and treated as “Apple Confidential Information” in accordance with the terms of Section 9 (Confidentiality) of the Developer Agreement. You agree to use such Apple Confidential Information solely for the purpose of exercising Your rights and performing Your obligations under this Addendum and agree not to use such Apple Confidential Information for any other purpose, for Your own or any third party’s benefit, without Apple's prior written consent. You further agree not to disclose or disseminate Apple Confidential Information to anyone other than those of Your employees or contractors who have a need to know and who are bound by a written agreement that prohibited unauthorized use or disclose of the Apple Confidential Information.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)
+
+This bans discussing Apple’s APIs publically or sharing information about them with any party except for employees or contractors who are bound by a similar agreement. Aside from the obvious attempt to stifle public discussion of shortcomings or anti-competitive behavior in Apple’s APIs this also appears to run afoul of the DMA. Given that the code bases of all the major browser engines are open source (including Safari’s) there does not appear to be any legitimate need for such a confidentiality clause.
+
+> Any practice that would in any way inhibit or hinder those users in raising their concerns or in seeking available redress, for instance by means of confidentiality clauses in agreements or other written terms, should therefore be prohibited.
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Any%20practice%20that%20would%20in%20any%20way%20inhibit%20or%20hinder%20those%20users%20in%20raising%20their%20concerns%20or%20in%20seeking%20available%20redress%2C%20for%20instance%20by%20means%20of%20confidentiality%20clauses%20in%20agreements%20or%20other%20written%20terms%2C%20should%20therefore%20be%20prohibited)</cite>
+
+### Third-party browsers will be effectively precluded from shipping their browsers on third party app stores on iOS
+
+Apple's proposal includes plans for allowing third-party native app stores to compete with their own on iOS. This is directly compelled by the act.
+
+While allowing third party native app stores is not part of the fight of our organization, it is relevant in so far as browsers, being free products, would like to list on every major app store available on iOS. Apple's proposal seems designed to prevent any free app from ever even considering listing on a third party native app store on iOS.
+
+In order to list their app on a third party app store, the app developer must sign an alternative contract allowing them the rights granted under the DMA but which comes with significantly different pricing. To our non-lawyer minds, having an optional alternate contract that semi-abides by the law and a standard contract which does not is baffling.
+
+The pricing difference between the contracts is worth scrutiny, particularly for free apps like browsers. If vendors choose the second contract, Apple will waive some app store fees but add a new  "Core Technology Fee" which boils down to a 50c charge per user, per year.
+
+
+In Apple's own words the fee is: 
+
+> The Core Technology Fee (CTF) is an element of the new business terms in the European Union (EU) that reflects the value Apple provides developers through ongoing investments in the tools, technologies, and services that enable them to build and share innovative apps with users around the world. Developers can choose to remain on the App Store’s current business terms or adopt the new business terms for iOS apps in the EU.
+><cite>[Apple Documentation](https://developer.apple.com/support/core-technology-fee/)</cite>
+
+This sounds awfully like a fee for access to hardware and software APIs. But the DMA specifically precludes such a fee:
+
+> Article 6(7) The gatekeeper shall allow providers of services and providers of hardware, **free of charge, effective interoperability with, and access for the purposes of interoperability to, the same hardware and software features accessed or controlled via the operating system** or virtual assistant listed in the designation decision pursuant to Article 3(9) as are available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business users and alternative providers of services provided together with, or in support of, core platform services, **free of charge, effective interoperability with, and access for the purposes of interoperability to, the same operating system, hardware or software features, regardless of whether those features are part of the operating system, as are available to, or used by, that gatekeeper when providing such services.**
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+(emphasis added)</cite>
+
+“Free of charge” being the key phrase.
+
+Astonishingly, Apple has added wording that prevents developers from switching back to the standard contract, while granting themselves the right to change either contract at any time:
+
+> Developers who adopt the new business terms at any time will not be able to switch back to Apple’s existing business terms for their EU apps. Apple will continue to give developers advance notice of changes to our terms, so they can make informed choices about their businesses moving forward.
+><cite>[Apple Documentation](https://developer.apple.com/support/dma-and-apps-in-the-eu/#dev-qa:~:text=Developers%20who%20adopt%20the%20new%20business%20terms%20at%20any%20time%20will%20not%20be%20able%20to%20switch%20back%20to%20Apple%E2%80%99s%20existing%20business%20terms%20for%20their%20EU%20apps.%20Apple%20will%20continue%20to%20give%20developers%20advance%20notice%20of%20changes%20to%20our%20terms%2C%20so%20they%20can%20make%20informed%20choices%20about%20their%20businesses%20moving%20forward.)</cite>
+
+
+How much it would cost for a browser to list on one of these third party app stores? iOS has 1.65 billion users. 1% browser market share represents 16.5 million users. If a browser vendor dares to list their app on a third party store, even once, and even if no one downloads it from that third party store, Apple will bill them $8.25 million per a year per 1% share every year with no recourse to change back to the previous contract.
+
+In our view (and the view of many others) is that this is designed to make it as difficult as possible for free apps to list on third party app stores as possible, depriving these app stores of these apps, and sapping their ability to get off the ground.
+
+The DMA also contains additional provisions that likely prohibit this behavior:
+
+> Article 6(12) The gatekeeper shall apply **fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores**, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).
+
+Apple’s policy is unfair, unreasonable, and discriminatory &mdash; both to free apps such as browsers, and to third party app stores.
+
+If Apple's proposal sounds ludicrous to you, you are not alone. We are confused as to how Apple's lawyers thought this would possibly be compliant with the DMA, and the degree to which this would alienate native app developers. Their willingness to pursue these proposals, despite presumably being aware how unpopular they would be, is itself a striking example of market power.
+
+We hope that the EU rejects this proposal and forces Apple to come up with a single non-alternative contract for all Native App developers who choose to distribute via Apple's App Store in the EU with fair, reasonable and non-discriminatory terms.
+
+### What Apple should have done and why they will ultimately lose
+
+Apple could have behaved differently here. They could have announced global rules allowing browser competition on iOS. These rules could include a minimum bar for security. They could have been working with the teams of each of the major browser vendors for months on what APIs they need and how to share them effectively. They could have upgraded their in-app browser (SFSafariViewController) and their Web App installation functionality to support the users choice of browser and to allow these third party browsers and Web Apps to compete fairly. They could significantly increase Safari's budget and fought to convince consumers of their vision for the Web in anticipation of intense mobile browser competition.
+
+Apple has done none of this. Even a generous observer would conclude their proposal seems designed to circumvent the intent and letter of the digital markets act. Their announcement is dripping with disdain for the EU regulators.
+
+> These proposals seem less about complying with the DMA and more about maintaining Apple’s walled garden,
+
+> The limited scope of change does little to address the genuine power imbalances within the app ecosystem.
+><cite>[Dr. Maria Rodriguez, Competition Law Expert at the University of Amsterdam](https://pc-tablet.com/clash-of-titans-apples-dma-compliance-proposals-raise-concerns-about-choice-and-competition/)</cite>
+
+This is a mistake, for all Apple's talk of protecting consumers, the focus on revenue and containing the new competition allowed, shows their hand. The public are not fools and they are not fooled.
+
+Even in traditionally pro-Apple forums the response to [Apple's browser competition proposal](https://www.macrumors.com/2024/01/26/mozilla-on-apple-eu-browser-engine-change/) has been extremely negative. Apple is losing whatever reputation for fair play it may have enjoyed. With each market investigation or act passed, this behavior is forced into the open.
+
+## What’s Next
+
+Apple’s compliance proposal is only that: a proposal that the EC can accept or reject, in whole or in part. Apple’s submissions will be reviewed by the EU and are subject to change. The voice of web developers matters now more than ever, as OWA is in contact with regulators and can amplify the concerns of folks working to build competitive experiences on the only open, interoperable, tax-free platform. 
+
+The EU thus far has had only this to say:
+
+> The DMA will open the gates of the internet to competition so that digital markets are fair and open. Change is already happening. As from March 7 we will assess companies' proposals, with the feedback of third parties. If the proposed solutions are not good enough, we will not hesitate to take strong action.
+><cite>[EU Industry Chief Thierry Breton](https://www.reuters.com/technology/apple-faces-strong-action-if-app-store-changes-fall-short-eus-breton-says-2024-01-26/)</cite>
+
+
+Our early reading of Apple’s proposal suggests that its plan does not align with either the letter or spirit of the DMA. We will be providing more updates as we parse the text. Although we have reasons to rejoice because alternate browser engines will now be able to ship to iOS, we remain concerned that this sort of gamesmanship by gatekeepers undermines the intent of the DMA. Fair competition for web browsers and proper support for Web Apps on iOS is not too much to ask. Indeed, we believe it’s now the legal right of EU citizens.
+
+
+> While legal experts expect the EU to challenge Apple's insincere compliance with the DMA, developers should take this opportunity to rethink their native app serfdom. They should push web apps to their limits and then demand further platform improvement.
+> The web doesn't require commission payments, technology fees based on usage, or permission from platform rentseekers. The web can set the iPhone free, even if Apple won't.
+><cite>[Thomas Claburn - The Register](https://www.theregister.com/2024/01/27/apple_europe_ios_analysis/)</cite>
+
+We will keep on fighting and will alert the EU to shortcomings and risks posed by each of the gatekeeper’s compliance plans.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)
+
+
+## Links 
+We believe it's important that readers be able to make up their own minds.
+
+[This is the full text](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) of the DMA. Of most interest is [Article 5](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=on%2Dgoing%20basis.-,CHAPTER%20III,PRACTICES%20OF%20GATEKEEPERS%20THAT%20LIMIT%20CONTESTABILITY%20OR%20ARE%20UNFAIR,-Article%C2%A05) and [Article 6](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Obligations%20for%20gatekeepers%20susceptible%20of%20being%20further%20specified%20under%20Article%C2%A08) which are only a few pages, however the recitals which start on the first page provide context for these articles, such as the reference to [web apps](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=web%20software%20applications).
+
+
+The following is a list of links to Apple’s documentation on their new browser engine rules and APIs.
+
+* [Apple announces changes to iOS, Safari and the App Store in the European Union](https://www.apple.com/au/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/)
+* [Update on apps distributed in the European Union](https://developer.apple.com/support/dma-and-apps-in-the-eu/)
+* [Embedded Browser Engine](https://developer.apple.com/contact/request/download/embedded_browser_engine.pdf)
+* [Web Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)
+* [Using alternative browser engines in the European Union](https://developer.apple.com/support/alternative-browser-engines/)
+* [BrowserEngineKit Documentation](https://developer.apple.com/documentation/browserenginekit)
+* [Scroll UI Container Documentation](https://developer.apple.com/documentation/browserenginekit/bescrollview)
+* [Drag UI Documentation](https://developer.apple.com/documentation/browserenginekit/bedraginteraction)
+* [Browser Engine Core Documentation](https://developer.apple.com/documentation/browserenginecore)
+* [Preparing your app to be the default web browser](https://developer.apple.com/documentation/xcode/preparing-your-app-to-be-the-default-browser)
+* [No mention of default settings for browsers](https://developer.apple.com/support/dma-and-apps-in-the-eu/#app-controls:~:text=Expanded%20default%20app%20controls%20for%20users%20in%20the%C2%A0EU)
+* [Requesting interoperability with iOS in the European Union](https://developer.apple.com/support/ios-interoperability/)
+* [Alternative distribution on iOS in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu/#ios-app-eu)
+* [Terms for alternative distribution and payments in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu/#distribution-eu)
+* [Fee Calculator for Apps in the EU](https://developer.apple.com/support/fee-calculator-for-apps-in-the-eu/)
+* [Core Technology Fee](https://developer.apple.com/support/core-technology-fee/)
+* [Alternate EU Terms Contract](https://developer.apple.com/contact/request/download/alternate_eu_terms_addendum.pdf)
+* [Apple AppStore Guidelines](https://developer.apple.com/app-store/review/guidelines/) Note: Ones with the “key” symbol apply to third party apps delivered outside of Apple’s AppStore.
+* [AppStore Guidelines  2.5.6](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20JavaScript.%20You%20may%20apply%20for%20an%20entitlement%20to%20use%20an%20alternative%20web%20browser%20engine%20in%20your%20app.%20Learn%20more%20about%20these%20entitlements.)
+* [AppStore Guideline Changes](https://developer.apple.com/news/?id=7j1f99yf)

--- a/src/es/posts/security-updates-browser-choice.md
+++ b/src/es/posts/security-updates-browser-choice.md
@@ -1,0 +1,33 @@
+---
+title: iOS Safari zero-day security bugs and how browser choice affects user safety
+date: '2023-12-05'
+tags:
+  - Security
+  - Browsers
+author: Frances Berriman
+permalink: /es/blog/security-updates-browser-choice/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+In the last couple of weeks we've seen a few browser security bugs pop up, giving us the opportunity to talk about how a competitive landscape for web browsers is vital to protecting users online.
+
+## Nasty Bugs All Around
+
+Firstly, we saw a [set of zero-day bugs identified in Webkit](https://www.infosecurity-magazine.com/news/apple-patches-actively-exploited/). Apple landed a fix for those in a [subsequent iOS update](https://support.apple.com/en-us/HT214031).
+
+Secondly, a [nasty security bug in Google Chrome](https://nvd.nist.gov/vuln/detail/CVE-2023-6345), also subsequently [patched.](https://www.malwarebytes.com/blog/news/2023/11/update-now-chrome-fixes-actively-exploited-zero-day-vulnerability)
+
+Both bugs were “high” severity, meaning attackers could compromise devices using malicious web pages. This is your friendly reminder to make sure your devices are up to date!
+
+## Compare and Contrast
+
+What's different about these two situations? 
+
+If a security bug shows up on a browser on Android, MacOS, Windows or most other OSs, users can opt to pick a different browser for a time until a patch has landed and their browsing experience is safe again. If their browser has a bad security track record, they can also switch to a better built one. Additionally, Chrome or any other browser on Android etc., can be patched without OS updates. Users don't have to wait for a new version of Android, wait for huge downloads, or reboot their devices.
+
+Users on iOS are less fortunate. Having [no other browsers to choose from](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers), they must hope that the security update doesn't catch them out in some way as they wait for an iOS update, as Safari isn't able to independently ship changes. With no choice, they have no option to wait it out on safer shores.
+
+This choice of software architecture - coupling a browser to an OS, or not - has been played out before. It wasn't long ago that Windows users had to wait for OS updates to receive patches for IE [because it was so tightly tied to OS components.](https://learn.microsoft.com/en-us/troubleshoot/developer/browsers/installation/prerequisite-updates-for-ie-11) Microsoft’s strategy handicapped their ability to keep browsers current. Eventually, they changed the design with Chromium-based Edge because decoupled updates are safer. Even without that design change, Windows users still had choices available to them in times of need. 
+
+All users deserve to have that choice.

--- a/src/es/posts/stuart-langridge-the-mazy-web.md
+++ b/src/es/posts/stuart-langridge-the-mazy-web.md
@@ -1,0 +1,20 @@
+---
+title: 'Stuart Langridge: The Mazy Web'
+date: '2024-10-08'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /es/blog/stuart-langridge-the-mazy-web/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+If you have a spare half hour, we highly recommend listening to Stuart Langridge's insightful and eloquent talk about why the open web is special. Stuart shares his passion for the internet and its incredible potential. In his talk, he delves into the unique qualities that make the web such a powerful tool and why it's crucial for us all to advocate for and explain its significance.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/Mn2YFU_UkEI?si=aTV2iXhIsEvfQzAP' frameborder='0' allowfullscreen title="Stuart Langridge - The mazy web she whirls:starting Open Web Advocacy"></iframe></div>
+
+If you understand why the open web unlocks doors and what makes it is special, please advocate on its behalf and help spead that message.
+
+

--- a/src/es/posts/the-digital-markets-act-is-in-force-what-happens-now.md
+++ b/src/es/posts/the-digital-markets-act-is-in-force-what-happens-now.md
@@ -1,0 +1,275 @@
+---
+title: The Digital Markets Act is in force! What happens now?
+date: '2024-03-07'
+tags:
+  - Policy
+  - Apple
+  - Google
+  - Microsoft
+  - Meta
+  - Bytedance
+  - EU
+author: OWA
+permalink: /es/blog/the-digital-markets-act-is-in-force-what-happens-now/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The Digital Markets Act (DMA) grace period for gatekeepers to comply has now ended.
+
+[The DMA is EU legislation](https://en.wikipedia.org/wiki/Digital_Markets_Act) that came into law on the 1st of November 2022 that aims to improve fairness, contestability and interoperability in very large platforms that operate in the EU that have significant and durable market power. In order to not impose expensive compliance obligations on small and medium businesses, the act only applies to truly massive companies with significant revenue that operate platforms used by tens of millions of EU consumers.
+
+The DMA comes with serious teeth, they have the power to fine gatekeepers up to 10% of global revenue repeatedly until they comply with the act. For reference Apple had a global revenue of $383 billion USD in 2023 and their net profit was $100 billion USD, meaning that the maximum cost of a single fine under the DMA is $38.3 billion USD, a sum any gatekeeper would surely blink at. In the case of repeated non-compliance they can fine up-to 20% of global revenue in a single fine. 
+
+Currently there are six gatekeepers who have been designated: Amazon, Apple, Bytedance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
+
+These gatekeepers have a number of “core platform services” that have been formally designated under the DMA. To be automatically designated the service must have at least  45 million users in the EU and at least ten thousand business users. Further they need to be of a type of platform covered by the act. Currently the types listed in the act are:
+* online intermediation services
+* online search engines
+* online social networking services
+* video-sharing platform services
+* number-independent interpersonal communications services
+* virtual assistants
+* cloud computing services
+* online advertising services
+* operating systems
+* web browsers
+
+Being designated means that the gatekeeper must make sure the designated core platform service is **fully compliant with the DMA before the end of the 6 month grace period**. That grace period ended today. The DMA is ex-ante which means it is the gatekeepers responsibility to make sure and show that they are in compliance.
+
+The core platform services that have been designated, split by type are:
+
+**Intermediation**
+* Amazon Marketplace
+* Apple App Store
+* Google Maps
+* Google Play
+* Google Shopping
+* Meta Marketplace
+
+**Social Networks**
+* Facebook
+* Instagram
+* LinkedIn
+* TikTok
+
+**Number-independent Interpersonal Communications Services**
+* Messenger
+* Whatsapp
+
+**Online Advertising Services**
+* Amazon
+* Google
+* Meta
+
+**Search**
+* Google
+
+**Video Sharing**
+* Youtube
+
+**Operating Systems**
+* iOS
+* Android
+* Windows
+
+**Browsers**
+* Chrome
+* Safari
+
+That grace period has now officially ended, so what happens now?  First each of the gatekeepers is required to have submitted a compliance report to the Commission as well as a public summary. Then, likely for the first few weeks nothing. The EU Commission is an evidence based organisation and will need time to assess how well each of the gatekeepers are complying with the DMA and select the highest priority targets to start proceedings against first.
+
+[Many observers](https://theplatformlaw.blog/2024/01/26/when-apple-takes-the-european-commission-for-fools-an-initial-overview-of-apples-new-terms-and-conditions-for-ios-app-distribution-in-the-eu/), including us, believe that Apple due to its combative and belligerent approach will be the first to be hit, likely with multiple proceedings. Indeed fireworks came early with [Apple’s attempt to sabotage Web Apps in the EU](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/) prior to the DMA coming into force.
+
+Luckily for the web, Apple’s plan faced massive backlash. [Our open letter to Tim Cook](https://letter.open-web-advocacy.org/) on the subject had 4640 individuals and 483 organisations sign. Signatures included two European MEPs (Karen Melchior & Patrick Breyer); a number of significant EU companies such as social media platform Mastodon; and individuals (advocating in their personal capacity) who work for SwissLife, Tchibo, W3C, Mozilla, Google, Microsoft, Vivaldi, BBC, Financial Times, ​​Red Hat, Oracle, Amazon, Wikimedia, Vercel, Netlify, Shopify, Spotify, AirBNB, Berlin University of the Arts, Open State Foundation - Netherlands, Cloudflare, Meta, Chase, Squarespace, Reddit, Atlassian, Maersk, Paypal, Salesforce, block, Adobe, ebay, Zynga, booking.com and thoughtworks; and many other developers and organisations from over 100 countries.
+
+The EU Commission [promptly opened an investigation](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) into the matter.
+
+**Three days later Apple caved and reversed their decision to break all Web Apps in the EU for millions of consumers.**
+
+The EU Commission said [in a statement](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) that:
+“Contrary to Apple’s public representation, the removal of Home Screen Web Apps on iOS in the EU was neither required, nor justified, under the Digital Markets Act,”
+
+Three European parliament MEPs — Karen Melchior, Tiemo Wölken, and Patrick Breyer — said [in a statement to the Financial Times](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) that it would be “in flagrant violation of the spirit, and likely the word of the DMA”, and reminded the company of the EU’s power to enforce fines of up to 10 percent of a company’s annual turnover under the new rules.
+
+Given Apple is not a company that backs down easily or quickly, the only plausible explanation is that Apple’s lawyers decided that the plan to sabotage Web Apps in the EU (and in effect globally) would subject Apple to immediate and serious legal risk, and recommended reversing course. This is important as it shows that public outreach combined with regulatory intervention can curb the worst of Apple’s anti-competitive behaviour and not even their billion dollar a year legal budget is sufficient to maintain it. The combination of strong laws and advocacy can protect the open web.
+
+Our non-profit organisation has two aims:
+* Fair and effective browser competition on all general purpose operating systems
+* Fair and effective Web App competition on all general purpose operating systems, in particular we are aiming for feature parity between Web Apps and Native Apps.
+
+For readers who are unaware, [Apple has effectively banned third party browsers on iOS](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) for the last 15 years by preventing them from using their own browser engine. Instead third party browsers vendors were forced to build a thin user interface shell around the WebKit WkWebView shipped with iOS, making them reskinned versions of Safari.
+
+This means there is **no browser competition on iOS** and that Apple can unilaterally set a ceiling on the feature set of Web Apps. Despite Apple [repeatedly](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) [claiming that](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple/) [Web Apps are the alternative to their App Store](https://developer.apple.com/app-store/review/guidelines/#:~:text=For%20everything%20else%20there%20is%20always%20the%20open%20Internet.%20If%20the%20App%C2%A0Store%20model%20and%20guidelines%20or%20alternative%20app%20marketplaces%20and%20Notarization%20for%20iOS%20apps%20are%20not%20best%20for%20your%20app%20or%20business%20idea%20that%E2%80%99s%20okay%2C%20we%20provide%20Safari%20for%20a%20great%20web%20experience%20too.), Web Apps are currently not able to effectively contest it due to [missing features](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features) and [bugs in Safari](https://open-web-advocacy.org/walled-gardens-report/#ios-safari-is-buggy). No third party browser can improve the situation due to Apple’s browser engine ban.
+
+With that context and these aims in mind, it's worth exploring the DMA and what changes it brings to the EU in relation to browsers, Web Apps and Web and what exactly the gatekeepers are obligated to do.
+
+## Key Passages
+
+### Recital 43
+
+> When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications.
+> </br><cite>[Digital Markets Act - Recital 43](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)</cite>
+
+This section is particularly important as it outlines what the DMA’s purpose is in prohibiting banning browser engines. Specifically it is to prevent gatekeepers from blocking competitors from providing functionality to competing browsers and to “web software applications”.
+
+This was likely, at least in part, based on the conclusions of the UK regulator who stated:
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+### Article 5(7)
+
+> Articles 5(7) **The gatekeeper shall not require end users to use, or business users to use, to offer, or to interoperate with**, an identification service, **a web browser engine** or a payment service, or technical services that support the provision of payment services, such as payment systems for in-app purchases, of that gatekeeper in the context of services provided by the business users using that gatekeeper’s core platform services.
+> </br><cite>[Digital Markets Act - Article 5(7)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)<br>
+(emphasis added)</cite>
+
+This is the specific part of the act that actually prohibits gatekeepers from imposing browser engines. It does not allow the gatekeeper any leeway to prevent this.
+
+### Article 6(7)
+
+> Article 6(7) The gatekeeper shall allow providers of services and providers of hardware, free of charge, effective interoperability with, and access for the purposes of interoperability to, the same hardware and software features accessed or controlled via the operating system or virtual assistant listed in the designation decision pursuant to Article 3(9) as are available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business users and alternative providers of services provided together with, or in support of, core platform services, free of charge, effective interoperability with, and access for the purposes of interoperability to, the same operating system, hardware or software features, regardless of whether those features are part of the operating system, as are available to, or used by, that gatekeeper when providing such services.</br></br>
+> The gatekeeper shall not be prevented from taking strictly necessary and proportionate measures to ensure that interoperability does not compromise the integrity of the operating system, virtual assistant, hardware or software features provided by the gatekeeper, provided that such measures are duly justified by the gatekeeper.
+> </br><cite>[Digital Markets Act - Article 6(7)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that designated operating systems must provide API access to third parties for the purpose of interoperability (i.e. making their software/hardware work on or with the device). Importantly it states that this must be provided “free of charge”.
+
+The “free of charge” appears to throw a spanner in the works of Apple’s Core Technology Fee which is a 50c per user per year fee for API access that Apple will charge for all app downloads (including app downloads from Apple’s App Store) of any developers that dares to list their app on a different app store on iOS. It’s hard to see how Apple’s lawyers possibly thought this would be compliant but does give some insight as to the level of hubris and belligerence that Apple is operating at here.
+
+Gatekeepers are only allowed strictly necessary, proportional and justified security measures to prevent compromising “the integrity of the operating system”. Justified here means that the burden of proof is on the gatekeeper to show that the measure is strictly necessary and proportional.
+
+### Recital 49, Recital 52 and Article 6(5)
+
+> A gatekeeper can use different means to favour its own or third-party services or products on its operating system, virtual assistant or web browser, to the detriment of the same or similar services that end users could obtain through other third parties.
+> </br><cite>[Digital Markets Act - Recital 49](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+> In such situations, the gatekeeper should not engage in any form of differentiated or preferential treatment in ranking on the core platform service, and related indexing and crawling, whether through legal, commercial or technical means, in favour of products or services it offers itself or through a business user which it controls. To ensure that this obligation is effective, the conditions that apply to such ranking should also be generally fair and transparent. Ranking should in this context cover all forms of relative prominence, including display, rating, linking or voice results and **should also include instances where a core platform service presents or communicates only one result to the end user**.
+> </br><cite>[Digital Markets Act - Recital 52](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)<br>
+(emphasis added)</cite>
+
+> Article 6(5) The gatekeeper shall not treat more favourably, in ranking and related indexing and crawling, services and products offered by the gatekeeper itself than similar services or products of a third party. The gatekeeper shall apply transparent, fair and non-discriminatory conditions to such ranking.
+> </br><cite>[Digital Markets Act - Article 6(5)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+These recitals and articles state that the gatekeeper can not self-preference themselves in various forms of ranking. This could apply to the user interface design of iOS where in the settings Apple’s apps get special locations, [various undermining of browser choice by Microsoft on Windows](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf) or Google prompting users to download Chrome on google.com or youtube.com in locations that competitors can not. All of these behaviours are now prohibited in the EU.
+
+### Article 6(3)
+
+> Article 6(3) The gatekeeper shall allow and technically enable end users to easily un-install any software applications on the operating system of the gatekeeper, without prejudice to the possibility for that gatekeeper to restrict such un-installation in relation to software applications that are essential for the functioning of the operating system or of the device and which cannot technically be offered on a standalone basis by third parties.</br></br>
+> The gatekeeper shall allow and technically enable end users to easily change default settings on the operating system, virtual assistant and web browser of the gatekeeper that direct or steer end users to products or services provided by the gatekeeper. That includes prompting end users, at the moment of the end users’ first use of an online search engine, virtual assistant or web browser of the gatekeeper listed in the designation decision pursuant to Article 3(9), to choose, from a list of the main available service providers, the online search engine, virtual assistant or web browser to which the operating system of the gatekeeper directs or steers users by default, and the online search engine to which the virtual assistant and the web browser of the gatekeeper directs or steers users by default.
+> </br><cite>[Digital Markets Act - Article 6(3)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article mandates browser and search engine choice screens in the EU. Mozilla [recently did a study](https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf) that showed a well designed choice screen could cause significant changes in market share, specifically Firefox could increase its market share to 20%. 
+
+### Article 6(4)
+
+> Article 6(4) The gatekeeper shall allow and technically enable the installation and effective use of third-party software applications or software application stores using, or interoperating with, its operating system and allow those software applications or software application stores to be accessed by means other than the relevant core platform services of that gatekeeper. The gatekeeper shall, where applicable, not prevent the downloaded third-party software applications or software application stores from prompting end users to decide whether they want to set that downloaded software application or software application store as their default. The gatekeeper shall technically enable end users who decide to set that downloaded software application or software application store as their default to carry out that change easily.</br></br>
+> The gatekeeper shall not be prevented from taking, to the extent that they are strictly necessary and proportionate, measures to ensure that third-party software applications or software application stores do not endanger the integrity of the hardware or operating system provided by the gatekeeper, provided that such measures are duly justified by the gatekeeper.</br></br>
+> Furthermore, the gatekeeper shall not be prevented from applying, to the extent that they are strictly necessary and proportionate, measures and settings other than default settings, enabling end users to effectively protect security in relation to third-party software applications or software application stores, provided that such measures and settings other than default settings are duly justified by the gatekeeper.
+> </br><cite>[Digital Markets Act - Article 6(4)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that operating system gatekeepers need to allow third parties to be able to install their apps both by other app stores and directly (i.e. via a link over the internet).
+
+The gatekeeper is allowed to take strictly necessary, proportional and justified security measures to protect the integrity of the hardware or operating system.
+
+### Article 6(12)
+
+> Article 6(12) The gatekeeper shall apply fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).</br></br>
+> For that purpose, the gatekeeper shall publish general conditions of access, including an alternative dispute settlement mechanism.</br></br>
+> The Commission shall assess whether the published general conditions of access comply with this paragraph.
+> </br><cite>[Digital Markets Act - Article 6(12)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This states that the terms of the app stores shall be fair, reasonable and non-discriminatory. It seems likely the exact meaning of “fair” will be extensively litigated in the EU. The act contains this paragraph to explain what “fair” means in more detail: 
+
+> Pricing or other general access conditions should be considered unfair if they lead to an imbalance of rights and obligations imposed on business users or confer an advantage on the gatekeeper which is disproportionate to the service provided by the gatekeeper to business users or lead to a disadvantage for business users in providing the same or similar services as the gatekeeper. The following benchmarks can serve as a yardstick to determine the fairness of general access conditions: prices charged or conditions imposed for the same or similar services by other providers of software application stores; prices charged or conditions imposed by the provider of the software application store for different related or similar services or to different types of end users; prices charged or conditions imposed by the provider of the software application store for the same service in different geographic regions; prices charged or conditions imposed by the provider of the software application store for the same service the gatekeeper provides to itself
+
+Crucially the terms the gatekeeper is allowed to set is for being on the app store, not being on the operating system. Gatekeepers have no ability under the act to set terms for being on the operating system beyond strictly necessary, proportional and heavily justified security measures.
+
+### Article 13(4)
+
+> Article 13(4) The gatekeeper shall not engage in any behaviour that undermines effective compliance with the obligations of Articles 5, 6 and 7 regardless of whether that behaviour is of a contractual, commercial or technical nature, or of any other nature, or consists in the use of behavioural techniques or interface design.
+> </br><cite>[Digital Markets Act - Article 13(4)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article grants the commission extremely broad powers to prevent gatekeepers seeking to avoid their obligations via “malicious compliance”. Clearly it was anticipated that at least a few of the gatekeepers would seek to undermine and circumvent the act.
+
+### Article 13(6)
+
+> Article 13(6) The gatekeeper shall not degrade the conditions or quality of any of the core platform services provided to business users or end users who avail themselves of the rights or choices laid down in Articles 5, 6 and 7, or make the exercise of those rights or choices unduly difficult, including by offering choices to the end-user in a non-neutral manner, or by subverting end users’ or business users' autonomy, decision-making, or free choice via the structure, design, function or manner of operation of a user interface or a part thereof.
+> </br><cite>[Digital Markets Act - Article 13(6)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article is to prevent gatekeepers from circumventing obligations by degrading the core platform service. It seems likely that this applied to Apple’s attempt to remove Web App installation in the EU as a method to avoid sharing it with third party browsers using their own engines, thus circumventing their obligations under Article 5(7). Apple essentially admitted this was the purpose of removing the functionality in their initial statement where [they stated](https://developer.apple.com/support/dma-and-apps-in-the-eu#8:~:text=Addressing%20the%20complex,in%20the%20EU.): 
+
+> Addressing the complex security and privacy concerns associated with **web apps using alternative browser engines would require building an entirely new integration architecture** that does not currently exist in iOS and was not practical to undertake given the other demands of the DMA and the very low user adoption of Home Screen web apps. **And so, to comply with the DMA’s requirements, we had to remove the Home Screen web apps feature in the EU**.
+> </br><cite>[Apple's statement on breaking Web Apps in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu#8:~:text=Addressing%20the%20complex,in%20the%20EU.)<br>
+(emphasis added)</cite>
+
+### Article 30(1)
+
+> Article 30(1) In the non-compliance decision, the Commission may impose on a gatekeeper fines not exceeding 10 % of its total worldwide turnover in the preceding financial year where it finds that the gatekeeper, intentionally or negligently, fails to comply with:<br>
+> (a) any of the obligations laid down in Articles 5, 6 and 7;<br>
+> (b) measures specified by the Commission in a decision adopted pursuant to Article 8(2);<br>
+> (c) remedies imposed pursuant to Article 18(1);<br>
+> (d) interim measures ordered pursuant to Article 24; or<br>
+> (e) commitments made legally binding pursuant to Article 25.
+> </br><cite>[Digital Markets Act - Article 30(1)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article outlines the fines the commission can impose on gatekeepers that violate any part of Article 5, 6 or 7. In this case the maximum individual fine is 10% of global revenue.
+
+### Article 30(2)
+
+> Article 30(2).   Notwithstanding paragraph 1 of this Article, in the non-compliance decision the Commission may impose on a gatekeeper fines up to 20 % of its total worldwide turnover in the preceding financial year where it finds that a gatekeeper has committed the same or a similar infringement of an obligation laid down in Article 5, 6 or 7 in relation to the same core platform service as it was found to have committed in a non-compliance decision adopted in the 8 preceding years.
+> </br><cite>[Digital Markets Act - Article 30(2)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that if the gatekeeper commits the same violation twice the commission can fine them up to 20% of global revenue in a single fine.
+
+## What changes is OWA pushing for?
+
+OWA is a global organisation and in order for both browser and web app competition to be both fair and effective these changes need to happen in as many jurisdictions as possible, and push for global uniformity. 
+
+That said, securing these changes in the EU will be a massive win for two reasons. First EU consumers and businesses can experience the benefits of increased competition and interoperability. Second, every major regulator on the planet is looking carefully at the DMA and planning their own regimes. Any success in the EU will provide these regulators with a mountain of evidence and a blueprint to force these gatekeepers to behave.
+
+Some important aims that could be achieved under the DMA are:
+1. **Allow other browsers to compete fairly and effectively on iOS with their own engine**<br>
+	Currently [Apple’s browser engine entitlement contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf) (a contract specifically for allowing API access) [is riddled with outrageously unfair terms](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#apple%E2%80%99s-new-contract-for-browsers-that-wish-to-use-their-own-engine) and given that Apple is only allowed to have strictly necessary, proportional and heavily justified security clauses in the contract it will need to be rewritten in order to be compliant with the DMA.
+
+2. **Force both Apple and Google to let other browsers install web apps powered by their own engine**<br>
+	Currently Apple does not let browsers install web apps on iOS powered by the browsers own engine at all.  Google does not let other browsers install web apps properly to achieve full system integration via WebAPK minting which is locked to Chrome. Both companies must open this up to third party browsers to be compliant with the DMA.
+
+3. **Ensure users choice of  default browser is respected**<br>
+In many cases on both iOS and Android the user’s choice of default browser is completely ignored. The default browser should be opened or invoked when the user clicks on a link in a non-browser app. Instead in many cases it is silently hijacked and replaced by a completely different in-app browser. Neither the operating system or the non-browser apps on it should engage in browser-jacking.
+
+4. **Stop Apple from preventing browsers being listed on third party app stores on iOS**<br>
+As discussed earlier, Apple’s Core Technology Fee for API access is clearly designed to prevent developers from listing their apps on third party apps stores on iOS. Given that API access is mandated to be “free of charge” under the act, Apple will need to update this in order to be in compliance with the DMA.<br><br>
+Further having a separate alternative contract with which developers can opt into their rights under the DMA at different fee structures is both bizarre and ridiculous.
+
+5. **Stop companies self preferencing their own browser by their core platform services**<br>
+Apple, Google and Microsoft have all engaged in behaviours and dark patterns to self preference their browsers by their various designated core platform services. These behaviours are now prohibited in the EU by the DMA.
+
+6. **Safari needs to allow fair competition of competing payment providers**<br>
+Currently Safari only supports Apple Pay, as a core platform service Apple is obligated to update it so that the user can choose alternative payment providers.
+
+7. **Reduce the power of default browser with a choice screen**<br>
+Ensure that both Apple and Google implement effective designs for their browser choice screens. Specifically the choice screen should not self preference their own browsers, should grant the chosen browser the “hotseat” and should appear on all existing devices once and all new devices (including after backup and restore).
+
+8. **Ensure that backups and restore works for Web Apps**<br>
+Currently on both iOS and Android Web Apps are not included in device backups. This puts Web Apps at a disadvantage to Native Apps and needs to be fixed by both Apple and Google.
+
+To be clear these obligations needed to have been already met by today, the fact they aren't means that they are already in breach of the DMA.  From OWA’s perspective we will lodge complaints about gatekeepers who have not met their obligations unless they are making timely good faith efforts to push as quickly as possible towards compliance.
+
+## Why is this important?
+
+If fair and effective competition for both browsers and Web Apps was allowed, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often better than native apps.  Native Apps will still have a lead in cutting edge graphics and gaming technology but here’s the thing, if companies see the Web platform as viable, they’ll invest in it and this gap will get narrower and narrower.
+
+Over the next ten years the Web will provide more and more for consumers. Simply put, what the Web “can't do” is shrinking while its advantages are only increasing.
+
+But for certain clear anti-competitive behaviour, mobile Web Apps would already be viable and thriving. Absent laws to prevent them from doing so, large gatekeepers are incentivized to block products they can’t excessively tax OR that compete with their own products.
+
+The Web can do so much more on mobile, we just have to let it.
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+* [Donate to help with our running costs](https://open-web-advocacy.org/donate/)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* We need help with advocacy, engineering, documentation, outreach and help in each jurisdiction/country.
+* Comment on articles in the media
+* Keep sharing the message and our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/) and the [OWA blog](https://open-web-advocacy.org/blog/).

--- a/src/es/posts/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition.md
+++ b/src/es/posts/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition.md
@@ -1,0 +1,192 @@
+---
+title: UK’s Browser and Cloud Investigation may fail to allow Web App competition
+date: '2024-08-20'
+tags:
+  - Policy
+  - CMA
+  - UK
+author:
+  - OWA
+permalink: >-
+  /es/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TL;DR:** We believe the UK Market Investigation Reference is missing [critical remedies](/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/#remedies). Most importantly *"Apple shall allow third-party browsers to install and manage Web Apps using their own browser engine."*. [**We need YOU to write to the CMA**](/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/#we-need-your-help!-act-today!) (before August 29th) and provide feedback on why allowing browsers to compete in providing Web App functionality is important.
+
+## What’s happening?
+
+As readers may recall, the UK Competition and Markets Authority launched a Market Investigation Reference (MIR) into [mobile browsers and cloud gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) on June 10th 2022. Apple was briefly able to halt this via legal technicalities but thankfully the [CMA won in the high court late last year restarting the investigation](https://open-web-advocacy.org/blog/cma-reopens-investigation-into-apple/).  
+
+From our extensive work in supporting the [Mobile Ecosystems Study](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study), we know the key reason the [Market Investigation Reference into Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) was launched was to enable the free, open and interoperable ecosystem of the web to contest Apple’s and Google’s app stores, reducing costs for UK’s consumers and businesses. While regulators across the world were focused on app stores, the UK was the only regulator that was looking towards the web and web apps to solve these issues on mobile ecosystems. This aim was made clear by the [opening statements of the Browsers and Cloud MIR](https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming):
+
+
+> We all rely on browsers to use the internet on our phones, and **the engines that make them work have a huge bearing on what we can see and do**. Right now, **choice in this space is severely limited** and that has real impacts – **preventing innovation and reducing competition from web apps**. We need to give innovative tech firms, many of which are ambitious start-ups, a fair chance to compete.
+> </br><cite>[Andrea Coscelli - Chief Executive of the UK's Competition and Markets Authority](https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming)</br>(emphasis added)
+</cite>
+
+Last week the browsers and cloud MIR released their [remedies paper](https://assets.publishing.service.gov.uk/media/66b484020808eaf43b50dea8/Working_paper_7_Potential_Remedies_8.8.24.pdf) outlining their initial thoughts on remedies and asking for feedback. While the paper contains a number of excellent remedies, not least of which is prohibiting Apple from banning browser engines from iOS, we are deeply concerned that the MIR will fail in its goal of allowing third party browsers to enable effective competition from Web Apps.
+
+<details>
+<summary>Full List of Remedies</summary>
+<br></br>
+
+This list is on page 21 of the [Browsers and Cloud Remedies Paper](https://assets.publishing.service.gov.uk/media/66b484020808eaf43b50dea8/Working_paper_7_Potential_Remedies_8.8.24.pdf).
+<br></br>
+**Issue 1 – Apple’s WebKit restriction**
+
+* A1 - Requirement for Apple to grant access to alternative browser engines to iOS.
+
+* A2 - Requirement for Apple to grant equivalent access to iOS to browsers using alternative browser engines. 
+
+* A3 - Requirement for Apple to grant equivalent access to APIs used by WebKit and Safari to browsers using alternative browser engines.
+
+**Issue 2 – Apple’s and Google’s control over supply of browser engines to restrict access to functionalities**
+
+* A4 - Requirement for Google to grant equivalent access to APIs used by Chrome.
+
+**Issue 3 – Apple preventing all rival browser vendors from offering remote tab IABs on iOS**
+
+* B1 - A requirement for Apple to enable remote tab IABs for WebKit-based browsers.
+
+* B2 - A requirement for Apple to enable remote tab IABs for browsers wishing to use alternative browser engines.
+
+**Issue 4 – Apple preventing rival browser engines from offering nonWebKit based webview IABs, including bundled engine IABs to app developers on iOS**
+
+* B3 - A requirement for Apple to allow alternative webviews to Apple’s iOS WKWebView.
+
+**Issue 5 – on Android, default settings and preinstallation of Android WebView make it difficult for app developers to use IABs based on alternative webviews**
+
+* No remedies proposed.
+
+**Issue 6 – Apple’s and Google’s IAB policies offer users limited choice and control in relation to which browser is used for IAB implementation in native apps**
+
+* B4 - A requirement for Apple and Google to implement remote tab IABs using the default browser.
+
+* B5 - A requirement for Apple and Google to make users aware of being in an IAB by implementing changes to the interface or implement disclosures.
+
+* B6 - A requirement for Apple and Google to implement opt-out settings for in-app browsing.
+
+**Issue 7 - Apple’s and Google’s control of choice architecture in factory settings**
+
+* C1 - A requirement for Apple and Google to ensure that multiple browsers are pre-installed, using defined criteria.
+
+* C2 - A requirement for Apple and Google to ensure the use of browser choice screens at device set-up.
+
+* C3 - A requirement for Apple and Google to ensure the placement of a default browser selected by the user in the ‘dock’ / ‘hot seat’ or on the default home screen at device set-up.
+
+* C4 - A requirement for Apple and Google to ensure that a user’s choice of default browser is always followed across all browser access points.
+
+**Issue 8 - Apple’s and Google’s use of certain choice architecture practices after device set-up**
+
+* C5 - A requirement for Apple and Google to ensure the use of browser choice screen(s) after device set-up.
+
+* C6 - A requirement for Apple and Google to make adaptations to the user journey for changing their default browser.
+
+* C7 - A requirement for Apple and Google to share user data on default browsers settings with browser vendors.
+
+* C8 - A requirement for Apple and Google to ensure that the frequency of default browser prompts and notifications is limited.
+
+* C9 - A requirement for Apple and Google to allow users to uninstall Safari browser app on iOS and Chrome on Android devices.
+
+**Issue 9 – Apple’s App Store policies in relation to cloud gaming services**
+
+* D1 - A requirement for Apple to review and amend its Guidelines to remove the specific restriction identified as restrictive and a prohibition on Apple introducing new restrictions with equivalent effect.
+
+* D2 - A requirement for Apple to enable cloud gaming native apps to operate on a ‘read-only’ basis (i.e. with no ingame purchases or subscriptions) so that games do not need to be re-coded and no commission would therefore be payable to Apple).
+
+**Issue 10 – app store rules in relation to in-app payment systems for in-game transactions**
+
+* D3 - A requirement for Apple and Google to allow CGSPs to incorporate their own or third party in-app payment systems for in-game transactions.
+
+</details>
+
+## Why might the MIR fail?
+
+In the remedies the MIR team is proposing both removing Apple’s rule banning browsers from using their own browser engines and obligating Apple to provide equivalent iOS API access to third party browser vendors that Safari and WebKit have.
+
+### 1. Browsers can’t Install Web Apps using their own Engine
+
+The problem is that these do not fix the core issue, namely, can browsers compete in the provision of Web App functionality using their own browser engine. Apple could plausibly argue that allowing browsers to use their own engine and providing them access to the share menu to install Apple’s WebKit implementation of Web Apps satisfies both requirements.
+
+This could lead to a situation where while browser engines such as Blink (Chrome, Edge, Opera, Vivaldi, DuckDuckGo, Brave) and Gecko (Firefox) could be ported to iOS, browser vendors would be unable to compete to improve the stability, functionality, security or privacy of Web Apps. This would still be under Apple’s sole control.
+
+As noted in the CMA’s mobile ecosystems study, Apple is heavily incentivized not to support Web Apps to their full potential. Certain features such as install prompts that would allow Web Apps to compete more fairly with Apple’s own apps and app store, will almost certainly never be implemented by Apple.
+
+> By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> </br><cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)</br>(emphasis added)
+</cite>
+
+Worse when faced with the genuine possibility of third-party browsers effectively powering Web Apps due to the EU’s Digital Markets Act, Apple's first instinct was to [remove Web Apps support in the EU entirely with no notice to either businesses or consumers](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/). Luckily, [under significant pressure, Apple backed down](https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/) from this particular stunt at the last moment. 
+
+### 2. Browser Access to Software/Hardware APIs is Insufficient
+
+Next, the wording on remedy A3 ("Requirement for Apple to grant equivalent access to APIs used by WebKit and Safari to browsers using alternative browser engines.") is scoped to only what Safari and WebKit have access to, which is a problem as that could allow Apple to set a ceiling by blocking Safari from having access to stuff Apple does not intend to implement for the Web, i.e. Bluetooth, USB etc. If Apple is not under any legal obligation to share needed Software/Hardware APIs required to support browser or Web App features that Safari does not support, they will not provide access to those APIs.
+
+It is critical that Apple can not reserve functionality for its own apps, system services and apps delivered by its app store by blocking browser vendors access to the required hardware and software APIs. Where feasible browser vendors should have the right to provide feature parity to Web Apps.
+
+### 3. Web Apps can’t succeed without Install Prompts
+
+In order for Web Apps to have a significant opportunity to truly compete on iOS, Safari needs to implement [install prompts](https://web.dev/learn/pwa/installation-prompt/) (the ability for websites to prompt, or provide a button to install them as a Web App). Apple, understanding the importance of reducing friction, has implemented a large variety of ways to install apps from Apple’s app store via Safari including [smart banners](https://open-web-advocacy.org/walled-gardens-report/#smart-app-banners) and [app clips](https://open-web-advocacy.org/walled-gardens-report/#app-clips) while keeping the method of installing Web Apps [hidden away in the share menu](https://open-web-advocacy.org/walled-gardens-report/#ios-safari).
+
+<figure>
+    {% image
+        "/images/blog/InstallPrompts1.png",
+        "Example of Install Prompt in Chrome on Android",
+        null, null,
+        [150, 200, 300],
+        "150px"
+    %}
+    {% image
+        "/images/blog/InstallPrompts2.png",
+        "Example of Expanded Install Prompt in Chrome on Android",
+        null, null,
+        [150, 200, 300],
+        "150px"
+    %}
+    <figcaption>Example of Install Prompt in Chrome on Android</figcaption>
+</figure>
+
+## Remedies
+
+We believe four additional remedies needed in order to allow the Web to compete fairly on iOS:
+
+1. *"Apple shall allow third-party browsers to install and manage Web Apps using their own browser engine."*
+
+
+2. *"A requirement for Apple to implement Install Prompts for iOS Safari."*
+
+
+3. *"A requirement for Apple to grant all software and hardware access to APIs to browsers using alternative browser engines that they require to port their engines and implement stability, functionality, security and privacy. Restrictions on this can be subject to only strictly necessary, proportionate and justified security grounds."*
+
+
+4. *"Where feature parity between Web Apps and Native Apps is possible, Apple must technically enable it and it should not be artificially prevented either by OS rules or OS design. Apple must not self-preference their own Apps, Apps sold via their App Store or their own Services over Web Apps."*
+
+These remedies are required because Apple's actions not only hurt the Web ecosystem, third-party businesses (be they browser vendors or software developers), but also make their devices worse for their own consumers. By depriving their consumers of the choice and competition that fair and effective browser and Web App competition would bring, they are worsening the functionality, interoperability, stability, security, privacy, and price of services on their devices. This MIR has the power to fix this for the UK, which will be a significant step towards fixing the problem globally.
+
+After 3 years of work from the CMA, it would be incredibly disappointing to get to the end of the investigation without resolving the anti-competitive behaviour that is preventing web apps from succeeding and unlocking innovation.
+
+## We need your help! Act today!
+
+The CMA is asking for feedback by the end of **Thursday August 29th 2024** from interested parties, developers and businesses. This is your opportunity to provide feedback to the MIR team.
+
+**We need YOU to write to the CMA**, share your thoughts on the proposed remedies and any remedies you think may be missing. 
+
+If you share our concern that competition issues related to Web Apps will not be resolved by the remedies proposed, please state so in your letter and outline why this is important to you, your business and to the future of tech in the UK.
+
+If possible, explain the harm that has been caused by browsers not being able to compete in the provision of Web App functionality on iOS. 
+
+While we encourage readers to write longer submissions, short but clear emails that explain the key points are still immensely helpful.
+
+Please let the CMA know if your name, business or submission is confidential.
+
+**Please consider spending 15 minutes writing to the regulator. After years of campaigning, this is a critical moment to ensure the Web is able to thrive, and we will not be successful without your support!**
+
+**You should send your letter to the MIR team at [browsersandcloud@cma.gov.uk](mailto:browsersandcloud@cma.gov.uk).**
+
+If you have further questions or concerns about this topic, or your letter writing, please join us in Discord or drop us an email:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+
+*Note: All mentions of iOS above including quotes from the MIR mean both iOS and iPadOS.*

--- a/src/es/posts/uk-cma-browser-cloud-gaming-progress-report.md
+++ b/src/es/posts/uk-cma-browser-cloud-gaming-progress-report.md
@@ -1,0 +1,62 @@
+---
+title: Browser and Cloud Gaming Market Investigation Update
+date: '2024-06-27'
+tags:
+  - Policy
+  - CMA
+  - UK
+author: OWA
+permalink: /es/blog/uk-cma-browser-cloud-gaming-progress-report/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The UK’s Competition and Markets Authority, [Browser and Cloud Gaming Market Investigation](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) has just released their progress report. Long time readers may remember that this investigation was restarted [after a high court win against Apple](https://open-web-advocacy.org/blog/apple-loses-on-appeal/).
+
+The report delves into Apple’s rule that all browsers on iOS must use the version of WebKit bundled with iOS which is under Apple’s exclusive control.
+
+> The requirement that all browsers on the iOS operating system use a specific version of the WebKit browser engine controlled by Apple, means that there is no competition between browser engines on the platform. Browser vendors cannot switch to an alternative browser engine or make changes to the version of WebKit used on iOS. Similarly, consumers are unable to switch to a browser based on an alternative browser engine. We consider that the lack of competitive pressure is likely to reduce Apple’s incentives to improve WebKit.
+
+> In addition, we have obtained evidence indicating that browser vendors incur 
+additional costs from having to develop and support a version of their browser 
+based on WebKit, which they would not do if the restriction were not in place. 
+Evidence from browser vendors also indicates that Apple is difficult to engage with 
+regarding requests for fixes or the addition of new features to WebKit on iOS.
+
+> Whilst Apple has submitted that the WebKit restriction is necessary to ensure the 
+security, privacy, and performance of iOS devices, and that this is an important 
+aspect of competition between iOS and Android devices, the evidence we have 
+seen to date does not support this conclusion.
+
+Interestingly the report also states that iOS and Android should be considered separate markets for browsers.
+
+> it is our emerging thinking that the supply of mobile browsers on iOS and Android should be considered as two separate product markets”
+
+This market investigation reference was launched by CMA’s Market Study into Mobile Ecosystems. In the [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) to the market investigation reference they listed the following potential remedies:
+
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services.
+
+Separately the powers of the CMA has just been significantly strengthened [with the passing of the Digital Markets, Competition and Consumers Bill](https://open-web-advocacy.org/blog/uk-passes-dmcc/). This will allow them to impose “codes of conduct” on large tech firms with “strategic market status”. This is entirely separate from the market investigation reference, however they will likely read each other’s report.
+
+We hope that the CMA will end Apple’s effective ban on third party browsers on iOS either via the MIR or the powers granted by the DMCC bill. 
+
+Right now, if competition was restored, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often BETTER than Native Apps. Native Apps will still have a lead in cutting edge graphics and gaming technology but if companies see the web platform as viable this gap will decrease over time.
+
+It is for this reason that allowing browser competition on iOS is critical. Apple’s effective browser ban prevents the emergence of such an open and free universal platform for mobile apps. Unlike desktop, developers cannot build their application once and have it work across all consumer devices. Instead, these policies combine with Apple’s trailing and feature-poor engine to force companies to create separate applications for iOS, significantly raising the cost and complexity of development and maintenance. This severely undermines any interoperability advantages Web Apps have between iOS and Android. A single prominent OS holding back the Web is enough to undermine its entire value proposition as a frictionless, capable and secure distribution mechanism for Web Apps.
+
+The fight to allow browser and Web App competition on iOS is not over. We would like to thank everyone for their support over the last 3 years and ask that consumers, developers and businesses write in and engage with the market investigation reference to arm them with all the data and information they need to successfully restore competition to a broken mobile ecosystem.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/uk-passes-DMCC.md
+++ b/src/es/posts/uk-passes-DMCC.md
@@ -1,0 +1,31 @@
+---
+title: 'UK passes Digital Markets, Competition and Consumers Bill'
+date: '2024-05-23'
+tags:
+  - Policy
+  - UK
+author: OWA
+permalink: /es/blog/uk-passes-DMCC/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+## UK passes Digital Markets, Competition and Consumers Bill
+
+On 23rd May, the Digital Markets, Competition and Consumers Bill was passed in Parliament. It is currently awaiting Royal Assent. As the [UK Government explains](https://www.gov.uk/government/news/new-bill-to-crack-down-on-rip-offs-protect-consumer-cash-onlineand-boost-competition-in-digital-markets), the Bill was introduced 
+
+> to crack down on rip-offs, protect consumer cash online and boost competition in digital markets.
+
+Most importantly for us, the new Act gives more powers to the UK's monopoly regulator, the [Competition and Markets Authority](https://www.gov.uk/government/organisations/competition-and-markets-authority) (CMA):
+
+> The CMA will be able to directly enforce consumer law rather than go through lengthy court processes…
+>
+> As part of the Bill, a Digital Markets Unit (DMU) within the CMA will be given new powers to tackle the excessive dominance that a small number of tech companies have held over consumers and businesses in the UK…
+> 
+> For example, the biggest tech firms may be instructed by the DMU to provide more choice and transparency to their customers. If firms don’t abide by these rules, the DMU will have the power to fine them up to 10% of their global turnover.
+
+OWA looks forward to continuing working with the CMA to bring about a fairer competitive landscape so that smaller British companies can serve their consumers as they wish to, rather than as Tech giants dictate.
+
+### Update 28 May: CMA opens consultation on digital markets competition regime
+
+The next working day after the DMCC became law, the CMA announced an [Open Consultation on digital markets competition regime guidance](https://www.gov.uk/government/consultations/consultation-on-digital-markets-competition-regime-guidance) which runs until 11:55pm on 12 July 2024. Let them know what you think; they're listening.  

--- a/src/es/posts/us-doj-files-apple-antitrust-case.md
+++ b/src/es/posts/us-doj-files-apple-antitrust-case.md
@@ -1,0 +1,27 @@
+---
+title: US Department of Justice files Antitrust lawsuit Against Apple
+date: '2024-03-21'
+tags:
+  - Policy
+  - Apple
+  - US
+author: OWA
+permalink: /es/blog/us-doj-files-apple-antitrust-case/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Today, the contents of the US Department of Justice [antitrust lawsuit against Apple were revealed](https://www.404media.co/us-government-antitrust-case-against-apple-documents/). The DOJ along with 16 State's Attorneys General are co-litigants against Apple, claiming a series of unlawful behaviours by the tech giant.
+
+The suit is wide sweeping, and takes issue with Apple's monopolising tactics in the smartphone market.  But, flipping to page 22, we see details of particular interest to OWA and the #AppleBrowserBan:
+
+> "Developers cannot avoid Apple’s control of app distribution and app creation by making web apps—apps created using standard programming languages for web-based content and available over the internet—as an alternative to native apps. **Many iPhone users do not look for or know how to find web apps, causing web apps to constitute only a small fraction of app usage.** Apple recognizes that web apps are not a good alternative to native apps for developers. As one Apple executive acknowledged, “[d]evelopers can’t make much money on the web.” Regardless, **Apple can still control the functionality of web apps because Apple requires all web browsers on the iPhone to use WebKit, Apple’s browser engine—the key software components that third-party browsers use to display web content.**"
+
+The entire suit is fantastic reading for anyone fed up with the bullying tactics of Apple. With this news following so tightly on from the [EU's Digital Markets Act coming into effect](https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/), the dominos are beginning to fall in favour of a fairer, better Open Web!
+
+Stay tuned for more detailed analysis soon.
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/es/posts/website-under-development.md
+++ b/src/es/posts/website-under-development.md
@@ -1,0 +1,13 @@
+---
+title: OWA has a new website!
+date: '2022-03-02'
+tags:
+  - Meta
+author: James Moore
+permalink: /es/blog/website-under-development/index.html
+layout: layouts/post.njk
+translated: false
+---
+A team of enthusiastic volunteers has got to work on [OWA](/)'s new site.
+
+To join them, [visit the Github](https://github.com/OpenWebAdvocacy/website).

--- a/src/es/posts/webventures-an-abridged-history-of-safari-showstoppers.md
+++ b/src/es/posts/webventures-an-abridged-history-of-safari-showstoppers.md
@@ -1,0 +1,45 @@
+---
+title: 'Webventures: An Abridged History of Safari Showstoppers'
+date: '2024-09-25'
+tags:
+  - Policy
+  - Apple
+  - iOS
+  - Safari
+author:
+  - OWA
+permalink: /es/blog/webventures-an-abridged-history-of-safari-showstoppers/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+This week, Webventures [published an article outlining various bugs and problems in iOS Safari over the last several years](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/) that were absolute showstoppers for the Web being a competitive constraint and substitute for mobile app stores.
+
+>iOS Safari is more than an inconvenience for developers, it's the fundamental reason interoperability has been stymied in mobile ecosystems; frequent showstopping bugs, a large patch gap, and lack of competing engines ensures the web is not a credible competitor to native. Here are the receipts to prove it
+><cite>[Webventures](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/)</cite>
+
+This is an [excellent and comprehensive article](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/) and we recommend reading it in full.
+
+Web Apps are being held back as businesses and developers can not be confident that they will consistently work on iOS, a platform no business can ignore without losing (in many cases) more than half their customers. 
+
+The critical issue here is that regulators can not regulate a browser not to have bugs or to fix them quickly. Browsers are complex and some level of bugs is to be expected. Browser vendors also need to work out which bugs to prioritise. The problem here is [lack of effective browser competition on iOS](https://open-web-advocacy.org/walled-gardens-report/#effective-competition%3F).
+
+This is due to [Apple's decision to ban rival browsers such as Firefox, Chrome, Edge, Opera, Vivaldi and Brave from porting their "real" browsers to iOS using their own engines](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Apple does this by rule 2.5.6 of their app store guidelines.
+
+When a critical bug breaks Web Apps on iOS for months, Apple has no great fear it will lose Safari users to rival browsers because they are introducing the exact same bugs into their rivals browsers via imposing their browser engine on third-party browsers. Rival browser vendors have very little control here when it comes to stability on iOS. This lack of fear of losing users removes a powerful incentive to be better.
+
+The solution is clear: fair and effective browser competition on iOS globally. This involves both allowing browser vendors to port their browsers, removing rules that prevent them from competing and giving the software and hardware API access they need to implement and compete in features, stability, performance security and privacy. This will place great pressure on Apple to improve and improve fast. It also provides an alternative for both developers and consumers should they fail to do so.
+
+Already we can see that regulatory pressure has led to some improvement but in order to be truly effective the underlying competition issues need to be fixed, and fixed globally.
+
+## How can you help?
+
+If you spot any mistakes or have additional issues that you believe should be included please [contact the author](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/#anchor--did-we-miss-anything). If any of the unfixed tickets referenced in the article are important to you or your team, **please comment on them**; this is important as it's evidence to both Apple and regulators that these issues are important and need to be fixed. If you're active on social media, you can point Safari developer relations to the link to your comment, too.
+
+As an organisation, our aim is to allow fair and effective browser and Web App competition on all major consumer operating systems. OWA has so much more work to do advocating for the web all over the globe. 
+
+We will always need your support, and you can do that in many ways:
+* [Donate to help with our running costs](https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/es/posts/why-browser-choice-matters.md
+++ b/src/es/posts/why-browser-choice-matters.md
@@ -1,0 +1,34 @@
+---
+title: Why is browser choice vital for the future of the Open Web?
+date: '2023-11-13'
+tags:
+  - Browsers
+author: Frances Berriman
+permalink: /es/blog/why-browser-choice-matters/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+OWA’s key goal is to enable true competition and browser choice across all devices. But, why do we care so deeply about this, and what would success look like?
+
+### Cost
+
+Currently, businesses that want to grow across many markets must develop not only a good website, but also native apps for any platforms they want to reach that don’t have [modern browser features available](https://infrequently.org/2021/04/progress-delayed/). Additionally, deriving most of their user base from native applications and app stores mean that they’re forced into giving a cut to those app stores (usually 30% of any payments made through the app store). It’s not uncommon for businesses to [pass that fee on to users as an extra cost](https://www.washingtonpost.com/technology/2023/02/24/apps-subscription-costs/).
+
+In a fairer world, businesses would be able to rely on modern web browsers being available to all of their users, regardless of the platform they choose, enabling businesses to opt out of app stores and serve their customers from a single application, avoiding the app-store tax.
+
+### Privacy and Security
+
+Although the web in general has a variety of issues in regards to privacy (hello ad-trackers!), browsers offer a sandboxed experience that is superior to native app security - Apple even knows this, and spoke about it in their recent [filing to the EU](https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf). 
+
+With that said, browsers that are stuck inside native applications are at the mercy of that application - [information can be freely read and tracked](https://infrequently.org/2021/07/hobsons-browser/) - so with browser choice available to an end user, they can regain control of their privacy and deprive those that would like to farm their data from their behaviours within their applications.
+
+### Innovation
+
+The most obvious reason that a lack of competition is an issue for everyone is it stifles innovation. With no fair way to deploy new browsers to all users, no new ones will be born. [The market is already showing this](https://gs.statcounter.com/browser-market-share#yearly-2009-2023) by the practical loss of Opera and the downward trend of Firefox - neither can succeed in today’s market.
+
+Currently, Google and Apple run a duopoly that essentially ensures that they are the only two active participants in deciding what happens to the open web (and mobile computing, in general), because they disallow anyone else to compete against them, preferentially favouring their own, closed, ecosystems of native apps. 
+
+If you want a choice in which company you trust with your web experience, the businesses that create those options need to know they have a fair chance to succeed. 
+
+If you want to read more about why closed ecosystems are a problem, take a look at our [Walled Gardens Report](/walled-gardens-report/). 

--- a/src/es/robot-meta/tags.md
+++ b/src/es/robot-meta/tags.md
@@ -1,0 +1,19 @@
+---
+title: Tag Archive
+layout: layouts/feed.njk
+pagination:
+  data: collections
+  size: 1
+  alias: tag
+  filter:
+    - all
+    - nav
+    - blog
+    - work
+    - featuredWork
+    - people
+    - rss
+permalink: '/es/tag/{{ tag | slug }}/'
+translated: false
+---
+

--- a/src/ja/pages/accessibility.md
+++ b/src/ja/pages/accessibility.md
@@ -1,0 +1,28 @@
+---
+title: Accessibility
+permalink: /ja/accessibility/
+metaDesc: Learn about the accessibility of the Open Web Advocacy website.
+layout: layouts/page.njk
+translated: false
+---
+
+The Open Web Advocacy is committed to ensuring digital accessibility for people with disabilities.
+We are applying the relevant accessibility standards, and we will do our best to continually improve the user experience
+for everyone.
+
+## Measures to support accessibility
+
+As a team of enthusiastic volunteers, we are focusing our efforts on web standards and semantic HTML.
+
+The tests done during development are:
+
+- checking for general accessibility problems with WAVE (Web Accessibility Evaluation Tool);
+- navigating the site using the keyboard;
+- using NVDA screen reader.
+
+## Feedback
+
+We welcome your feedback on the accessibility of our pages.
+If you encounter any accessibility barriers accessing our content, please let us know by email:
+[contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org). We will do our
+best to address the issue as soon as possible.

--- a/src/ja/pages/apple-attempts-killing-webapps.md
+++ b/src/ja/pages/apple-attempts-killing-webapps.md
@@ -1,0 +1,45 @@
+---
+title: Immediate Action Needed!
+permalink: /ja/apple-attempts-killing-webapps/
+metaDesc: >-
+  Apple has officially announced that they are attempting to kill web apps in
+  the EU, which will have ramifications worldwide
+layout: layouts/page.njk
+translated: false
+---
+
+**Apple has officially announced that they are attempting to kill web apps in the EU, which will have ramifications worldwide.**
+
+## ACT NOW
+
+**We need immediate support from web developers and businesses that operate online in the EU**.  The European Commission needs to hear from YOU to understand the devastating impact Apple’s new ban will have on your livelihoods, businesses and customers.
+
+To facilitate this, [please sign our open letter](https://letter.open-web-advocacy.org/) so that we can understand the scale of the impact and provide it to the European Commission in a single large submission.
+
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+<p><strong>Are you established in the EU and have an Apple Developer Account?</strong></p>
+<p>If you are, we encourage you to write directly to Apple to request preservation of the existing functionality that allows Safari and other iOS browsers to add Web Apps to the home screen, allows them to run in top-level activities (not in tabs), integrates with iOS settings and permissions, enables Push Notifications and homescreen icon badging, allows persistent storage, and to run fullscreen. </p>
+<p><a href="https://developer.apple.com/support/ios-interoperability/">Submit your interoperabilty request to Apple</a></p>
+
+## What’s happening?
+
+Apple have announced a series of changes designed to comply with the European Union’s Digital Markets Act.
+
+Throughout this process, they’ve chosen to maliciously comply as much as possible, resulting in a series of decisions meant to cripple the ability for anyone to compete on their platform outside of their App Store.
+
+You can read more about the changes they’ve made in these two blog posts:
+
+[It’s Official, Apple Kills Web Apps in the EU](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/)
+
+[OWA’s Review of Apple’s DMA Compliance Proposal for the Web](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/)

--- a/src/ja/pages/apple-dma-review.html
+++ b/src/ja/pages/apple-dma-review.html
@@ -1,0 +1,5695 @@
+---
+title: Apple DMA Review
+permalink: /ja/apple-dma-review/
+layout: layouts/paper.njk
+metaDesc: ''
+subtitle: ' Review of Apple''s Compliance Proposal - VERSION 1.0'
+paperName: OWA - DMA - Review of Apple's Compliance Proposal - v1.0
+paperSize: 4.95 MB
+translated: false
+---
+
+<h2 id="introduction">
+  <a class="header-anchor" href="#introduction" aria-hidden="true">#</a>
+  2. Introduction
+</h2>
+
+<p>
+  The Digital Markets Act (DMA) aims to restore contestability, interoperability,
+  choice and fairness back to digital markets in the EU. These fundamental
+  properties of an effectively functioning digital market have been eroded by the
+  extreme power gatekeepers wield via their control of “core platform services”.
+</p>
+<p>
+  The lack of competition on mobile ecosystems is, at its heart, a structural one.
+  Gatekeepers wield vast power due to the security model that these devices are
+  built on. Traditionally, on operating systems such as Windows, macOS and Linux,
+  users can install any application they want, with no interaction from the
+  operating system gatekeeper, either by the business or the end user. Users can
+  then grant these programs the ability to do anything they desire.
+</p>
+<p>
+  Locking down what applications can do, such as restricting which APIs they can
+  access behind user permissions, is not by itself anti-competitive and can bring
+  legitimate security advantages. However, the manner in which it has been
+  implemented on mobile devices is both self-serving and in its current form,
+  significantly damages competition.
+</p>
+<p>
+  This damage surfaces in several forms:
+</p>
+<p>
+  First, the gatekeeper can control what is allowed to be installed on devices
+  they have already sold to consumers, often for a significant profit. They
+  utilize this device-level control to demand a 30% cut of all third-party
+  software that the consumer installs, not on merit, but simply because they
+  control the only mechanisms available to businesses to release that software,
+  and can further block or hinder the consumer from using or acquiring services
+  outside of their app store.
+</p>
+<p>
+  The second is more subtle. In order to deliver their “native” apps to consumers
+  on Android or iOS, developers must create custom applications in specific
+  programming languages for each individual platform. Typically, companies will
+  require separate development teams for each OS. This not only multiplies
+  development and maintenance cost, but puts in place an invisible barrier to
+  interoperability. Even the built up expertise for creating software for a
+  specific platform provides significant lock-in advantages to the platform’s
+  gatekeeper.
+</p>
+<p>
+  Finally, even if a developer has no desire to interact with the gatekeeper, they
+  are forced into a commercial and legally binding relationship with them. This is
+  due to the fact that the gatekeeper inserts itself between the customer and
+  these third party developers. With smartphones now 15 years old, this may seem
+  normal to us now, but imagine if Microsoft demanded that every software provider
+  signed an onerous contract with them or be barred from releasing a product on
+  Windows. What would have been unacceptable, anti-competitive behavior to both
+  consumers, businesses and regulators on desktop, has been tolerated on mobile
+  simply because these computers were considered a “new” category.
+</p>
+<p>
+  Mobile devices are just small computers whose primary input is touch, there is
+  no sacred or magical property that means they have to run on a proprietary app
+  store model. Nothing is stopping mobile computers running on the open model that
+  desktop computers run on, just as there is nothing stopping a desktop computer
+  running the app store model. Inertia and great profits are however powerful
+  forces. Between them, Apple and Google have created a powerful and entrenched
+  duopoly.
+</p>
+<p>
+  Even with the DMA forcing Apple to open up the ecosystem to competition, Apple
+  is still inserting themselves front and center between consumers and app
+  developers. They insist all developers for iOS/iPadOS (including developers who
+  have no intention of using their app store) pay them $100 per year, that they
+  sign the full Apple developer program contract and submit themselves to what is
+  effectively app store review (although nominally locked to security). Worse,
+  they are attaching significant recurring penalty fees to developers who dare to
+  make their software available outside of Apple’s app store. Apple is using every
+  tool at their disposal to dissuade developers from leaving their app store and
+  to undermine the goals of the DMA.
+</p>
+<p>
+  Apple's key excuse to impose this control is security. Apple's argument is, in
+  essence, that only they can be trusted to vet what consumers are allowed to
+  install on their devices. All third parties must submit to their review.
+</p>
+<p>
+  What is needed is a way to securely run interoperable and capable software
+  across all operating systems. Luckily, such a solution already exists and is not
+  only thriving on open desktop platforms but is dominating, and that
+  dominance is growing every year. The solution is of course, the Web and more
+  specifically Web Apps. Today, more than 60% of users' time on desktop is done
+  using web technologies, and that looks set to only grow.
+</p>
+<p>
+  Web Apps have a number of properties that allow them to solve this critical
+  problem. They are run in the security of the browser's sandbox, which <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">even
+    Apple admits is “orders of magnitude more stringent than the sandbox for native
+    iOS apps.”</a>. They are truly interoperable between operating systems. They
+  don't require developers to sign contracts with any of the OS gatekeepers. They
+  are capable of incredible things and 90% of the apps on your phone could be
+  written as one today.
+</p>
+<p>
+  So why aren't they thriving on mobile? The simple answer to this question is
+  lack of browser competition on iOS and active hostility by Apple towards
+  effective Web App support, both by their own browser and by their OS. Apple's
+  own browser faces no competition on iOS, as they have effectively barred the
+  other browsers from competing by prohibiting them from using or modifying their
+  engines, the core part of what allows browser vendors to differentiate in
+  stability, features, security and privacy.
+</p>
+<p>
+  The DMA explicitly sets out to right this wrong by mandating that gatekeepers
+  can no longer enact such a ban:
+</p>
+
+<blockquote>
+  <p>In particular, each browser is built on a web
+    browser engine,
+    which is responsible for key browser functionality such as
+    speed, reliability and web compatibility. When gatekeepers
+    operate and impose web browser engines, they are in a position
+    to determine the functionality and standards that will apply
+    not only to their own web browsers, but also to competing web
+    browsers and, in turn, to &gt;web software applications.
+    Gatekeepers
+    should therefore not use their position to require their
+    dependent business users to use any of the services provided
+    together with, or in support of, core platform services by the
+    gatekeeper itself as part of the provision of services or
+    products by those business users.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital
+        Markets Act - Recital 43</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent stated for this in the DMA is to prevent gatekeepers from dictating
+  the speed, stability, compatibility and feature set of “web software
+  applications”.
+</p>
+<p>
+  Apple has announced new rules that would, at first glance, allow browser vendors
+  to port their real browsers to iOS. However, on closer inspection, this is a
+  mirage. Instead Apple appears intent on making it <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">“as
+    painful as possible” for browser vendors</a> to port their engines to
+  iOS/iPadOS. As we will outline in our paper, Apple's current proposal falls far
+  short of compliance. Apple is not only undermining browser competition on iOS,
+  but appears to be actively attempting to prevent the growth of an entire open
+  and interoperable ecosystem that could feasibly supplant and replace their app
+  store model.
+</p>
+<p>
+  Apple have seen the Web as a threat to their app store as far back as 2011, when
+  Philip Schiller internally sent an email to Eddie Cue titled “HTML5 poses a
+  threat to both Flash and the App Store”.
+</p>
+
+<blockquote>
+  <p>
+    Food for thought: Do we think our 30/70% split will last forever? While I am a
+    staunch supporter of the 30/70% split and keeping it simple and consistent across
+    our stores, I don’t think 30/70 will last unchanged forever. I think someday we will
+    see a challenge from another platform or a web based solution to want to adjust our
+    model.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+        Phil Schiller - Apple Upper Management
+      </a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This attitude appears not to have changed. Faced with the genuine possibility of third-
+  party browsers effectively powering Web Apps, Apple's first instinct appears to have
+  been to <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+    remove Web Apps support entirely with no notice to either businesses or
+    consumers</a>. Luckily, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+    under significant pressure, Apple backed down</a> from this particular
+  stunt at the last moment.
+</p>
+
+<p>
+  Apple is very explicit in its public statement that they initially planned to remove the
+  functionality as the DMA would force them to share it with third-party browsers. Even in
+  their statement backing down, they make it clear they do not intend to allow third-party
+  browsers that use their own engine to be able to install and manage Web Apps. In both
+  statements, Apple cites "security" as the reason for their decisions.
+</p>
+<p>
+  Unfortunately for Apple, it has been unable to prove that Safari or WebKit are actually
+  more secure than its competitors. When obligated by the UK’s Competition and Markets
+  Authority to provide evidence to back up its assertion that WebKit was more secure than
+  Blink or Gecko, Apple failed to do so.
+</p>
+
+<blockquote>
+  <p>... the evidence that we have seen to date does not suggest that there are material
+    differences in the security performance of WebKit and alternative browser engines.
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>Overall, the evidence we have received to date does not suggest that Apple's
+    WebKit restriction allows for quicker and more effective response to security threats
+    for dedicated browser apps on iOS.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Apple's actions not only hurt the Web ecosystem, third-party businesses (be they
+  browser vendors or software developers), but also make their devices worse for their own
+  consumers. By depriving their consumers of the choice and competition that fair and
+  effective browser and Web App competition would bring, they are worsening the
+  functionality, interoperability, stability, security, privacy, and price of services on their
+  devices.
+</p>
+<p>
+  A reasonable person might argue
+  <em>Why would Apple make their own devices worse, surely
+    better devices means more hardware sales?</em> This behavior comes, however, with key
+  advantages for Apple, even if they harm Apple's own consumers.
+</p>
+
+<p>
+  Critically, service revenue is of growing importance for Apple as
+  <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">their hardware sales have
+    peaked and are declining</a>. Apple has not had a “hit” new product for 14 years, namely the
+  iPad, and, if you are being generous, 9 years for the Apple Watch. It does not currently
+  seem likely that Apple’s VR/AR headset
+  <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">will
+    have any significant impact on Apple’s overall
+    hardware sales</a>.
+</p>
+
+<p>
+  The UK regulator cites two incentives: protecting their app store revenue from
+  competition from Web Apps, and protecting their Google search deal from competition
+  from third-party browsers.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple receives significant revenue from Google
+      by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially
+    from high usage
+    of Safari. [...] <strong class="stressed">The WebKit restriction may help to
+      entrench this position</strong> by limiting
+    the scope for other browsers on iOS to differentiate themselves from Safari [...] As
+    a result, it is less likely that users will choose other browsers over Safari, which in
+    turn <strong class="stressed">secures Apple’s revenues from Google</strong>.
+    [...]
+    Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via Apple
+    IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring
+    all browsers on iOS to use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control
+      over the maximum functionality of all browsers on iOS</strong> and, as a consequence,
+    hold up the development and use of web apps. This limits the <strong class="stressed">competitive
+      constraint that web apps pose on native apps</strong>, which in turn protects and benefits
+    Apple’s App Store revenues.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  These two revenue streams are vast, even for a company of Apple’s size. Apple collected
+  <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.">
+    $85 billion USD in App Store fees in 2022</a>,
+  of which it keeps approximately 30%. Apple
+  reportedly receives
+  <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+    $18-20 billion USD</a> a year from their Google Search engine deal,
+  accounting for 14-16 percent of Apple's annual operating profits.
+</p>
+<p>
+  A third and interesting incentive the CMA does not cite, but which the US's Department of
+  Justice does, is that this behavior greatly weakens the interoperability of Apple's devices,
+  making it harder for consumers to switch or multi-home. It also greatly raises the barriers
+  of entry for new mobile operating system entrants by depriving them of a library of
+  interoperable apps.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple has long understood how middleware can help promote
+      competition</strong> and
+    its myriad benefits, including increased innovation and output,
+    <strong class="stressed">by increasing scale and interoperability</strong>.
+    [...]
+    In the context of smartphones, examples of
+    <strong class="stressed">middleware include internet browsers</strong>,
+    internet or cloud-based apps, super apps, and smartwatches, among other products
+    and services.
+    [...]
+    <strong class="stressed">
+      Apple has limited the capabilities of third-party iOS web browsers, including by
+      requiring that they use Apple’s browser engine, WebKit</strong>.
+    [...]
+    Apple has sole discretion to review and approve all apps and app updates.
+    <strong class="stressed">Apple
+      selectively exercises that discretion to its own benefit</strong>, deviating from or changing
+    its guidelines when it suits Apple’s interests and allowing Apple executives to control
+    app reviews and decide whether to approve individual apps or updates. Apple often
+    enforces its App Store rules arbitrarily.
+    <strong class="stressed">And it frequently uses App Store rules and
+      restrictions to penalize and restrict developers that take advantage of
+      technologies that threaten to disrupt, disintermediate, compete with, or erode
+      Apple’s monopoly power</strong>.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+        DOJ Complaint against Apple</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Interoperability via middleware would reduce lock-in for Apple’s devices. Lock-in is a clear
+  reason for Apple to block interoperability, as can be seen in this email exchange where
+  Apple executives dismiss the idea of bringing iMessage to Android.
+</p>
+
+<blockquote>
+  <p>
+    The #1 most difficult [reason] to leave the Apple universe app is iMessage ...
+    iMessage amounts to serious lock-in
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Unnamed Apple Employee</a>
+    </cite>
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>
+    iMessage on Android would simply serve to remove [an] obstacle to iPhone
+    families giving their kids Android phones ... moving iMessage to Android will hurt us
+    more than help us, this email illustrates why.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Craig Federighi - Apple's Senior Vice President of Software Engineering</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>The DMA has the power to fix all of these underlying issues and unleash a powerful,
+  open, interoperable and secure competitor to not only Apple's
+  app store but also Google's. Lack of
+  contestability for mobile app stores and mobile operating systems is
+  a key concern for the DMA that viable Web
+  Apps solve.
+</p>
+
+<p>This will also remove a heavy burden from new entrants into the operating system
+  market; lack of apps. No longer will developers need to develop custom apps
+  for each operating system, any
+  operating system with good web app support and browser competition will support
+  all web apps automatically. Web
+  Apps support operating systems that developers have not even heard of.
+  The impact of allowing them to compete
+  fairly on mobile will be profound.
+</p>
+
+<p>
+  We request the Commission open a proceeding into Apple and investigate what we allege
+  is severe and deliberate non-compliance. The number of ways that Apple is not complying is so myriad that we,
+  recognising that the commision does not have infinite resources to pursue all of them simultaneously, have split
+  them into three tranches of remedies.
+</p>
+<p>Some remedies require time and/or pre-requisite remedies in order to be effective.
+  Remedies in this document are ordered to ensure that either competitive benefits are delivered earlier or to
+  unlock future remedies. In this way, we propose a program of continual improvement in the competitive landscape,
+  delivering wins at every step along the path.
+</p>
+
+<p>While we have attempted to be comprehensive, it is possible, and perhaps even likely,
+  that there will be infringements that we have not included or are not yet aware of.
+</p>
+
+<p>Our proposed remedies include:</p>
+
+<ul>
+  <li>Restricting Apple's API contract for browsers down to strictly necessary,
+    proportionate and justified security measures.</li>
+  <li>Make clear what the security measures are for third party browsers using
+    their own engine by publishing them in a single up-to-date document.</li>
+  <li>Removing any App Store rule that would prevent third party browsers from
+    competing fairly.</li>
+  <li>Allow browser vendors to keep their existing EU consumers when switching
+    to use their own engine.</li>
+  <li>Removing the special placement of Safari.</li>
+  <li>Making Safari uninstallable.</li>
+  <li>Implementing Install Prompts in iOS Safari for Web Apps.</li>
+  <li>Allowing Browser Vendors and Developers to be able to test their browsers
+    and web software outside the EU.</li>
+  <li>Allowing Browsers using their own engine to install and manage Web Apps.</li>
+  <li>Make notarization a fast and automatic process, as on macOS.</li>
+  <li>Allow direct browser installation independently from Apple’s app store.</li>
+  <li>Allow users to switch to different distribution methods of a native
+    app and allow developers to promote that option to the user.</li>
+  <li>Don't break third party browsers for EU residents who are traveling.</li>
+  <li>Opt-Into Rights contract should be removed.</li>
+  <li>Core Technology Fee should be removed.</li>
+  <li>Apple should publish a new more detailed compliance plan.</li>
+</ul>
+
+<p>Apple is obligated under Articles 5(7), 6(3), 6(4) and 6(7) to fix each
+  of the above issues. Apple has failed to achieve effective compliance
+  with these obligations contrary to Article 13(3). Further Apple has
+  taken numerous and significant steps that obstruct and undermine it in
+  contravention of Article 13(4). Apple has introduced conditions and
+  restrictions on DMA-conferred rights that have no legal basis in the
+  DMA and gone far beyond the restrictions that the DMA does allow by
+  introducing rules that have no basis in security or that are not justified,
+  strictly necessary or proportionate.
+</p>
+
+<p>Any intervention that the Commission makes will have global ramifications. Regulators around the world are carefully watching the implementation of the DMA as they plan their own regulatory regimes. Already <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">Japan has become the second jurisdiction in the world to explicitly prohibit banning browser engines</a>. <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">Australia</a>, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">India, Korea and Brazil</a> are all planning on implementing their own versions of the DMA. The UK has just <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">passed the Digital Markets, Competition and Consumers Bill</a> that grants their regulator great power to enforce codes of conduct against tech giants.
+</p>
+
+<p>Successful resolution of these issues have an exceptional chance of becoming de facto global, as no jurisdiction will want to miss out on clear benefits being enjoyed by EU consumers. However, if Apple manages to successfully avoid complying with the DMA, these problems could persist indefinitely.
+</p>
+
+<p>
+  We urge the Commission to enforce the DMA and obligate Apple to allow
+  browsers and Web Apps to compete fairly and effectively on their mobile ecosystem.
+  This will unlock contestability, fairness and interoperability. Companies will then
+  have to compete for users on merit, not via lock-in or control over operating
+  systems. Consumers will benefit from choice, better quality and cheaper software,
+  interoperability, and the genuine ability to multihome across devices and operating
+  systems offered by different companies.
+</p>
+
+<p>
+  These changes can finally fix a mobile ecosystem that has been
+  structurally broken, and artificially hindered, for more than a decade.
+</p>
+
+<h2 id="review">
+  <a class="header-anchor" href="#review" aria-hidden="true">#</a>
+  3. Review
+</h2>
+
+<h3 id="Apples-new-browser-engine-entitlement-contract">
+  <a class="header-anchor" href="#Apples-new-browser-engine-entitlement-contract" aria-hidden="true">#</a>
+  3.1. Apple’s New Browser Engine Entitlement Contract
+</h3>
+
+<h4 id="api-contract-not-restricted-to-only-security">
+  <a class="header-anchor" href="#api-contract-not-restricted-to-only-security" aria-hidden="true">#</a>
+  3.1.1. API Contract not Restricted to Only Security
+</h4>
+
+<p>
+  As part of Apple’s compliance proposal, Apple published a new contract,
+  namely the “Web Browser Engine Entitlement Addendum for Apps in the EU”.
+</p>
+
+<p>
+  This is a contract to be allowed to have the “Alternative Web Browser
+  Engine App (EU)” entitlement profile. To understand what an entitlement is,
+  we can look to Apple’s documentation:
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">An entitlement is a right or privilege that grants
+      an executable particular
+      capabilities</strong>. For example, an app needs the HomeKit Entitlement — along with
+    explicit user consent — to access a user’s home automation network. An app
+    stores its entitlements as key-value pairs embedded in the code signature of
+    its binary executable.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements">
+        Apple Developer Documentation</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  An entitlement is a permission which grants applications the ability
+  to access some specific hardware or software features of the operating
+  system. For example Apple grants the Safari app the ability to access
+  bluetooth via the “com.apple.bluetooth.internal” entitlement.
+</p>
+
+<p>
+  The contract further specifies:
+</p>
+
+<blockquote>
+  <p>
+    &lsquo;Alternative Web Browser Engine APIs&rsquo; means the restricted Application
+    Programming Interfaces (&lsquo;APIs&rsquo;) contained in the Apple Software, which
+    are provided to You under this Addendum for using an Alternative Web Browser Engine.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This therefore means that this contract is Apple’s terms and conditions
+  for access to these APIs. This applies not only to browsers installed
+  from Apple’s app store but also <strong>applies to browsers that are either
+    installed from a different app store or directly from a website</strong>.
+</p>
+
+<p>The DMA states:</p>
+
+<blockquote>
+  <p>
+    Article 6(7) <strong class="stressed">
+      The gatekeeper shall allow providers of services and
+      providers of hardware, free of charge, effective interoperability with,
+      and access for the purposes of interoperability to, the same hardware
+      and software features accessed or controlled via the operating system
+      or virtual assistant listed in the designation decision pursuant to
+      Article 3(9) as are available to services or hardware provided by the
+      gatekeeper</strong>. Furthermore, the gatekeeper shall allow business users
+    and alternative providers of services provided together with, or in
+    support of, core platform services, free of charge, effective
+    interoperability with, and access for the purposes of interoperability
+    to, the same operating system, hardware or software features,
+    regardless of whether those features are part of the operating system,
+    as are available to, or used by, that gatekeeper when providing such
+    services.
+    <strong class="stressed">The gatekeeper shall not be prevented from taking strictly necessary
+      and proportionate measures to ensure that interoperability does not
+      compromise the integrity of the operating system, virtual assistant,
+      hardware or software features provided by the gatekeeper, provided
+      that such measures are duly justified by the gatekeeper.</strong>
+    </p>
+    <p>
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+        Digital Markets Act - Article 6(7)</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This is clearly a strong restriction on which conditions Apple can place
+  on general API access. That is, while 6(7) allows Apple to have a
+  number of strictly necessary, proportionate and justified security
+  conditions to protect the integrity of the operating system, it is
+  not allowed to then add any other conditions it may want.
+</p>
+
+<p>
+  Apple’s contract helpfully separates out which conditions Apple
+  considers to be security requirements in two sections: “You must
+  meet the following security requirements” and “3.1 Security”.
+</p>
+
+<p>
+  Apple should ensure that each and every condition in this contract is:
+</p>
+
+<ul>
+  <li>To protect the integrity of the operating system</li>
+  <li>Strictly necessary</li>
+  <li>Proportionate</li>
+  <li>Duly justified by Apple</li>
+</ul>
+
+<p>
+  <strong>This immediately strikes out all conditions in the contract that
+    are not security conditions - which make up the majority of the contract.</strong>
+</p>
+
+<p>
+  Apple must remove all non-security terms from its browser engine entitlement contract. The contract must only
+  contain terms allowed by Article 6(7) of the DMA. OWA supports the contract spelling out the necessary,
+  proportionate, and justified security rules to protect the integrity of the operating system.
+</p>
+
+<h4 id="article5-7-no-security-exceptions">
+  <a class="header-anchor" href="#article5-7-no-security-exceptions" aria-hidden="true">#</a>
+  3.1.1.1. Article 5(7) - No Security Exceptions
+</h4>
+
+<p>
+  Under Article 5(7), Apple is obligated to allow browser vendors to port their existing browser engines to iOS.
+  Article 5(7) contains no security exceptions.
+</p>
+<p>
+  This means Apple can not seek to prevent or hinder the features and functionality that browser engines can provide
+  by claiming exemptions under security. Article 13(3) and 13(4) in conjunction with 5(7) means that Apple must enable
+  browser vendors to port their browser engines in their entirety, and Apple must provide those engines the access and
+  integration they require to operate.
+</p>
+<p>
+  We would propose that the Commission therefore looks at security rules through this lens and ensure that any
+  security rule that would significantly hinder browser vendors from porting their existing engines should be struck
+  out. Major browser vendors take security extremely seriously and will likely voluntarily accept a number of rules
+  related to patching and promptly fixing vulnerabilities as they already do this for every other operating system.
+</p>
+<p>
+  Thus, any app store or API contract rule that would make it extremely difficult or impossible for a competent
+  browser vendor to port their existing browser (with its engine) to iOS would be in violation of Article 5(7) and
+  Article 13(4).
+</p>
+<p>
+  If we look at the intent of Article 5(7) with respect to browser engines it goes further. The intent is spelt out in
+  this segment of Recital 43:
+</p>
+
+<blockquote>
+  <p>
+    In particular, each browser is built on a web browser engine, which is responsible for key browser functionality
+    such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they
+    are in a position to determine the functionality and standards that will apply not only to their own web browsers,
+    but also to competing web browsers and, in turn, to web software applications.”
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+        Digital Markets Act - Recital 43</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent is to allow third-party browser vendors to contest the functionality, speed and stability of the
+  gatekeepers browser, including in the provision of the functionality of Web Apps.
+</p>
+<p>
+  This means that any app store or API contract rule that would block functionality from a third-party browser would
+  be in violation of Article 5(7) and 13(4). The most that Apple can insist upon is that browser vendors take
+  reasonable steps to mitigate any security issues to at least the baseline level of security for that API (or
+  equivalent APIs) on iOS.
+</p>
+<p>
+  OWA expects that browser vendors should be subject to security requirements, but as previously stated, security
+  should not be used to block the ability of browsers and Web Apps to compete with the gatekeepers native apps and
+  services.
+</p>
+<p>
+  In summary, <strong>security rules (and other app store rules) that violate
+    Article 5(7) should be modified or struck out</strong>.
+</p>
+
+<h3 id="must-not-use-browser-engine-of-operating-system">
+  <a class="header-anchor" href="#must-not-use-browser-engine-of-operating-system" aria-hidden="true">#</a>
+  3.1.2. Must not use the Browser Engine of the Operating System
+</h3>
+
+<p>
+  Due to Apple’s 15 year ban of third-party browser engines, browser vendors will need to gradually phase in their own
+  engines over time using phased roll-outs and multi-variant testing. Deploying an engine to a new operating system is
+  a complex process and has to be done in a slow and methodical manner to identify bugs and performance issues.
+</p>
+<p>
+  As a result, it is essential that all browser vendors be allowed to ship dual engine browsers. That is, browsers
+  that can use both the system provided WKWebView and their own engine within a single binary. Technically the binary
+  would only contain the code for a single engine, the one the browser vendor provides, since the WKWebView is an
+  operating system provided component.
+</p>
+<p>
+  However, Apple has added a rule in their contract to explicitly ban this:
+</p>
+
+<blockquote>
+  <p>
+    Be a separate binary from any Application that uses the system-provided
+    web browser engine
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>To our knowledge there is no reasonable or rational reason to impose this
+  restriction.</p>
+
+<p>It is not entirely clear what this rule means, but the most obvious interpretation is
+  that the browser is not allowed to make use of the WKWebView. Potentially it could mean that the browser is also
+  not able to make use of or call SFSafariViewController (which may have some niche use cases even for browsers that
+  ship their own engine).</p>
+
+<p>The WKWebView is an operating system component, and thus a software feature of iOS
+  covered under Article 6(7). Since Apple has not provided any security justification for this rule, nor do we
+  believe one plausibly exists, this term is in clear contravention of 6(7).</p>
+
+<p>Without explanation we can only guess Apple’s reasons for adding this rule. The
+  most obvious guess is that Apple is simply being malicious by ensuring browser vendors can not update their
+  existing browser app to use their own engine, which will then ensure that those browser vendors will lose all
+  their existing EU customers if they attempt to port their engine over.</p>
+
+<p>It is also possible that this is simply as childish and anticompetitive as “if
+  you want to not be forced to use it, then you're not allowed to use it at all”. Apple has behaved in a
+  similar manner in a number of other instances with their app store and their payment handler.</p>
+
+<p>A significant consequence of this rule is that it makes phasing in the engine over time
+  with A/B testing impossible. A/B testing (also known as split testing or bucket testing) is a methodology for
+  comparing two versions of an app in order to know which performs better. In the case of browsers, there are bugs
+  which only occur rarely i.e for 1/10,000 or 1/100,000 users. In order to pick up these bugs before releasing them
+  on millions of users, browser vendors turn on features for a percentage of users (i.e 1% or .1%) to catch issues.
+  This is a critical part of browser development. </p>
+
+<p>In this case, browser vendors will be toggling users between the WebKit version of
+  their browser and their own engine version of their browser so as to collect sufficient bug data to make their own
+  engine version stable. Such a rule would make this impossible.</p>
+
+<p>This will make it significantly more difficult for browser vendors to port their
+  engines, let alone have a successful product using their own engine which meets or exceeds the quality and
+  adoption of their WebKit WebView-based browser. This is the only real plausible purpose of the rule. Coupled with
+  the complete lack of security or any other justification, this rule would be in violation of Article 5(7), and
+  Article 13(4).</p>
+
+<p>Thus, under Article 5(7), Article 6(7), and Article 13(4) <strong>Apple must
+    allow browser vendors to ship “dual engine” browsers by removing</strong>
+  <q>Be a separate binary from any Application that uses the system-provided
+    web browser engine</q> from their browser engine entitlement contract and not
+  include an equivalent rule in their
+  app store rules.
+</p>
+
+<h3 id="must-be-new-and-separate-app">
+  <a class="header-anchor" href="#must-be-new-and-separate-app" aria-hidden="true">#</a>
+  3.1.3. Must be New and Separate App
+</h3>
+
+<p>Apple has a number of rules making it clear that the Web Browser Engine Entitlement
+  will only be provided in the EU. Additionally, they will force browser vendors to submit a brand new
+  application called an "Alternative Web Browser Engine App (EU)" in the contract.</p>
+
+<blockquote>
+  <p>Your Application must:</p>
+  <ul>
+    <li>Be distributed solely on iOS in the European Union;</li>
+    <li><strong class="stressed">Be a separate binary from any Application that uses the
+        system-provided web browser engine;</strong></li>
+  </ul>
+  <p>
+    ...
+    2.4 The Entitlement Profile is compatible and may only be used with Applications solely distributed within the EU
+    on devices running iOS 17.4 or later
+    ...
+    You are permitted to use the Entitlement Profile only in connection with Your Alternative Web Browser Engine App
+    (EU) developed or distributed under this Addendum and with Apple-branded products"
+  </p>
+  <p><cite>
+      <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+        Apple’s Browser Engine Entitlement Contract
+      </a>
+    </cite></p>
+</blockquote>
+
+<p>Apple has chosen to restrict browser competition on iOS to the EU. This means under
+  Apple's current proposal all browsers that intend to bring and modify their own engine will need to create a
+  brand new application. Existing users will need to switch to this "new" app or remain siloed on the
+  existing WKWebView version of their browser.</p>
+
+<p>The rule to ship a separate app in the EU does not affect Safari, as the WKWebView is
+  under Apple's sole control, contains Safari's engine and is updated in lockstep with Safari. That is to
+  say: the system provided browser engine is Safari’s engine, hence they are automatically exempt from this
+  rule.</p>
+
+<p>For a third-party browser to make this transition, they would need to ship a new app,
+  and then advertise to the existing users to switch to the new app. The ramifications of this is so severe
+  it’s unlikely any browser vendor would be willing to take this step as it causes serious issues:
+</p>
+
+<ul>
+  <li>Browser vendors would likely lose a significant percentage of
+    their existing users in the transition.</li>
+  <li>Their "real" browser (i.e. the one they ship on every
+    other operating system) will start with zero installs. This means that, even after a period of time, it may
+    still not be eligible for the choice screen as it only displays the top 12 browsers for the country of the user.
+    It would be worth investigating whether imposing the “new and separate app rule” would therefore
+    breach 13(4)’s effective compliance obligation in relation to Apple’s 6(3) choice screen
+    obligations.</li>
+  <li>This introduces considerable friction and complexity into porting
+    users data, login cookies and settings to the new app. This is problematic as:
+    <ul>
+      <li>In some cases user’s data will be lost in the
+        transfer.</li>
+      <li> Significant development work will be required to sync it.</li>
+      <li>It is unclear what to do for users that become and cease to be EU
+        residents,an artificial problem caused by Apple's geolock.</li>
+      <li>Users opting to keep both applications may find their information
+        out of sync across the two.</li>
+      <li>Browsers will likely want to avoid any high-friction method such as
+        requiring the user to sign-in to use browser cloud syncing
+        functionality, if available.</li>
+    </ul>
+  </li>
+  <li>This is likely to lead to significant user confusion and frustration. Many
+    users are completely unaware that they are not using the “real” versions of popular browsers. This
+    is further complicated by Apple’s insistence (previously indefinitely, now for the next 6 months) that
+    browser vendors would not be able to port their browsers to iPad in the EU. Most users are not concerned with
+    what engine their browser uses, rather they are concerned with the features, stability, speed, security and
+    privacy, etc. that different browsers offer relative to each other.
+  </li>
+</ul>
+
+<p>
+  It is unlikely that a browser vendor
+  would do a major advertising campaign for the EU for their updated browser that would inadvertently highlight
+  the shortcomings of their WkWebView based browser to other large markets. While there is a high probability that
+  Apple will be forced to allow browser competition on iOS in most (if not all) jurisdictions in the future, it is
+  equally likely that there will be a multi-year lag. Browser vendors will not wish to lose market share with
+  their WkWebView based browsers in those jurisdictions while they wait for change.
+</p>
+
+<p>All of this is avoided if the browser vendor can simply update their existing
+  application.</p>
+
+<p>Hypothetically, if Apple were to update the technology powering the Apple TV app, they
+  would not force all their users to download and sign into a new app. They would simply silently update the
+  technology under the hood for all users, providing them a better product with no friction or user frustration. To
+  force browser vendors to have to ship a new app simply to update the underlying technology is both unreasonable
+  and anti-competitive. Particularly when allowing browser vendors to use their own engines for their browser is
+  directly compelled via the DMA.</p>
+
+<h4 id="potential-solutions">
+  <a class="header-anchor" href="#potential-solutions" aria-hidden="true">#</a>
+  3.1.3.1. Potential Solutions
+</h4>
+
+<p>There are a three potential solutions open to Apple including:</p>
+
+<ul>
+  <li><strong>Solution A.</strong> Allow Browser Engines Globally</li>
+  <li><strong>Solution B.</strong> Two Binaries for One Bundle ID</li>
+  <li><strong>Solution C.</strong> Global Dual Engine Binary with Toggle</li>
+</ul>
+
+<h5 id="solution-a-allow-browser-engines-globally">
+  <a class="header-anchor" href="#solution-a-allow-browser-engines-globally" aria-hidden="true">#</a>
+  3.1.3.1.1. Solution A - Allow Browser Engines Globally
+</h5>
+
+<p>Apple could allow browsers to compete fairly with their own engines globally. This is
+  the only option that would enable fair competition. <br><br>However we believe this is an unlikely option
+  since:</p>
+<ol>
+  <li>The DMA has no ability to impose extra-jurisdictional remedies, and
+    OWA is unaware of other legal mechanisms that could force this change.</li>
+  <li>Apple’s revenue from Safari is reportedly $20B USD per year,
+    an amount so significant that it’s unlikely Apple would willingly
+    enable competition unless
+    compelled.</li>
+  <li>Enabling browser competition on iOS globally in the provision of
+    features of Web Apps, will increase Web Apps ability to contest the
+    Apple’s app store which is a
+    significant source of revenue for Apple.</li>
+</ol>
+
+<p>The UK’s Competition and Markets Authority noted both of these potential motives
+  for Apple’s rule locking browsers to the WKWebView in their report.</p>
+
+
+<blockquote>
+  <p><strong class="stressed">
+      Apple receives significant revenue from Google by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially from high
+    usage of Safari. Safari has a strong advantage on iOS over other browsers
+    because it is pre-installed and set as
+    the default browser. The WebKit restriction may help to entrench this
+    position by limiting the scope for other
+    browsers on iOS to differentiate themselves from Safari (for example
+    being less able to accelerate the speed of
+    page loading and not being able to display videos in formats not supported
+    by WebKit). As a result, it is less
+    likely that users will choose other browsers over Safari, which in turn
+    secures Apple’s revenues from
+    Google.</p>
+  <p>Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via
+    Apple IAP. Apple therefore benefits from
+    higher usage of native apps on iOS. By requiring all browsers on iOS to
+    use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control over the maximum
+      functionality of all browsers on
+      iOS</strong> and, as a consequence, hold up the development and use of web apps. This
+    limits the <strong class="stressed">competitive constraint that web apps</strong>
+    pose on native apps,
+    which in turn protects and benefits Apple’s App Store revenues.
+  </p>
+
+  <p><cite>
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report&sa=D&source=editors&ust=1718648881316868&usg=AOvVaw0MbJ8M7tsg-0mKyIlffnKV">UK
+        CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite></p>
+</blockquote>
+
+<p>The reason we have included this as an option is that by providing it as the best and
+  most reasonable option from a competition point of view. It gives us a frame of reference for Apple’s other
+  options. The other options, while possibly legal, are still anti-competitive and place competing vendors under
+  significant burden.</p>
+
+<h5 id="solution-b-two-binaries-for-one-bundle-id">
+  <a class="header-anchor" href="#solution-b-two-binaries-for-one-bundle-id" aria-hidden="true">#</a>
+  3.1.3.1.2. Solution B - Two Binaries for One Bundle ID
+</h5>
+
+<p>Allow browser vendors to provide two signed binaries under one application (one bundle
+  id). These two binaries would be:</p>
+
+  <ul>
+    <li><strong>One -</strong> A signed binary which contains the real browser with its
+      own engine to ship to the EU and other jurisdictions that mandate Apple allow
+      browsers be able to choose and
+      modify their engine. This would need to include the ability to do A/B testing
+      with WKWebView outlined <a href="#must-not-use-browser-engine-of-operating-system">above</a>.
+    </li>
+    <li><strong>Two - </strong> A signed binary which contains the version of the
+      browser which is forced to use Apple’s WKWebView which can be shipped
+      in other jurisdictions.<br><br>An
+      update mechanism that can then toggle which binary to deliver based on
+      if the end user is an EU resident. This
+      would likely require some development work on Apple's part to update
+      their distribution mechanism and to
+      ensure that both binaries can continue to access user data.
+    </li>
+  </ul>
+
+  <p>One problem with this solution is the question of what happens when users become or
+    cease to be EU residents. This would necessitate a complex swap over procedure
+    by the browser vendors where local
+    storage data is copied from one version of the browser to another. This could
+    be a significant source of bugs.</p>
+
+  <h5 id="solution-c-global-dual-engine-binary-with-toggle">
+    <a class="header-anchor" href="#solution-c-global-dual-engine-binary-with-toggle" aria-hidden="true">#</a>
+    3.1.3.1.3. Solution C - Global Dual Engine Binary with Toggle
+  </h5>
+
+  <p>Allow browser vendors to ship a single binary globally which contains both the browser
+    vendor's own engine and the WKWebView version. For regulatory jurisdictions that haven’t yet forced
+    Apple to allow competition, the browser would use the WKWebView, and for those who have, the browser would use the
+    browser's own engine. Apple can indicate to the browser app whether they are allowed to use their own
+    engine, and based on that the browser could then decide if they wish to use their own engine. Likely only a
+    small technical change would be required for this solution to work. That is for Apple to provide some mechanism to
+    let browser vendors detect whether they can use their engine or not, as legally required. Aside from that this
+    would likely require no technical changes on Apple’s end, they would simply need to update their contracts
+    to allow it. In the event Apple is unwilling to develop such an API, Apple can simply update their contracts and
+    each browser vendor can detect whether a user is an EU resident to the best of their abilities using their own
+    mechanisms such as IP address.
+  </p>
+
+  <p>
+    The downside to this solution for browser vendors is that they would then be forced to
+    ship an additional 60 MB &nbsp;- 70 MB (OWA’s estimate) to many millions of users who would not be able to
+    use that engine due to Apple’s browser engine restrictions. This would then have an effect on user
+    acquisition and retention rates as well as those users’ data usage.
+  </p>
+
+  <p>We recommend that the Commission reach out to the vendors to ask their opinions, and
+    whether this solution would be feasible, if required to distribute a single global
+    binary.
+  </p>
+
+  <h4 id="c3-summary">
+    <a class="header-anchor" href="#c3-summary" aria-hidden="true">#</a>
+    3.1.3.2. Summary
+  </h4>
+
+  <p>It is not acceptable for Apple to use their mechanics of restricting browser engines to the EU to
+    suppress and undermine browser competition in the EU. If Apple can not be compelled to allow browser competition
+    globally on iOS, they should be compelled to make browser competition on iOS within the
+    EU <strong>at least</strong> minimally viable. The aim should be to allow third party browser
+    vendors to effectively contest Safari’s features, performance, security and privacy on a fair playing field.
+  </p>
+
+  <p>The commission does not need to force Apple to do anything outside of the EU. The
+    commission simply needs to compel Apple to allow browser vendors to update their existing browser apps for EU
+    customers to use their own engine, if Apple wishes to implement a complex solution to geolock that to the EU, that
+    is Apple’s choice, not the Commissions. Solutions A and Solution C are both straightforward ways in which
+    Apple could achieve a fairer result with minimal technical work.</p>
+
+  <h3 id="review-of-security-terms">
+    <a class="header-anchor" href="#review-of-security-terms" aria-hidden="true">#</a>
+    3.1.4. Review of Security Terms
+  </h3>
+
+  <h4 id="reasonable-security-clauses">
+    <a class="header-anchor" href="#reasonable-security-clauses" aria-hidden="true">#</a>
+    3.1.4.1. Reasonable Security Clauses
+  </h4>
+
+  <p>OWA would recommend asking each of the browser vendors their opinions on whether they
+    believe each security clause in Apple’s contract is reasonable or if any modifications should be made. The
+    following security clauses which Apple lists in their contract appear to be reasonable on our first review,
+    however OWA would need additional time to comprehensively analyze each of these conditions.
+  </p>
+
+  <blockquote>
+    <ol>
+      <li><strong class="alone">Secure Development, Supply Chain Monitoring &amp; Best
+          Practices</strong> <q>Commit to secure development processes, including
+          monitoring Your Application’s software supply chain for vulnerabilities, and following best practices
+          around secure software development (such as performing threat modeling on new features under
+          development)</q>;</li>
+      <li><strong class="alone">Vulnerability Submission Portal &amp; Policy</strong>
+        Provide a URL to a published vulnerability disclosure policy that includes contact information for
+        reporting of security vulnerabilities and issues to You by third parties (which may include Apple), what
+        information to provide in a report, and when to expect status updates;</li>
+      <li><strong class="alone">Timely Vulnerability Fixes</strong>
+        Commit
+        to mitigate vulnerabilities that are being exploited within Your Application or the Alternative Web Browser
+        Engine in a timely manner (e.g., 30 days for the simplest classes of vulnerabilities being actively
+        exploited);</li>
+      <li><strong class="alone">Publish Vulnerabilities</strong> Provide a
+        URL to a publicly available webpage (or pages) that provides information on which reported vulnerabilities have
+        been resolved in specific versions of the browser engine and associated Application version if
+        different;</li>
+      <li><strong class="alone">Root Certificate Policies</strong> If Your
+        Alternative Web Browser Engine uses a root certificate store that is not accessed via the iOS SDK, You must make
+        the root certificate policy publicly accessible and the owner of that policy must participate as a browser in
+        the Certification Authority/Browser Forum; </li>
+      <li><strong class="alone">Support Modern TLS</strong> Demonstrate
+        support for modern Transport Layer Security protocols to protect data-in-transit communications when the browser
+        engine is in use</li>
+      <li><strong>Memory Safe Languages OR Memory Safety Features</strong> Use memory-safe programming languages, or
+        features that improve memory safety within other
+        languages, within the Alternative Web Browser Engine at a minimum for all code that processes web
+        content;</li>
+      <li><strong class="alone">Latest Security Mitigations</strong>
+        Adopt
+        the latest security mitigations (for example, Pointer Authentication Codes) that remove classes of
+        vulnerabilities or make it much harder to develop an exploit chain;</li>
+      <li><strong class="alone">Best Security Practices</strong> Follow
+        secure design, and secure coding, best practices;</li>
+      <li><strong class="alone">Process Separation and Validate IPC</strong>
+        Use process separation to limit the effects of exploitation and validate inter-process communication
+        (IPC) within the Alternative Web Browser Engine;</li>
+      <li><strong class="alone">Supply Chain Vulnerability Monitoring </strong>
+        Monitor for vulnerabilities in any third-party software dependencies and the Your Alternative Web
+        Browser Engine App (EU)’s broader software supply chain, migrating to newer versions if a vulnerability
+        impacts Your Alternative Web Browser Engine App (EU);</li>
+      <li><strong>Don’t use Orphaned Software Libraries </strong>
+        Not use frameworks or software libraries that are no longer receiving security
+        updates in response to vulnerabilities.</li>
+    </ol>
+  </blockquote>
+
+  <p>These rules appear reasonable <strong>on the provision that Safari must equally
+      abide by them</strong>. For these rules, the current level of security of Safari and Apple's
+    native app ecosystem should be the benchmark. No browser should be penalized for doing a better job at security
+    than Apple's accepted status quo on iOS. </p>
+
+  <p>Apple attempted to claim to the UK’s CMA that WebKit’s security was
+    superior to that of Gecko and Blink, however the UK regulator found that Apple had no evidence to back up the
+    assertion. In Apple’s next response to the CMA they had dropped this claim.</p>
+
+  <blockquote>
+    <p>
+      ... in Apple's opinion, WebKit offers a better level of security
+      protection than Blink and Gecko.
+    </p>
+    <p>... the evidence that we have seen to date <strong class="stressed">does not
+        suggest</strong> that <strong class="stressed">there are material differences in the security
+        performance of WebKit and alternative browser engines</strong>.</p>
+    <p>Overall, the evidence we have received to date <strong class="stressed">does not
+        suggest that Apple's WebKit restriction allows for quicker and more effective response to security threats
+        for
+        dedicated browser apps on iOS</strong></p>
+    <p><cite><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report&sa=D&source=editors&ust=1718648881323727&usg=AOvVaw1wItvbQ1Je9Q3JkI-67aGA">UK
+          CMA - Interim Report into Mobile Ecosystems</a>
+        <br>(emphasis added)
+      </cite></p>
+  </blockquote>
+
+  <p>Both developers and users are already aware that installing a native app is more
+    dangerous than visiting a website, including if that app has passed a brief human “app review”.
+  </p>
+
+  <blockquote>
+    <p><strong class="stressed">The most dangerous feature that browsers have</strong>
+      are not the device API’s; it <strong class="stressed">
+        is the ability to link to and download native apps</strong>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/&sa=D&source=editors&ust=1718648881324812&usg=AOvVaw2sL7B3anF49FFINzlBGD5Z">
+          Niels Leenheer - HTML5test</a>
+        <br>(emphasis added)
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>Apple strongly relies on app store review as a mechanism to protect users from iOSs weaker
+    sandbox for Native Apps. Apple has placed great trust in “app review”, despite the fact they
+    reportedly only employ a
+    <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/2021/9/3/22654197/apple-app-store-editorial-scams-refunds&sa=D&source=editors&ust=1718648881325405&usg=AOvVaw1LOd-cVMGn8IJrs-XrKV4L">mere
+      500 reviewers</a>. These reviewers are expected to review 100,000+ Native Apps per week,
+    without the benefit of access to source code. While they are assisted by automated tools, each reviewer gets less
+    than 15 minutes to manually tap through apps, a process which is unlikely to be effective at picking up many types
+    of malicious apps.
+  </p>
+
+  <p>It doesn’t even appear to be effective in picking up apps that violate Apple’s payment
+    rules (that grant it a 15-30% stake), something they are likely to want to enforce. In one particularly striking
+    example of app review being ineffective at blocking updates that violate the current rules of the Apple’s
+    app store, Epic managed to <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://appleinsider.com/articles/20/08/13/epic-skirts-apples-30-commission-fee-by-implementing-direct-payments&sa=D&source=editors&ust=1718648881325903&usg=AOvVaw3-ON3mUJ8u47X62grvpCgZ">
+      slip in an entire third party payment solution</a> into their app without it being
+    picked up in review.</p>
+
+  <p>As Apple’s head of fraud <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/%23document/p1&sa=D&source=editors&ust=1718648881326439&usg=AOvVaw0GfUIzG04QW5vA4X2yAY4m">
+      Eric Friedman</a> said regarding review processes: </p>
+
+  <blockquote>
+    <p>please don’t ever believe that they accomplish
+      anything that would deter a sophisticated hacker.
+    </p>
+    <p>I consider them a wetware rate limiting service and nothing more</p>
+
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/%23document/p1&sa=D&source=editors&ust=1718648881327117&usg=AOvVaw1Ec3Iuo5AQkXt6ICujaCiG">
+          Eric Friedman - Apple’s former head of fraud on App Store Review</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>This suggests that while Apple outwardly projects confidence in the value of their app
+    store review some informed insiders view it as worthless. </p>
+
+  <p>Browsers use a far more reliable form of security than brief human review upon update.
+    They lockdown the entire environment that the third party code, that is websites and Web Apps, runs in. This
+    environment is called a sandbox and every action a website takes is tightly controlled. Even Apple acknowledges
+    that browsers sandbox is massively superior to iOS’s sandbox for native apps:</p>
+
+  <blockquote>
+    <p>WebKit’s sandbox profile on iOS is orders of magnitude more
+      stringent than the sandbox for native iOS apps.”</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf&sa=D&source=editors&ust=1718648881328155&usg=AOvVaw2hKr-aSR5tg7Dxtmif_g8G">
+          Apple’s Response to the CMA’s Mobile Ecosystems Market Study Interim Report</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>Thus while we agree that the standard browsers should be held to a higher standard than
+    that of a typical native app, it is critical that any security threat that browsers face be viewed holistically
+    and not in isolation. That is, were the user forced to install a native app to use that functionality, instead of
+    using a website or Web App what would their relative risk be. Would it be significantly better or worse.
+  </p>
+
+  <p>For example, if a browser implements a relatively secure, but not perfect,
+    implementation of WebBluetooth, then its level of security should be compared to the current accepted level of
+    security for native iOS apps that iOS already meets in their own CoreBluetooth implementation, not the
+    hypothetical perfect security that Safari's non-existent WebBluetooth implementation would like to
+    obtain.</p>
+
+  <p>Security is a subtle art and many of these rules are by necessity subjective. For
+    example “best practices” is no doubt a subject of fierce disagreement on certain points. As such,
+    Apple should only be able to focus on points where there is broad agreement in the industry that certain practices
+    are categorically and unambiguously bad.</p>
+
+  <p>Any complaint by Apple based on violation of these rules should be necessary,
+    reasonable, proportionate and justified with extensive evidence by Apple.</p>
+
+  <p>In some cases there may be more than one method to mitigate a threat and browser
+    engines’ very design may dictate how a browser defends against a particular threat. It is important
+    therefore that Apple’s rules do not force browsers to mitigate each threat in specific ways but rather focus
+    on the degree to which each browser has effectively mitigated a threat. In some cases there will be broad
+    agreement between browsers on how to mitigate particular threats, and in those cases the rules can be more
+    specific.</p>
+
+  <p>Apple should be very specific about which rule has been broken and its evidence for why
+    it believes that is the case. Apple’s current app review approach where apps are rejected without citing
+    specific rules or clearly outlining why, is unacceptable here.</p>
+
+  <p>Browser vendors should be consulted on each individual rule to see if they jointly
+    agree that all the conditions are reasonable before settling on the final list.</p>
+
+  <h4 id="problematic-security-clauses">
+    <a class="header-anchor" href="#problematic-security-clauses" aria-hidden="true">#</a>
+    3.1.4.2. Problematic Security Clauses
+  </h4>
+
+  <p>The following security terms in the contract are problematic:</p>
+
+  <h5 id="vulnerabilities-in-browser-apis">
+    <a class="header-anchor" href="#vulnerabilities-in-browser-apis" aria-hidden="true">#</a>
+    3.1.4.2.1. Vulnerabilities in Browser APIs
+  </h5>
+
+  <blockquote>
+    <p>Prioritize resolving reported vulnerabilities with expedience, over new
+      feature development. For example, where the Alternative Web Browser Engine bridges capabilities between the
+      platform’s SDK and web content to enable Web APIs, upon request the developer must remove support for such
+      a
+      Web API if it is identified to present a vulnerability. Most vulnerabilities should be resolved in 30 days, but
+      some may be more complex and may take longer.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881330441&usg=AOvVaw0la_jg3x_eODxXYnvCuoJY">Apple’s
+          Browser Entitlement Contract</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>What Apple is saying here, is that if an API has a vulnerability, no matter how minor
+    and no matter how much effort the browser vendor has taken to mitigate the vulnerability, Apple can demand that
+    they remove the browser API. This is not reasonable, proportionate, strictly necessary and Apple is not offering
+    to justify its decisions. All APIs contain the potential for vulnerabilities. Further, Apple would never accept an
+    equivalent clause for its own apps or browser. </p>
+
+  <p>This is particularly important as the primary reason that the DMA grants browsers the
+    right to use their own browser engine is to prevent gatekeepers (such as Apple) from determining the functionality
+    and standards for third-party browsers. Allowing Apple to ban third-party browsers from offering functionality on
+    flimsy (or non-existent) security justifications would severely undermine this goal.</p>
+
+  <p>This appears to grant Apple broad powers to use unnecessary and disproportionate
+    security measures to block rival browsers from providing functionality that is distinct from Safari, preventing
+    one of the core aims of the act in allowing browser vendors to port their own engines. It is critical that
+    browsers are allowed to bring functionality to enable browsers and Web Apps to compete with the software and
+    services of the gatekeepers including their native app ecosystems. If Apple is allowed to block functionality then
+    it will prevent this competition. Apple should not be able to impose any security rules that would outright
+    preclude browser vendors from porting such functionality, especially when considering that 5(7) does not have any
+    security carve-outs.</p>
+
+  <p>Additionally, in general, under 6(7), security terms which are not strictly necessary
+    or proportionate must be removed or be modified to be in compliance with the act.</p>
+
+  <p>There is always a trade off between security and utility. The safest browser would be
+    one that refuses to open. The key here for browser vendors is to offer as much security as reasonably possible for
+    their chosen level of utility. No browser should be compelled to reduce utility in the name of security if they
+    have taken firm efforts to mitigate risks.</p>
+
+
+  <h5 id="vulnerability-disclosure">
+    <a class="header-anchor" href="#vulnerability-disclosure" aria-hidden="true">#</a>
+    3.1.4.2.2. Vulnerability Disclosure
+  </h5>
+
+  <p>Apple states that all browser vendors must publish a vulnerability disclosure policy
+    and publicly state which reported vulnerabilities have been resolved in specific versions
+    of the browser engine and associated Application version if different.</p>
+
+  <blockquote>
+    <p>Provide a URL to a published vulnerability disclosure policy that includes
+      contact information for reporting of security vulnerabilities and issues to
+      You by third parties (which may
+      include Apple), what information to provide in a report, and when to expect
+      status updates;</p>
+    <p>…</p>
+    <p>Provide a URL to a publicly available webpage (or pages) that provides information
+      on which reported vulnerabilities have been resolved in specific versions of the browser engine and associated
+      Application version if different</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881332611&usg=AOvVaw28a2cC9N1Zn0s6lZmZW2aA">
+          Apple’s Browser Entitlement Contract</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>We believe this is reasonable on the proviso that Apple also abides by it when
+    publishing updates to Safari. Safari should not have any privileged status with regards to which security
+    vulnerabilities it publishes or the manner in which it publishes them. An obligation for competitors to publish
+    security vulnerabilities while exempting Apple from the same obligation would provide a significant unfair
+    competitive advantage to Apple. </p>
+
+  <p>One example of this Apple failing to adequately warn users of a
+    vulnerability or breach is the <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/&sa=D&source=editors&ust=1718648881333936&usg=AOvVaw0orQMFSYrABh-jhIggE7pN">
+      xCodeGhost iOS malware</a>. </p>
+
+  <p>Documents revealed as part of the current trial of Fortnite vs Apple show that in fact
+    128 million users downloaded the more than 2,500 infected apps, about two thirds of these in China. Popular apps
+    such as WeChat, Didi Chuxing, and Angry Birds 2, among others, were infected by XcodeGhost. These are some of the
+    largest native Apps in the world, being the equivalents of Facebook and Uber in China. WeChat, for example, has
+    1.24 billion users.</p>
+
+  <p>Apple discussed contacting users and briefly made an announcement on their China
+    website. Shortly after, it was removed. To our knowledge, Apple never contacted users to inform them of the
+    breach.</p>
+
+  <blockquote>
+    <p><strong class="stressed">this decision to not notify more than 100 million
+        users</strong> about potential security issues seems to <strong class="stressed">
+        have more to
+        do with protecting the platform’s reputation</strong> than helping users stay
+      safe</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/&sa=D&source=editors&ust=1718648881335296&usg=AOvVaw1J_1BGlANU-ml3i4mkB9ej">
+          Kirk McElhearn - Intego</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>The security of iPhones is one of Apple’s key marketing claims.
+    According to
+    <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881335815&usg=AOvVaw2HNrWblPzFpJA9YqG0nbCz">
+      two dozen security researchers</a>, who spoke on the condition of anonymity, Facebook,
+    Microsoft and Google all publicize their bug-bounty programs and take every opportunity to acknowledge and thank
+    those that find bugs and vulnerabilities sharing valuable insights, weaknesses and solutions. In contrast, Apple
+    conducts its programs in secrecy.
+  </p>
+
+  <p>Apple reportedly has a considerable bug backlog:</p>
+
+  <blockquote>
+    <p>You have to have a healthy internal bug fixing mechanism before you can
+      attempt to have a healthy bug vulnerability disclosure program. What do you expect is going to happen if they
+      report a bug that you already knew about but haven’t fixed? Or if they report something that takes you 500
+      days to fix it?</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881336537&usg=AOvVaw1BxLt0pQEOZekxIt3QNpQ5">
+          Moussouris - Helped create Microsoft's Bug Bounty Program</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>It seems like Apple thinks people reporting bugs are annoying and they want
+      to discourage people from doing so</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881337100&usg=AOvVaw2By_5WMhl3ASlln6lPhfGN">
+          Tian Zhang - an iOS software engineer</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>Apple’s closed-off approach hinders its security efforts</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881337618&usg=AOvVaw1OAx2GKYtJQlSip2_0Eq6v">
+          Dave Aitel - co-author of “The Hacker’s Handbook</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>Apple is slow to fix reported bugs and does not always pay hackers what they
+      believe they’re owed. Ultimately, they say, Apple’s insular culture has hurt the program and created
+      a
+      blind spot on security.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/&sa=D&source=editors&ust=1718648881338118&usg=AOvVaw2r1axOx40q9aItYViHoBAz">
+          Reed Albergotti - Washington Post</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <blockquote>
+    <p>I want to share my frustrating experience participating in Apple Security
+      Bounty program. I've reported four 0-day vulnerabilities this year between March 10 and May 4, as of now
+      three
+      of them are still present in the latest iOS version (15.0) and one was fixed in 14.7, but Apple decided to cover
+      it up and not list it on the security content page. When I confronted them, they apologized, assured me it
+      happened due to a processing issue and promised to list it on the security content page of the next update.
+      There
+      were three releases since then and they broke their promise each time.</p>
+    <p>
+      <cite>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://habr.com/en/post/579714/&sa=D&source=editors&ust=1718648881338629&usg=AOvVaw2U0guBzjJqVM3VzRoLBYiN">
+          Denis Tokarev</a>
+      </cite>
+    </p>
+  </blockquote>
+
+  <p>If Apple can avoid full disclosure while compelling other vendors to, Apple may use
+    these disclosures to falsely claim superior security or create a pretense for delisting other browsers from its
+    app store. We recommend keeping this policy with the caveat that it also applies equally to Apple’s own
+    browser.</p>
+    <p>We also believe that non-disclosure agreements, which entirely prohibit security researchers from
+      publishing their findings (once a reasonable number of days has elapsed, for example
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html%23:~:text%3D%2522This%2520bug%2520is%2520subject%2520to%2520a%252090%2520day%2520disclosure%2520deadline.%2520If%2520a%2520fix%2520for%2520this%2520issue%2520is%2520made%2520available%2520to%2520users%2520before%2520the%2520end%2520of%2520the%252090%252Dday%2520deadline%252C%2520this%2520bug%2520report%2520will%2520become%2520public%252030%2520days%2520after%2520the%2520fix%2520was%2520made%2520available.%2520Otherwise%252C%2520this%2520bug%2520report%2520will%2520become%2520public%2520at%2520the%2520deadline.%2522&sa=D&source=editors&ust=1718648881339306&usg=AOvVaw0tcALn0tWSkb8uh8HYZ8hU">
+        Google Project Zero uses the shorter of 90 days or 30 days after patched</a>) after reporting
+      them to a particular browser vendor (such as Apple) should be prohibited, particularly if the browser vendor has
+      declined to fix these exploits. The ultimate aim here is to improve security by removing the ability of parties
+      to
+      hide both fixed and unfixed exploits from the public and tech community. This applies great pressure to increase
+      investment in security.
+    </p>
+
+    <h3 id="lack-of-justification-of-security-terms">
+      <a class="header-anchor" href="#lack-of-justification-of-security-terms" aria-hidden="true">#</a>
+      3.1.5. Lack of Justification of Security Terms (and Non-Security Terms)
+    </h3>
+
+    <blockquote>
+      <p>A gatekeeper can use different means to favour its own or third-party
+        services or products on its operating system, virtual assistant or web browser, to the detriment of the same
+        or
+        similar services that end users could obtain through other third parties.</p>
+      <p><cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881340240&usg=AOvVaw1x3ePSmnN34p8vpZqMHVGJ">
+            Digital Markets Act - Recital 49</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>One potential mechanism for favoring their own services is blocking competitors with
+      unnecessary and disproportionate security measures. As alleged in the USA Department of Justice’s (DOJ)
+      complaint, Apple has a history of using security rules inconsistently to serve their own financial
+      interests.</p>
+
+    <blockquote>
+      <p>In the end, Apple deploys privacy and security justifications as an elastic
+        shield that can stretch or contract to serve Apple’s financial and
+        business interests.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881341096&usg=AOvVaw3ROuLQRUpO40aOjRFCvTAs">
+            DOJ Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Although 5(7) does not contain carve-outs for security measures, we believe that it
+      would be proportional under the act to require browsers to meet security standards providing it doesn’t
+      prevent the browsers from porting their engines, and prevent them from implementing functionality. The language
+      under Article 6(7) of the DMA states that Apple must duly justify any security measures, which Apple should do
+      for
+      5(7).</p>
+
+    <p>Apple has not attempted to provide any justification to any of the rules in their
+      browser entitlement contract or rules found in documents or contracts it pulls in under "Apple
+      Materials''. We believe that Apple should be required to provide very detailed security justifications
+      for
+      each individual rule attached to obtaining this API access; Why is it strictly necessary and proportionate to
+      prevent this access from compromising the integrity of the operating system, hardware or software features
+      provided by Apple as per the wording and intent of the act.</p>
+
+    <p>It is important that Apple publicly publish these justifications so that they can be
+      scrutinized by the browser development and developer community to make sure that Apple is not attempting to use
+      security rules to undermine either the DMA or competition to their benefit, nor to EU consumers and business
+      users' detriment. This will allow the browser development and developer community to provide evidence and
+      feedback as to if each rule is reasonable and whether Apple's explanation as to its necessity and
+      proportionality are credible.</p>
+
+    <p>We support Apple having the ability to remove browsers that are either malicious or
+      consistently fail to meet a reasonable security standard clearly laid out in the rules (i.e patching regularly,
+      fixing vulnerabilities in a timely fashion, etc). However, we believe Apple should need to prove any allegations
+      with evidence and should face consequences for frivolous or unjustified removal of browsers.</p>
+
+    <h3 id="viral-terms">
+      <a class="header-anchor" href="#viral-terms" aria-hidden="true">#</a>
+      3.1.6. Viral Terms
+    </h3>
+
+    <p>Apple appears to conflate other rules and terms into their contract for API access via
+      the term “Apple Materials”. </p>
+
+    <p>It is defined in the contract as:</p>
+
+    <blockquote>
+      <p>&lsquo;Apple Materials&rsquo; means the Documentation, Entitlement
+        Profile, and other materials provided by Apple to You, and which are incorporated by reference into the
+        requirements of this Addendum.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881342877&usg=AOvVaw0Hy8FnBC8A_1g-H0mf1CHX">
+            Apple’s Browser Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is a frustratingly vague term. </p>
+
+    <p>Apple also state in the contract that they can not guarantee the availability,
+      completeness, or accuracy of Apple Materials. Given this term encompasses all potential rules the browser vendor
+      must abide by it is critical that these are available, clear, complete and accurate. Browser vendors (and likely
+      regulators) should be made aware of any plan to update them well in advance. Changes should be then subject to
+      scrutiny by the Commission, browser vendors and third parties such as OWA.</p>
+
+    <p>From their definition, it appears to encompass all documentation related to third-party browser
+      engines, any documentation those documents reference,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881343684&usg=AOvVaw204j-5Q8r67EPfVBmVnEJI">
+        the Apple Developer Program License Agreement</a> and the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/&sa=D&source=editors&ust=1718648881343943&usg=AOvVaw3_VI4MzGo0bfnX-gYJ0CSB">
+        Apple App Store Review Guidelines</a>.
+    </p>
+
+    <p>Further, the contract explicitly states on multiple occasions that signing and abiding by the
+      terms in Apple Developer Program License Agreement is required to use these APIs, indeed this contract is
+      structured as an addendum to the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881344392&usg=AOvVaw19-W8q7lywCR4eMttGNnwD">
+        Apple Developer Program License Agreement</a>.
+    </p>
+
+    <p>These combined documents contain a vast number of non-security terms and are
+      inappropriately referenced in the context of a browser that is not distributed via Apple’s app
+      store.
+    </p>
+
+    <p>As such these viral terms must be removed and Apple should clearly present all security
+      rules that they wish third-party browser vendors to abide by in order to access APIs necessary for building iOS
+      browsers.</p>
+
+    <h3 id="conflated-terms">
+      <a class="header-anchor" href="#conflated-terms" aria-hidden="true">#</a>
+      3.1.7. Conflated Terms
+    </h3>
+
+    <p>Again “Apple Materials” is problematic as it conflates together various
+      concepts that need to be separate.</p>
+
+    <p>It is defined in the contract as:</p>
+
+    <blockquote>
+      <p><span>‘Apple Materials’ means the Documentation, Entitlement
+          Profile, and other materials provided by Apple to You, and which are incorporated by reference into the
+          requirements of this Addendum.</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881345475&usg=AOvVaw3JXUhm1g0QF9LlJHx9uZJi">
+            Apple’s Browser Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Specifically this means Apple Materials includes:</p>
+    <ul>
+      <li>All documentation for the APIs</li>
+      <li>The nature of how these APIs function and whether they exist</li>
+      <li>All rules the browser vendor has to abide by</li>
+      <li>Additional contractual terms</li>
+      <li>Any other document referenced</li>
+    </ul>
+
+    <p>Specifically out of these, the rules which browser vendors need to abide by (which the
+      act mandates can only be security rules) need to be separated out into their own term and in a single document
+      which is available, clear, complete, accurate and up to date.</p>
+
+    <h3 id="hard-to-know-if-in-compliance">
+      <a class="header-anchor" href="#hard-to-know-if-in-compliance" aria-hidden="true">#</a>
+      3.1.8. Hard to Know if in Compliance
+    </h3>
+
+    <p>Even ignoring Apple's insertion of non-security rules into its API contract, the fact that
+      rules could be hidden in any of a vast range of non-explicitly defined documents,
+      that <a href="#viral-terms">by Apple's own admission</a> may be incomplete or
+      inaccurate and which they can change at any time without notification, means that staying in compliance becomes
+      a
+      fraught and unpredictable task for even the most diligent and security conscious of browser vendors. Even
+      browser
+      vendors with security significantly superior to Safari in all aspects could not be confident of being in
+      compliance when the existing rules are unclear and changes in compliance requirements are not telegraphed in
+      advance</p>
+
+    <p>This is clearly not strictly necessary, reasonable or proportionate.</p>
+
+    <h3 id="severe-and-unreasonable-penalties">
+      <a class="header-anchor" href="#severe-and-unreasonable-penalties" aria-hidden="true">#</a>
+      3.1.9. Severe and Unreasonable Penalties
+    </h3>
+
+    <p>Apple's Browser Engine API contract contains the following clause:</p>
+
+    <blockquote>
+      <p>2.9 While in no way limiting Apple’s other rights under
+        this Addendum or the Developer Agreement, or any other
+        remedies at law or equity, <strong>if Apple has reason to believe </strong>
+        You or Your Alternative Web Browser Engine App (EU) have
+        <strong>failed to comply with the requirements</strong> of this <strong>Addendum</strong>
+        or the <strong class="stressed">Developer Agreement</strong>, Apple
+        <strong>reserves the right to
+          revoke to Your access to any or all of the Alternative
+          Web Browser Engine APIs</strong> immediately upon notice to You;
+        require You to remove Your Entitlement Profile from Your
+        Alternative Web Browser Engine Application (EU); <strong>terminate
+          this Addendum; block updates of, hide, or remove Your
+          Alternative Web Browser Engine App (EU) and/or other
+          Applications from the App Store; block Your Applications
+          from distribution on Apple platforms; and/or to suspend or
+          remove You from the Apple Developer Program</strong>.
+      </p>
+      <p><cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881348084&usg=AOvVaw0pX-RMfm6LUKyfV85KK4M2">
+            Apple’s Browser Engine Entitlement Contract</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>That is, if Apple believes (note, Apple is not placing any burden of proof on itself
+      here) that any rule has been broken in either this contract or in the developer agreement then they grant
+      themselves the right to:</p>
+
+    <ul>
+      <li>Revoke access to the APIs</li>
+      <li>Remove the browser engine entitlement from the browser</li>
+      <li>Block updates or remove the browsers</li>
+      <li>Block other applications the browser vendor distributes on Apple
+        platforms</li>
+      <li>Suspend or remove the developer from the Apple developer
+        program</li>
+    </ul>
+
+    <p>Given the inherent vagueness of the rules that Apple is imposing here and Apple's long history
+      of being a <a href="#direct-browser-installation">poor and self-serving judge of the
+        implementation of those rules</a> this is an extremely threatening clause even to browser
+      vendors who are competently doing an appropriate job of <q>protecting the
+        integrity of the operating system, software and hardware of the gatekeeper</q>.</p>
+
+    <p>This is not strictly necessary, proportionate or reasonable.</p>
+
+    <p>While we support Apple's right to revoke access in cases of persistent negligence
+      or significant and provable malice, this clause as it currently stands, will allow Apple to strategically and
+      anti-competitively bully browser vendors over non-existant or minor edge cases.</p>
+
+    <p>For example, as this rule stands, if Mozilla were to violate a non-security rule related to
+      scrolling logic buried in a recently updated document on Apple's components, then under Apple’s
+      contract, they would be able to block and remove Firefox from all Apple platforms including macOS. While we
+      think
+      this exact scenario is unlikely due to the regulatory scrutiny it would bring, it does highlight the power Apple
+      is granting itself though this contract and how it subverts the intent of the DMA that the rules for API access
+      be
+      only security rules which are strictly necessary, proportionate and duly justified for
+      <i><q>protecting the integrity of the operating system, software and hardware of the
+        gatekeeper</q></i>.
+    </p>
+
+
+    <p>We believe this clause should be updated with language that impresses the necessity and
+      proportionality of any response by Apple and place a burden on Apple to justify with evidence any punitive
+      action
+      it might take against any browser vendor.</p>
+
+    <h3 id="requirement-to-use-apple-components">
+      <a class="header-anchor" href="#severe-and-unreasonable-penalties" aria-hidden="true">#</a>
+      3.1.10. Requirement to use Apple Components
+    </h3>
+
+    <p>In Apple's browser engine entitlement contract they appear to obligate browser
+      vendors to use iOS user interface libraries, rather than their own already built into Gecko and Blink.</p>
+
+    <p>In their documentation for BrowserEngineKit they state:</p>
+
+    <blockquote>
+      <p>To correctly render CSS and manipulate the Javascript DOM, your browser app
+        needs to integrate closely with UIKit and customize the way it handles many low-level user interface events.
+        Use
+        view classes in BrowserEngineKit to handle scrolling, drag interactions, and the context menu in your browser
+        app.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/BrowserEngineKit&sa=D&source=editors&ust=1718648881350509&usg=AOvVaw02E5Gy3LV491m305GhM1U8">
+            Apple Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This becomes a rule and not a suggestion due to this clause in the contract:</p>
+
+    <blockquote>
+      <p><strong class="stressed">You agree to use</strong>, only
+        through the use of the Entitlement Profile, <strong class="stressed">
+          an Alternative Web Browser Engine</strong>
+        in Your Alternative Web Browser Engine App (EU) <strong class="stressed">only as expressly
+          permitted</strong> in this Addendum and in the <strong class="stressed">Apple
+          Materials</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881351361&usg=AOvVaw2BVtxLot8HRji-B7mpK-IQ">
+            Apple Browser Engine Entitlement Contract</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>As discussed before, "Apple Materials" is a disconcertingly vague and broad
+      term that in effect means any imperative statement in any documentation referenced from the contract or
+      referenced
+      from those documents in a cascade are considered binding rules.</p>
+
+    <p>This is critical for two reasons. One, it means significant re-architecture of
+      third-party browsers' engines. This is highlighted in this ticket from Google:</p>
+
+    <blockquote>
+      <p>It's not entirely clear, but this seems to imply that existing browser
+        rendering engines must be re-architected to fit the UIKit rendering model. Chromium has a large and
+        sophisticated
+        rendering architecture which is designed to be platform-agnostic, rather than rely on
+        operating-system-specific
+        details such as the OS compositing architecture. As such, complex behaviour like scrolling is implemented
+        nearly
+        identically across all non-iOS Chrome platforms including Windows, MacOS, Android, Linux and ChromeOS. Using
+        an
+        operating-system provided scrolling / compositing architecture is infeasible for Chromium both because of the
+        huge
+        engineering expense and also because it would result in a worse product
+        in some ways.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/OpenWebAdvocacy/OpenWebCompetitionPlatform/issues/11&sa=D&source=editors&ust=1718648881352498&usg=AOvVaw11u68tQPCgUpow9rzneiEB">
+            Rick Byers - Web Platform Area Tech Lead, Chrome - Open Web Competition Platform</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The second, is that it is in the implementation of these very user interface libraries
+      that a not insignificant proportion of browser competition lies.</p>
+
+    <p>Scrolling is a good example. Apple's implementation for scroll on iOS Safari has
+      been riddled with bugs for any Web App that is attempting more 'app-like' layouts, that is ones where
+      part
+      of the page scrolls vertically rather than the entire page scrolling vertically.</p>
+
+    <blockquote>
+      <p>For more than 6 years, one of the biggest issues Web Developers have had to
+        deal with in Safari and other WebKit-based browsers on iOS (and in a lesser extent on macOS), is the inability
+        to
+        reliably block body scroll, or, said in other words, to remove the ability to scroll the current page in
+        certain
+        situations.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/web-platform-tests/interop/issues/84&sa=D&source=editors&ust=1718648881353339&usg=AOvVaw0ppLky7nKRBgIMlhZ1IORp">
+            OWA - Proposed Interop Issue</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple appears unable or unwilling to fix these bugs, despite identical functionality
+      working in almost every other browser for years. This has likely been prolonged by the complete lack of browser
+      competition on iOS to apply pressure to fix these bugs or risk losing market share.</p>
+
+    <p>Finally, Apple is only allowed to apply security rules in their API contract under
+      Article 6(7), but even if they were to move these rules to their app store guidelines, they should still be
+      struck
+      out under Article 5(7), and Article 13(4) for preventing browsers from porting significant and key parts of
+      their
+      engines.</p>
+
+    <p>It is essential that Apple does not constrain browsers from competing and bringing
+      their full rendering stack (the rendering stack is the collection of libraries responsible for converting html,
+      css and JavaScript into the displaying and updating the actual pixels on the screen inside the area controlled
+      by
+      the browser). Browser vendors should have the right, but not the obligation, to use these iOS provided user
+      interface libraries and components as appropriate to their needs.</p>
+
+    <p>This does not require Apple to make any technical changes. They simply have to update
+      their contracts and associated documentation. Apple may state they do not intend to enforce these rules in their
+      contract, but this is a misleading stance. Apple should not assert it has rights that are prohibited by the
+      DMA.</p>
+
+    <h3 id="privacy">
+      <a class="header-anchor" href="#privacy" aria-hidden="true">#</a>
+      3.1.11. Privacy
+    </h3>
+
+    <p>Apple is only allowed to apply strictly necessary, proportionate and duly justified for
+      <q>protecting the integrity of the operating system, software and hardware of the
+        gatekeeper</q> on API access.
+    </p>
+
+    <p>While improving privacy is a laudable goal, we have three concerns with Apple's
+      privacy section in their browser entitlement contract:</p>
+
+    <ol>
+      <li>The browser entitlement contract is the wrong place to include these
+        clauses as the DMA requires this to be limited to strictly necessary, proportionate and justified security
+        related rules. All of these rules, at a minimum, will need to be moved to the app store guidelines.</li>
+      <li>We are concerned that Apple may have weak or unenforced privacy rules for both
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://techcrunch.com/2023/07/25/apple-att-antitrust-france/&sa=D&source=editors&ust=1718648881355020&usg=AOvVaw3roi0e63FwvYxnUtDqMkfr">
+          its own apps</a> and
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/&sa=D&source=editors&ust=1718648881355366&usg=AOvVaw28ayu92dUxylCb2o_ML1og">
+          apps distributed by its app store</a> —
+        But extremely strong rules for browsers and
+        Web Apps. This will create pressure for apps that are based on advertising to be distributed via Apple’s
+        app store instead of the open web, as the former offers expanded access and weaker privacy protection for
+        consumers.
+      </li>
+      <li>Any privacy rule in the app store guidelines must not, in effect, ban any of
+        the existing major browsers from being ported, and thus contravene Article 5(7). Currently this would likely
+        only impact Chrome. Chrome is in the process of phasing out third-party cookies
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/&sa=D&source=editors&ust=1718648881355994&usg=AOvVaw28RITYOAtO7qbGHBDcZ5wI">
+          but has halted this while the UK's Competition and Market Authority reviews this
+          change</a>. The CMA is concerned that the phase out of third-party cookies in Chrome and replacement with
+        privacy sandbox will reduce competition in advertising. Apple must not apply any rule, that combined with this
+        fact, would de facto ban Google from porting its browser to iOS. While as an organization we can see the
+        privacy
+        benefits of the phase out of third-party cookies and support it, it can not be used as a tool to block
+        competitors from iOS. We would also be concerned at any attempt to fragment the functionality of browsers from
+        jurisdiction to jurisdiction.
+      </li>
+    </ol>
+
+    <blockquote>
+      <p>The CMA clarified that raising these concerns does not imply a belief that
+        the Privacy Sandbox changes cannot proceed. However, it signals the necessity for further resolutions before
+        moving forward.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/&sa=D&source=editors&ust=1718648881356948&usg=AOvVaw0RgC9iV-EQnPj9l_YxQvkp">
+            UK’s CMA Raises Concerns, May Delay Google’s Third-Party Cookie Phase-Out</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The CMA’s preliminary view is that Google is likely to have been aware
+        that these announcements, including the setting of a two-year deadline for deprecating TPCs, would adversely
+        affect market participants and reduce competition. For example, studies cited by Google in the announcement of
+        22
+        August 2019 suggested that when advertising is made less relevant by removing TPCs, funding for publishers
+        falls
+        by 52% on average.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62052c52e90e077f7881c975/Google_Sandbox_.pdf&sa=D&source=editors&ust=1718648881357849&usg=AOvVaw1it1Tv2dVz0SXIxu1Ml79e">CMA
+            on Privacy Sandbox</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>We also note that Apple intends to apply privacy rules to apps that are not distributed
+      by their app store but are signed/notarized by them. OWA considers Apple’s proposed notarization system
+      for
+      third party apps to be App Store Review, in all but name. Again while improving privacy is a laudable goal, we
+      are
+      concerned at the power this allows Apple to indiscriminately wield over apps that are not delivered though their
+      app store. This is strictly prohibited by the DMA as the security carve outs in both 6(4) and 6(7) are both
+      fairly
+      narrowly scooped.</p>
+
+    <p>The appropriate way for this issue to be dealt with is not to place this power in Apple's
+      hands. Apple has a long and proven history of bending its own rules to act in its own financial interests even
+      when that weakens or harms user privacy. Apple has also been shown to have
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/&sa=D&source=editors&ust=1718648881358772&usg=AOvVaw11PxJypjtY0q7-3ktT05dg">
+        dubious policies when it comes to their own employees' own privacy</a>. Apple is not a
+      trusted arbiter of privacy.
+    </p>
+
+    <blockquote>
+      <p>
+        In the end, Apple deploys privacy and security justifications as an
+        elastic shield that can stretch or contract to serve Apple’s financial and
+        business interests.
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+            DOJ Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>
+        Apple has a tactical commitment to your privacy, not a moral one. When it comes down to guarding your privacy
+        or losing access to
+        Chinese markets and manufacturing, your privacy is jettisoned without a second thought.
+        <cite>
+          <a href="">
+            Cory Doctorow - Former European director of the Electronic Frontier Foundation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>
+        Tim Cook, Apple’s chief executive, has said the data is safe. But at the data center in Guiyang, which Apple
+        hoped would be completed by next month, and another in the Inner
+        Mongolia region, <strong class="stressed">
+          Apple has largely ceded control to the Chinese government</strong>.
+      </p>
+      <p>
+        Chinese state employees physically manage the computers. Apple abandoned the encryption technology it used
+        elsewhere after China would not allow it. And the digital keys that unlock
+        information on those computers are stored in the data centers they’re meant to secure.
+      </p>
+      <p>[...]</p>
+      <p>
+        Apple has tried to isolate the Chinese servers from the
+        rest of its iCloud network, according to the documents.
+        The Chinese network would be “established, managed, and
+        monitored separately from all other networks, with no
+        means of traversing to other networks out of country.”
+        <strong class="stressed">
+          Two Apple engineers said the measure was to prevent security
+          breaches in China from spreading to the rest of Apple’s
+          data centers</strong>.
+      </p>
+      <p>
+        <strong class="stressed">Apple said that it sequestered the Chinese data centers
+          because they are, in effect, owned by the Chinese
+          government</strong>, and Apple keeps all third parties disconnected
+        from its internal network.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2021/05/17/technology/apple-china-censorship-data.html">
+            New York Times - Censorship, Surveillance and Profits:
+            A Hard Bargain for Apple in China</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Apple’s marketing insists that when it comes to privacy the company is
+        ethical and different, but when it comes to the people actually tasked with building the products that adhere
+        to
+        those standards — these values suddenly and mysteriously disappear.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/&sa=D&source=editors&ust=1718648881362093&usg=AOvVaw2uyJu8xRa8q8abgixbMmF8">
+            Karl Bode - Techdirt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">Privacy is a fundamental human right</strong>.
+        It’s also one of our
+        core values. Which is why we design our products and services to
+        protect it. That’s the kind of innovation we believe in.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/au/privacy/&sa=D&source=editors&ust=1718648881362649&usg=AOvVaw27QiHS-0cyyFD6SVaY4bwR">
+            Apple on Privacy</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>To solve the privacy issues, we would propose three solutions:</p>
+
+    <ol>
+      <li>Stronger privacy laws for the EU that would equally apply to native
+        apps, Web Apps, websites and Apple's own apps.</li>
+      <li>Apple taking steps to actually enforce a number of their privacy
+        rules and abiding by them for their own apps. They could then advertise the privacy advantages of their app
+        store over competitors or direct downloads. </li>
+      <li>Apple should not use any word games to exclude themselves from their own
+        privacy rules. For example Apple often refers to itself as a first party and displays different softer
+        warnings
+        or no warnings for similar behavior when Apple is the one collecting users data for the purposes of
+        advertising.
+        While a small part of its overall business,
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.forbes.com/sites/daviddoty/2023/02/08/apple-the-story-behind-its-new-ad-offerings-to-retailers-restaurants-hotels-other-location-based-businesses/%23:~:text%3DApple%2520seems%2520to%2520be%2520growing,coming%2520up%2520fast%2520if%2520quietly.)&sa=D&source=editors&ust=1718648881363839&usg=AOvVaw1xH0Kgn6tnXDBGTn8ShARq">
+          advertising is a significant and growing chunk of Apple’s revenue</a> coming in at $3.7
+        billion directly in 2021 and an additional $18 billion in 2021 via its search deal with Google.
+      </li>
+    </ol>
+
+    <p>For example
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/privacy/data/en/app-store/&sa=D&source=editors&ust=1718648881364338&usg=AOvVaw22k1INZIs5-X0gXTbukoPo">
+        in this document</a> they state that for their app store, they use users’
+      personal and identifiable data for the purposes of showing adverts. Users can opt-out via a deeply nested menu
+      option via “Settings &gt; [your name] &gt; Media &amp; Purchases &gt; View Account, and then tap to turn
+      off
+      Personalized Recommendations”:
+    </p>
+
+    <blockquote>
+      <p><strong class="stressed">
+          We collect your personal data</strong> so that we can provide you the content
+        you purchase, download, or want to update in the App Store
+        and other Apple online stores, including iTunes Store and Apple Books.</p>
+
+      <p><strong class="stressed">We also use information about your account, purchases, and downloads in the stores
+          to offer advertising</strong> to ensure that ads on the App Store, Apple News, and Stocks,
+        where available, are relevant to you. You have choices with respect to this advertising, as described
+        below.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/privacy/data/en/app-store/&sa=D&source=editors&ust=1718648881365551&usg=AOvVaw3Z6eSuxPgrIRmMljT_jh8E">
+            Apple App Store Data Policy</a>
+        </cite>
+      </p>
+    </blockquote>
+
+
+    <p>This appears to be potentially in breach of the DMA’s data rules that all
+      gatekeepers must abide by. Specifically this Article 5(2) (b):</p>
+
+    <blockquote>
+      <p>
+        2. The gatekeeper shall not do any of the following:
+      </p>
+      <p>
+        . . .
+      </p>
+      <p>
+        (b) <strong class="stressed">combine personal data from</strong> the relevant
+        core platform
+        service with personal data from any further core platform
+        services or <strong class="stressed">from any other services provided by the
+          gatekeeper </strong>
+        or with personal data from third-party services;
+      </p>
+      <p>
+        . . .
+      </p>
+      <p>
+        <strong class="stressed">unless the end user has been presented
+          with the specific choice
+          and has given consent</strong> within the meaning of Article 4, point
+        (11), and Article 7 of Regulation (EU) 2016/679.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Article 5(2)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>In this case Apple is combining data from its app store (a core platform service of Apple) with
+      other services of Apple including Apple News and Apple Stocks in order to perform targeted advertising. Whether
+      this is in breach would likely depend on whether users were prompted and the nature of that consent prompt.
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://9to5mac.com/2021/09/02/apple-personalized-ads-targeting-ios-15/%23:~:text%3DFor%2520iOS%252015%2520users%252C%2520Apple%2520has%2520begun%2520prompting,well%2520as%2520for%2520targeting%2520App%2520Store%2520Search%2520Ads.&sa=D&source=editors&ust=1718648881367362&usg=AOvVaw0QHD1BGfIFgF4PDAWixlMV">
+        Prior to iOS 15</a> users were not prompted and were automatically opted into targeted
+      advertising for Apple’s own apps.
+    </p>
+
+    <p>Apple’s behavior related to targeted advertising on iOS is already
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://techcrunch.com/2023/07/25/apple-att-antitrust-france/&sa=D&source=editors&ust=1718648881367812&usg=AOvVaw3pdDC_5xSqzJpEY25HxEr4">
+        under investigation by the French Competition Authority</a>. They are investigating whether
+      Apple is self preferencing by categorizing its behavior as it relates to advertising as special and thus under
+      different rules to other third parties on iOS.
+    </p>
+
+    <p>Apple’s carefully chosen definition of “tracking” excludes its own
+      behaviors from its privacy rules as they relate to targeted advertising. As Apple is both the operating system
+      and
+      the publisher of multiple Apple default apps, the app store is able to directly show targeted adverts without
+      providing the applied data to a third-party. We believe this is an intentional redefinition of
+      “tracking” to allow Apple to craft rules to allow its own use of targeted advertising whilst
+      disallowing the same behavior in third parties.</p>
+
+    <blockquote>
+      <p><strong class="stressed">Apple does not consider the processing activities
+          it undertakes in terms of personalised advertising (ie use of first-party data from different Apple apps and
+          services) as ‘tracking’</strong>, particularly as it does not link information
+        collected by apps from different companies, and therefore its apps are not required to show the ATT prompt.
+        This
+        is factually correct, given that, as detailed above, Apple uses data it collects from its own services which
+        it
+        operates under a single corporate ownership for personalised advertising purposes.</p>
+      <p></p>
+      <p>6.177 However, as further discussed in Appendix J, based on our consideration of
+        the ICO’s definition of online tracking, which does not distinguish between
+        first-party and third-party data, we consider
+        <strong class="stressed">Apple’s own use of its users'
+          personal data no less consistent with this description of
+          ‘tracking’ than that of third-party developers</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/63f61bc0d3bf7f62e8c34a02/Mobile_Ecosystems_Final_Report_amended_2.pdf&sa=D&source=editors&ust=1718648881369123&usg=AOvVaw3OdnW6YsomlMitiqsEmfVf">
+            CMA Mobile Ecosystems Report</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <h4 id="sharing-of-state">
+      <a class="header-anchor" href="#privacy" aria-hidden="true">#</a>
+      3.1.11.1. Sharing of State
+    </h4>
+
+    <blockquote>
+      <p>Not sync cookies and state between the browser and any other apps, even other
+        apps of the developer</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881369859&usg=AOvVaw1nFEwavFs8YY3BOb4RkjSD">
+            Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This line is problematic as it prohibits functionality that browsers already provide to
+      users. For example, many browsers (including Safari) sync state between a user's mobile browser and their
+      desktop browser. A lack of sync may prohibit other user-facing functionality, such as password autofill and tab
+      syncing.</p>
+
+    <p>As discussed in the previous section, Apple may only have strictly necessary,
+      proportionate and justified security rules in their browser engine API contract, thus this rule would need to be
+      moved to the app store rules. If Apple chooses to introduce this as an app store rule they would need to be more
+      specific and be cautious so as not to block browser vendors from providing useful functionality to users,
+      otherwise they risk violating Article 5(7).</p>
+
+    <h3 id="confidentiality-clause">
+      <a class="header-anchor" href="#confidentiality-clause" aria-hidden="true">#</a>
+      3.1.12. Confidentiality Clause
+    </h3>
+
+    <p>Apple has long had
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.nytimes.com/2008/07/26/business/26nocera.html&sa=D&source=editors&ust=1718648881370845&usg=AOvVaw1Igq1pyLWRhj07bxKrzABd">
+        a culture of secrecy</a>. This includes inserting confidentiality clauses into both its
+      agreements with other companies and with its staff.
+    </p>
+
+    <p>Its initial developer contract contained clauses banning companies publicly
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.wired.com/2008/09/apple-imposes-n/&sa=D&source=editors&ust=1718648881371293&usg=AOvVaw1EDq41V2ZXb1coeaepTfeI">
+        complaining about being rejected from the app store</a>. Rejection letters include a clause that
+      read:
+    </p>
+
+    <blockquote>
+      <p>THE INFORMATION CONTAINED IN THIS MESSAGE IS UNDER
+        NON-DISCLOSURE.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.wired.com/2008/09/apple-imposes-n/&sa=D&source=editors&ust=1718648881371719&usg=AOvVaw2NWYbyQFq_eh2Gj5qE9tPo">
+            Apple Rejection Email</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>They still have a similar clause in their current developer contract:</p>
+
+      <p>You may not issue any press releases or make any other public statements
+        regarding this Agreement, its terms and conditions, or the relationship of the parties without Apple’s
+        express prior written approval, which may be withheld at Apple’s discretion.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/%23ADPLA9:~:text%3D9.4%2520Press%2520Releases,at%2520Apple%25E2%2580%2599s%2520discretion.&sa=D&source=editors&ust=1718648881372433&usg=AOvVaw3kSBkPwm3H-gnhTaYlWNvr">Apple
+            Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Astonishingly, in Apple’s developer contract they state that anything the developer submits
+      to Apple is not confidential including if Apple wishes to publish it, use it to develop competing products or to
+      share this information with Apple’s partners and the app developers competitors. Given app store review is
+      essentially a condition of being on iOS, currently this seems a prime example of
+      the <q>serious imbalances in bargaining power and, consequently, to unfair
+        practices and conditions
+        for business users</q> that recital 4 of the DMA discusses:</p>
+
+    <blockquote>
+      <p>
+        Apple works with many application and software developers
+        and some of their products may be similar to or compete
+        with Your Applications. <strong class="stressed">Apple may also be developing its
+          own similar or competing applications and products or may
+          decide to do so in the future. To avoid potential
+          misunderstandings</strong> and except as otherwise expressly set
+        forth herein, Apple cannot agree, and expressly disclaims,
+        any confidentiality obligations or use restrictions,
+        express or implied, with respect to any information that
+        You may provide in connection with this Agreement or the
+        Program, including but not limited to information about
+        Your Application, Licensed Application Information, and
+        metadata (such disclosures will be referred to as “Licensee
+        Disclosures”). <strong class="stressed">You agree that any such Licensee Disclosures
+          will be non-confidential. Except as otherwise expressly set
+          forth herein, Apple will be free to use and disclose any
+          Licensee Disclosures on an unrestricted basis without
+          notifying or compensating You. You release Apple from all
+          liability and obligations that may arise from the receipt,
+          review, use, or disclosure of any portion of any Licensee
+          Disclosures. Any physical materials You submit to Apple
+          will become Apple property and Apple will have no obligation
+          to return those materials to You or to certify their destruction</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#ADPLA9:~:text=9.4%20Press%20Releases,at%20Apple%E2%80%99s%20discretion.">
+            Apple Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple has inserted the following clause into its browser engine entitlement
+      contract:</p>
+
+    <blockquote>
+      <p>
+        Confidentiality <strong class="stressed">You agree that any non-public information
+          regarding the Alternative Web Browser Engine APIs or
+          Alternative Web Browser Engine (EU) Entitlement Profile
+          shall be considered and treated as “Apple Confidential
+          Information”</strong> in accordance with the terms of Section 9
+        (Confidentiality) of the Developer Agreement. You agree
+        to use such Apple Confidential Information solely for the
+        purpose of exercising Your rights and performing Your
+        obligations under this Addendum and agree not to use such
+        Apple Confidential Information for any other purpose, for
+        Your own or any third party’s benefit, without Apple's
+        prior written consent. <strong class="stressed">You further agree not to disclose
+          or disseminate Apple Confidential Information to anyone
+          other than those of Your employees or contractors who have
+          a need to know and who are bound by a written agreement
+          that prohibited unauthorized use or disclose of the Apple
+          Confidential Information</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+            Apple Browser Engine Entitlement Document</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Besides clearly not being a security measure, this clause directly violates the DMA in
+      another way, In Recital 42 the DMA states:</p>
+
+    <blockquote>
+      <p><strong class="stressed">Any practice that would in any way inhibit or
+          hinder those users in raising their concerns</strong> or in seeking available redress,
+        <strong class="stressed">for instance by means of confidentiality clauses in agreements</strong> or other
+        written terms, should therefore be prohibited. This prohibition should be without
+        prejudice to the right of business users and gatekeepers to lay down in their agreements the terms of use
+        including the use of lawful complaints-handling mechanisms, including any use of alternative dispute
+        resolution
+        mechanisms or of the jurisdiction of specific courts in compliance with respective Union and national law.
+        This
+        should also be without prejudice to the role gatekeepers play in the fight against illegal content
+        online.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881376619&usg=AOvVaw09qM5CLBK1scrAO5SeVllu">
+            DigitalMarkets Act - Recital 42</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The EU courts, the Commission and other EU national authorities do not work for the
+      browser vendors, nor are they required to sign any such non-disclosure agreement (NDA). This contract explicitly
+      states that such sharing of any non-public interactions with courts and regulators in the EU would be a
+      violation
+      of the contract.</p>
+
+    <p>Apple should not attempt to grant itself confidentiality rights that it is already
+      explicitly prohibited from granting by the DMA.</p>
+
+    <p>This combination of an unreasonable and blanket ban on criticizing Apple’s app
+      review process and a clause that Apple can use confidential information submitted to them for the purposes of
+      app
+      store review in any way they see fit, including to compete against the very same app, again points to an
+      imbalance
+      in power between the Apple the gatekeeper and the business users.</p>
+
+    <p>This clause will, at a minimum, need to be updated with a sentence that explicitly
+      explains that browser vendors are permitted to share such information about their interactions with Apple, to
+      regulators and other government enforcement bodies in the EU.</p>
+
+    <p>We would go further and argue it is unreasonable of Apple to hide malicious compliance
+      of the DMA from the broader public via such confidentiality clauses and to obligate business users to release
+      confidential information to Apple nominally for app store review, that Apple can then use for any purpose.
+    </p>
+
+    <p>Should browser vendors wish to talk to the press about Apple (for example) rejecting
+      their browser for frivolous reasons, then they should be able to do so. Blocking public pressure, which
+      facilitates the proper functioning of the DMA via NDAs or confidentiality agreements, should be
+      prohibited.
+    </p>
+
+    <p>Preventing individuals and companies from talking to regulators and courts via
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881378016&usg=AOvVaw1qR2-9G0u3CwpGca40npGr">
+        such illegal NDAs is not hypothetical</a>. In this example Apple subcontractor Thomas Le
+      Bonniec was frightened by his non-disclosure agreement and initially did not come forward with allegations
+      about Siri’s privacy practices.
+    </p>
+
+    <blockquote>
+      <p>It was scary. I thought I may end up broke for the rest of my
+        life,</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881378575&usg=AOvVaw26GlKzqCqo2jyiRZngp545">Apple
+            subcontractor Thomas Le Bonniec</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>is contract threatened unspecified 'monetary damages' if he shared
+        confidential information 'outside of work' — with no
+        exceptions, according to his complaint.
+      </p>
+
+      <p>As a dedicated Siri data analyst, Le Bonniec said he heard conversations he believed
+        violated users’ privacy, including details about sexual preferences, bank account numbers and health
+        problems. He said that the importance of exposing the existence of the recordings outweighed the risks of
+        breaking
+        his agreement, so he went public. After an outcry by consumers, Apple made changes to Siri to address privacy
+        concerns.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/&sa=D&source=editors&ust=1718648881379264&usg=AOvVaw0KLUFh7iqGO2Pb-UY6Q7ZX">
+            Sabrina Willmer, Austin Weinstein and Bloomberg - Tech firms are using NDAs to illegally muzzle
+            whistleblowers</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This clause needs to be removed from the browser engine entitlement contract. Any
+      similar clause in the app store rules should include language making it explicit that complaints to the
+      Commission, EU courts and other EU legal bodies are permitted. In our opinion, it is not enough to simply state
+      elsewhere that they will not enforce such action. The contracts themselves need to be compliant with the DMA.
+      Further, if possible under any section of the DMA or any other applicable EU law, Apple’s confidentiality
+      clauses should be scrutinized to make sure they are necessary, proportionate, fair and reasonable.</p>
+
+    <h3 id="apple-can-change-or-break-any-api-with-no-notice">
+      <a class="header-anchor" href="#apple-can-change-or-break-any-api-with-no-notice" aria-hidden="true">#</a>
+      3.1.13. Apple can Change or Break any API with No Notice
+    </h3>
+
+    <p>In their browser engine entitlement contract Apple states that they can change or break
+      any API with no notice.</p>
+
+    <blockquote>
+      <p>
+        <strong class="stressed">Apple may at any time, and from time to time, with or
+          without prior notice to You, modify, remove</strong>, or reissue
+        the Apple Materials or the <strong class="stressed">Alternative Web Browser Engine
+          APIs, or any part thereof. You understand that any such
+          modifications may require You to change or update Your
+          Alternative Web Browser Engine App (EU) at Your own cost
+          and that features and functionality of such App may cease
+          to function</strong>. Except as required by applicable law, Apple
+        has no express or implied obligation to provide, or
+        continue to provide, the Apple Materials or Alternative
+        Web Browser Engine APIs, and may suspend or discontinue
+        all or any portion of Your access to them at any time
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+            Apple Browser Engine Entitlement Document</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is clearly unreasonable, as the browser vendors need time to update their browser
+      in order to make sure it continues to work despite the API change or removal.</p>
+
+    <p>Next, Apple is obligated to make sure any software or hardware feature that is used, or
+      available on the system, is provided to browser vendors free of charge subject to narrow scope security measures
+      under Article 6(7).</p>
+
+    <p>Apple is also not allowed under Article 5(7) or Article 13(4) to remove or alter any
+      API in such a way that would undermine the effectiveness of Article 5(7) in allowing browser vendors to port
+      their
+      engines to iOS.</p>
+
+    <p>Finally, under Article 13(6) of the DMA, Apple is not allowed to degrade the conditions
+      or quality of any of the core platform services provided to business users or end users who avail themselves of
+      the rights or choices laid down in Articles 5, 6 and 7 in particular Article 5(7) and Article 6(7).</p>
+
+    <h3 id="apple-can-withhold-any-api-from-browser-vendor">
+      <a class="header-anchor" href="#apple-can-withhold-any-api-from-browser-vendor" aria-hidden="true">#</a>
+      3.1.14. Apple can Withhold any API from any Browser Vendor
+    </h3>
+
+    <p>In the same paragraph in Apple’s browser engine entitlement contract Apple
+      states:</p>
+
+    <blockquote>
+      <p>Except as required by applicable law, Apple has no express or implied
+        obligation to provide, or continue to provide, the Apple Materials or Alternative Web Browser Engine APIs, and
+        may
+        suspend or discontinue all or any portion of Your access to them at any time</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881382057&usg=AOvVaw1zBT4Jkl5guHn_VcHC2aUD">
+            Apple Browser Engine Entitlement Document</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>That is, Apple can suspend any API from any individual browser vendor. Apple does not
+      state they need to provide any evidence or rationale for such a suspension.</p>
+
+    <p>Given that this contract is in essence exclusively for the EU, and Apple are even
+      calling the app “Alternative Web Browser Engine (EU)”, and the DMA causes Apple to have an express
+      obligation to provide and continue to provide these APIs to browser vendors subject to narrow scope security
+      measures, Apple should not be attempting to override the DMA by contract. </p>
+
+    <p>As such this paragraph is explicitly inconsistent with the DMA and should be
+      removed.</p>
+
+    <h3 id="apple-can-remove-any-browser-from-its-app-store-at-its-sole-discretion">
+      <a class="header-anchor" href="#apple-can-remove-any-browser-from-its-app-store-at-its-sole-discretion" aria-hidden="true">#</a>
+      3.1.15. Apple can Remove any Browser from its App Store at its Sole Discretion
+    </h3>
+
+    <blockquote>
+      <p>Nothing herein shall imply that Apple will accept Your Alternative Web
+        Browser Engine App (EU) for distribution on the App Store, and You acknowledge and agree that Apple may, in
+        its
+        sole discretion, reject, or cease distributing Your Alternative Web Browser Engine App (EU) for any reason.
+        For
+        clarity, once Your Alternative Web Browser Engine App (EU) has been selected for distribution via the App
+        Store it
+        will be considered a “Licensed Application” under the Developer Agreement”</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881383176&usg=AOvVaw3Iex1cFhrN8bzQx4XFeIG5">
+            Apple Browser Engine Entitlement Document</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple in this clause states that, at its sole discretion, it can reject or remove a
+      browser vendor's app from the app store for any reason.</p>
+
+    <p>Again this is clearly not permissible under the DMA. Apple is required to operate its
+      app store with FRAND (Fair, reasonable and non-discriminatory) conditions under Article 6(12). Further, it is
+      not
+      allowed to restrict browser vendors from using their own engines under Article 5(7). </p>
+
+    <p>Any attempt to construct app store rules to prevent browsers from using their own
+      engine in order to provide improved features, stability, security or privacy relative to Safari would likely be
+      in
+      violation of Article 13(4) for undermining Article 5(7).</p>
+
+    <p>That is, rejecting a browser from Apple’s app store would not be at its sole
+      discretion and it could not do it for any reason. Apple should not try to override the DMA via its contract and
+      this paragraph should be modified to be compliant with the text of the DMA.</p>
+
+    <h3 id="apple-developer-agreement">
+      <a class="header-anchor" href="#apple-developer-agreement" aria-hidden="true">#</a>
+      3.1.16. Apple Developer Agreement
+    </h3>
+
+    <p>While, in the short term, all browser vendors will likely want to be on Apple’s
+      app store, it is not clear if this will remain the case. We would expect that over the long term many browser
+      vendors will switch to direct distribution and no longer provide their apps via the Apple’s app
+      store.</p>
+
+    <p>Many developers do not distribute on Apple’s app store for macOS, as a point of
+      comparison. </p>
+
+    <blockquote>
+      <p>Neither is on the store because they don't have to be. They can be on
+        Mac and distribute to users without sharing the revenue with us</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email&sa=D&source=editors&ust=1718648881384625&usg=AOvVaw0zdhVCxNyW3EcN61LqRxFb">
+            Philip Schiller - Apple Upper Management - On the Mac App Store</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Mere control of the app store review process, <a href="#apple-should-make-notarization-for-directly-downloaded-browsers-automatic">while of dubious and
+        likely negative value in improving browser security</a>, does allow Apple to exert great
+      control by holding up or rejecting app store updates. This exact
+      concern is highlighted in the DOJs case against Apple. This means that the prospect of having users download
+      signed apps directly from the browser vendors website using an automatic notarization system, similar to
+      macOS, is
+      likely quite appealing for browser vendors.</p>
+
+    <blockquote>
+      <p>Apple often enforces its App Store rules arbitrarily. And it frequently uses
+        App Store rules and restrictions to penalize and restrict developers that take advantage of technologies that
+        threaten to disrupt, disintermediate, compete with, or erode
+        Apple’s monopoly power.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881385451&usg=AOvVaw0NuD7QzcvM6XeOBWthjoaF">
+            DOJ - Case 2:24-cv-04055</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>For this reason it is quite concerning that Apple has chosen to make the contract for browser
+      engine APIs an amendment to the "<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881385920&usg=AOvVaw2AHfq04O6ANOFUsShJqUPc">Apple
+        Developer Program License Agreement</a>".</p>
+
+    <p>In the opening paragraphs it states that:</p>
+
+    <blockquote>
+      <p>Applications developed under this Agreement for iOS, iPadOS, macOS, tvOS,
+        visionOS, and watchOS can be distributed: (1) through the App Store, if selected by Apple, (2) on a limited
+        basis
+        for use on Registered Devices (as defined below), and (3) for beta testing through TestFlight. Applications
+        developed for iOS, iPadOS, macOS, and tvOS can additionally be distributed through Custom App Distribution, if
+        selected by Apple. Applications developed for macOS can additionally be separately distributed as described in
+        this Agreement.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/&sa=D&source=editors&ust=1718648881386670&usg=AOvVaw0AUoa_QsCmYsunLIjUQkeu">
+            Apple Developer Program License Agreement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly, the only apps that can be distributed using this agreement outside
+      Apple's app store or Apple's app store guidelines are applications for macOS:</p>
+
+    <p><q>Applications developed for macOS can additionally be separately distributed as
+        described in this Agreement.</q></p>
+
+    <p>The agreement then has an entire section describing the rules for having your app
+      notarized for macOS.</p>
+
+    <blockquote>
+      <p>Apple may revoke Tickets at any time in its sole discretion in the event that
+        Apple has reason to believe, or has reasonable suspicions, that Your Application contains malware or
+        malicious,
+        suspicious or harmful code or components or that Your developer identity signature has been
+        compromised.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/terms/apple-developer-program-license-agreement/%23ADPLA5.3&sa=D&source=editors&ust=1718648881387589&usg=AOvVaw0jmfy4McZtR9eDikOgbixI">
+            Apple - Notarization for macOS</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is worth taking note that even in the instance where Apple has found that your app
+      contains malware, this clause has lighter implications and is less broad than the one in Apple's contract
+      for
+      browser engine API access for potentially far more minor or dubious infractions. </p>
+
+    <p>While this clause does have the phrase <q>in its sole
+        discretion</q> it does at least make clear the nature of the infringement: That
+      Apple would have reason to believe that app contains malicious code and that the penalty would simply be
+      having
+      that specific app unnotarized.</p>
+
+    <p>Apple is required by the act to allow browser vendors to distribute directly and will
+      only be subject to the strictly necessary, proportionate and justified security measures in 6(4) and 6(7). Thus,
+      either the browser engine entitlement contract should be separate or the Apple Developer Program License
+      Agreement
+      should be updated with language making it clear that apps can be distributed directly and that any rules in the
+      Apple Developer Program License Agreement or associated documents do not apply to them. Instead, only a clearly
+      listed set of security rules would apply.</p>
+
+
+    <h2 id="choice-screens">
+      <a class="header-anchor" href="#choice-screens" aria-hidden="true">#</a>
+      3.2. Choice Screens
+    </h2>
+
+    <blockquote>
+      <p><strong class="stressed">A gatekeeper can use different means to favour its
+          own or third-party services or products on its operating system</strong>, virtual
+        assistant or web
+        browser, <strong class="stressed">to the detriment of the same or similar services that end users could
+          obtain
+          through other third parties</strong>. This can for instance happen where certain software
+        applications or services are pre-installed by a gatekeeper. To enable end user choice, gatekeepers should not
+        prevent end users from un-installing any software applications on their operating system. It should be
+        possible
+        for the gatekeeper to restrict such un-installation only when such software applications are essential to the
+        functioning of the operating system or the device. Gatekeepers should also allow end users to easily change
+        the
+        default settings on the operating system, virtual assistant and web browser
+        <strong class="stressed">when those default settings favour their own software applications and services. This
+          includes prompting a choice
+          screen</strong>, at the moment of the users’ first use of an online search engine, virtual
+        assistant or web browser of the gatekeeper listed in the designation decision, allowing end users to select an
+        alternative default service when the operating system of the gatekeeper directs end users to those online
+        search
+        engine, virtual assistant or web browser and when the virtual assistant or the web browser of the gatekeeper
+        direct the user to the online search engine listed in the designation decision.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881389125&usg=AOvVaw02ut7-IcXih_A2f_9hSSWW">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The act explains that gatekeepers of operating systems can favor their own products by
+      pre-installing them and setting them as the system default. One of the methods used by the act to help combat
+      this
+      self-preferencing is a choice screen for browsers on operating systems where the browser of the gatekeeper has
+      been set as the default.</p>
+
+    <p>No choice screen will ever completely nullify the advantage granted to the gatekeeper
+      by setting the default browser. In order to have maximum impact in minimizing the effect of this
+      self-preferencing, to increase user autonomy and to not introduce new self-preferencing via the choice screen
+      itself, the choice screen must be carefully designed. Apple’s choice screen, while much improved from
+      initial proposals, still has significant issues.</p>
+
+    <p>While this document focuses only on Apple, in most cases we recommend equivalent
+      remedies for Google’s Android.</p>
+
+    <h3 id="browser-should-be-allowed-to-show-more-information-on-choice-screen">
+      <a class="header-anchor" href="#browser-should-be-allowed-to-show-more-information-on-choice-screen" aria-hidden="true">#</a>
+      3.2.1. Browsers should Be Allowed To Show More Information on Choice Screen
+    </h3>
+
+    <p>Currently on iOS the amount of information that browser vendors can show on the choice
+      screen is extremely limited. It is limited to the company's name, browser name and browser logo.</p>
+
+    <figure>
+      <img alt="" src="/images/apple-dma-report/image5.png">
+      <figcaption>Apple’s Browser Choice Screen</figcaption>
+    </figure>
+
+    <p>One of the aims of the act with the choice screen is to allow users to make an informed
+      choice and to limit the degree to which operating system gatekeepers can self-preference their own browser by
+      setting it as the default.</p>
+
+    <p>With this in mind, it seems entirely appropriate that Apple allow browser vendors to
+      display a sentence explaining why users should choose their browser. The layout should be updated to allow the
+      full sentence to be displayed without clicking on any buttons, a more reasonable character limit might be 150
+      characters (about 30 words).</p>
+
+    <p>To do otherwise concentrates power in the hands of major browsers and suppresses
+      smaller entrants from the mobile browser market. </p>
+
+    <h3 id="shouldnt-be locked-to-the-gatekeepers-app-store">
+      <a class="header-anchor" href="#shouldnt-be locked-to-the-gatekeepers-app-store" aria-hidden="true">#</a>
+      3.2.2. Shouldn't be Locked to the Gatekeepers App Store
+    </h3>
+
+    <blockquote>
+      <p><strong class="stressed">To prevent further reinforcing their dependence on
+          the core platform services of gatekeepers, and in order to promote multi-homing, the business users of those
+          gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate</strong> for the purpose of interacting with any end users that those business
+        users have already acquired through core platform services provided by the gatekeeper or through other
+        channels.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881391333&usg=AOvVaw1Y4E-ABY_a-UIZLGwFJz_M">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Multi-homing is where an end user or business user uses multiple core-platform
+      services. For example owning an Android phone and an iOS iPad. It could also be having multiple apps on a phone
+      from different distributors such as different app stores or directly from the business user (i.e. direct
+      download
+      / distribution via the web).</p>
+
+    <p>The act specifically highlights direct distribution, in this case downloading and
+      updating directly from the business users own website, as something business users should have the option of
+      choosing for their users. Should a browser vendor wish to distribute to their users directly via their own
+      website
+      (as opposed to Apple’s app store), they should be able to do so.</p>
+
+    <p>Choice screens aim to nullify the way that operating system gatekeepers self-preference
+      themselves via setting defaults on the operating system. This remedy should not then reinforce the dependence on
+      the core platform services of gatekeepers, in particular their app store.</p>
+
+    <p>There are a number of concerns here:</p>
+
+    <ol>
+      <li>Apple is only counting browsers downloaded from their app stores in
+        the calculation of the 12 most popular browsers. Browsers that are downloaded directly or from another app
+        store need to be included in this count.</li>
+      <li>Browsers that are not available on the gatekeepers app store at all
+        still need to be included.</li>
+      <li>Browser vendors should not be locked to the gatekeepers app store
+        and should be able to opt into distributing directly to users. Given that all of Apple's security checks
+        are built into their browser entitlement contract and notarization process, there is absolutely no plausible
+        reason to introduce scare screens, and doing so would, in our opinion, be a violation of the act.</li>
+    </ol>
+
+    <p>To allow Apple to impose their app store as the sole gateway for downloading browsers
+      via the choice screen or even the default is against the intent of the act.</p>
+
+    <p>These changes are critical to browser competition on mobile operating systems. In the
+      same manner that it would have been ridiculous for Microsoft to tie their choice screen to only browsers on a
+      Microsoft store from which they set the rules and get a 30% cut, it is unreasonable for Apple to tie their
+      choice
+      screen to their app stores along with their rules and their up to 30% cut.</p>
+
+    <p>Without allowing browser vendors chosen via the choice screen to be directly downloaded
+      from the browser vendor themselves, and instead forcing them to use the Apple’s app store, will continue
+      to
+      damage browser competition including:</p>
+
+    <ul>
+      <li>Forcing browser vendors to share 30% of all revenue made via
+        in-app purchases, which would effectively kill various business models or significantly reduce browser revenue
+        (i.e. for purchases of VPNs, or subscriptions to AI assistants).</li>
+      <li>Forcing all browser vendors to accept the gatekeeper’s app
+        store rules and conditions, which are well documented to be unfair and hamper competition.</li>
+      <li>Introduces delays and complexity into planning and releases.</li>
+    </ul>
+
+    <h3 id="should-be-a-background-and-direct-download">
+      <a class="header-anchor" href="#should-be-a-background-and-direct-download" aria-hidden="true">#</a>
+      3.2.3. Should be a Background and Direct Download
+    </h3>
+
+    <p>As discussed in the previous section, taking the user to the app store is an
+      inappropriate flow, it also introduces friction relative to the gatekeepers browser which is
+      preinstalled.
+    </p>
+
+    <p>Instead, the user should simply pick their new default browser from the choice screen
+      and the operating system should download and install the browser in the background. The choice screen should
+      allow
+      the browser vendor to show relevant information about their browser, including pictures and videos that the user
+      can see by clicking on a “see more” arrow icon. </p>
+
+    <p>This design works far better when different browsers are coming from different
+      distribution channels such as directly from the browser vendors website. Both Google and Apple's design
+      currently conflict with this requirement and will need to be reworked.</p>
+
+    <p>Next, Apple appears to have recently added a time to download countdown to the Apple
+      app store page.</p>
+
+    <figure>
+      <img alt="" src="/images/apple-dma-report/image4.png">
+      <figcaption>The Choice Screen when Brave has been selected and
+        the download symbol has
+        been pressed. Note the “cancel” button at the top
+        and the install time widget that Apple has
+        added.</figcaption>
+    </figure>
+
+    <p>We believe that this, in combination with the prominent cancel button, is an attempt by
+      Apple to use the fact they are preinstalled to undermine user autonomy and push users towards Safari.</p>
+
+    <p>Instead of having a countdown, we believe that Apple should simply set that browser as
+      the default browser immediately, continue to the homescreen, and replace Safari on the hotseat with the user
+      selected browser. It will be clear to the user that the browser is downloading, as it will have the standard
+      downloading circle on the hotseat. We believe after this process has been started, it should continue until it
+      has
+      finished. Providing an additional cancel option undermines the choice screen.</p>
+
+    <h3 id="browser-vendors-need-data-on-the-choice-screen-to-measure-performance">
+      <a class="header-anchor" href="#browser-vendors-need-data-on-the-choice-screen-to-measure-performance" aria-hidden="true">#</a>
+      3.2.4. Browser Vendors Need Data on the Choice Screen to Measure Performance
+    </h3>
+
+    <p>Third party browser vendors need access to the number of times their browser was shown
+      and the number of times their browser was picked on the choice screen by end users. This data can be aggregated
+      per country per day. Additionally it would be useful to include additional information, such as the position in
+      the choice screen the browser was shown.</p>
+
+    <p>For example one piece of aggregated data a browser vendor might receive could
+      be:</p>
+
+    <dl>
+      <dt>Country:</dt>
+      <dd>Germany</dd>
+      <dt>Date:</dt>
+      <dd>2024-07-01</dd>
+      <dt>Browser:</dt>
+      <dd>Firefox</dd>
+      <dt>Times Shown:</dt>
+      <dd>1451</dd>
+      <dt>Times Selected:</dt>
+      <dd>435</dd>
+    </dl>
+
+    <p>i.e. 1451 people were shown Firefox across all positions in Germany on 2024-07-01, out
+      of them 435 chose to make Firefox the default browser.</p>
+
+    <p>For the more detailed one that includes position an example would be:</p>
+
+    <dl>
+      <dt>Country:</dt>
+      <dd>Germany</dd>
+      <dt>Date:</dt>
+      <dd>2024-07-01</dd>
+      <dt>Browser:</dt>
+      <dd>Firefox</dd>
+      <dt>Times Shown:</dt>
+      <dd>77</dd>
+      <dt>Times Selected:</dt>
+      <dd>5</dd>
+      <dt>Position:</dt>
+      <dd>12</dd>
+    </dl>
+
+    <p>i.e. 77 people were shown Firefox in the 12th position in Germany on 2024-07-01, out of
+      them 5 chose to make Firefox the default browser.</p>
+
+    <p>This is important to give browser vendors the chance to work out what works in
+      advertising and adding features to their browser, as well as providing data that the remedy is effective.
+    </p>
+
+    <p>Given the data is aggregated and boils down to two numbers per country per day (or 24
+      for the more detailed one), there is no plausible privacy or security reason not to collect or share this data.
+      The only party that benefits from this data not being available is the operating system gatekeeper.</p>
+
+    <p>The operating system gatekeeper benefits in two ways. First, third party browser
+      vendors can not work out what blurb, advertising or features work in encouraging users to switch browsers.
+      Second,
+      the relative effectiveness of the choice screen is obscured.</p>
+
+    <p>Given this data is aggregated and non-confidential in nature, gatekeepers should not be
+      able to prevent browser vendors from publishing it if they choose to.</p>
+
+    <p>Finally, whether or not a remedy is effective is clearly important to the DMA. For
+      example in the event a gatekeeper is believed to have frustrated the objectives of an article, a proceeding can
+      be
+      opened. The gatekeeper can then be obligated to fix the behavior via commitments or be fined. In the event those
+      commitments are not effective the proceeding can be reopened.</p>
+
+    <blockquote>
+      <p>
+        2. The Commission may, upon request or on its own initiative, reopen by decision the relevant proceedings,
+        where:
+      </p>
+      <ul>
+        <li>(a) there has been a material change in any of the facts on which the decision was based;</li>
+        <li>(b) the gatekeeper concerned acts contrary to its commitments;</li>
+        <li>(c) the decision was based on incomplete, incorrect or misleading information provided by the parties;
+        </li>
+        <li><strong class="stressed">(d) the commitments are not effective</strong>.</li>
+      </ul>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Article 25(2)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>The objective of Article 6(3) as outlined in Recital 49 is to nullify the
+      self-prefencing advantage gatekeepers grant their own apps via setting them as the default by default.</p>
+
+    <blockquote>
+      <p><strong class="stressed">A gatekeeper can use different means to favour its own or third-party services or
+          products on its operating system, virtual assistant or web browser, to the detriment of the same or similar
+          services that end users could obtain through other third parties.</strong>
+        This can for
+        instance happen where certain software applications or services are pre-installed by a gatekeeper. To enable
+        end
+        user choice, gatekeepers should not prevent end users from un-installing any software applications on their
+        operating system. It should be possible for the gatekeeper to restrict such un-installation only when such
+        software applications are essential to the functioning of the operating system
+        or the device. <strong class="stressed">
+          Gatekeepers should also allow end users to easily change the default settings on the operating
+          system,
+          virtual assistant and web browser when those default settings favour their
+          own software applications and
+          services. This includes prompting a choice
+          screen</strong>, at the moment of the users’ first use of an online search engine, virtual
+        assistant or web browser of the gatekeeper listed in the designation decision, allowing end users to select an
+        alternative default service when the operating system of the gatekeeper directs end users to those online
+        search
+        engine, virtual assistant or web browser and when the virtual assistant or the web browser of the gatekeeper
+        direct the user to the online search engine listed in the designation decision.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881400323&usg=AOvVaw2RhX2Wi6VmmQPP-hy62lGK">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+      </cite></p>
+    </blockquote>
+
+    <p>As such it is of critical importance that data to measure the effectiveness of
+      Apple’s compliance with the remedy is both collected and shared with relevant parties.</p>
+
+    <h3 id="apples-dark-pattern-exacerbated-by-keeping-hotseat">
+      <a class="header-anchor" href="#apples-dark-pattern-exacerbated-by-keeping-hotseat" aria-hidden="true">#</a>
+      3.2.5. Apple's Dark Pattern Exacerbated by Keeping Hotseat
+    </h3>
+
+    <figure>
+      <img alt="Main icons on iOS’s hotseat" src="/images/apple-dma-report/image2.png">
+      <figcaption>The hotseat on iOS’s homescreen</figcaption>
+    </figure>
+
+    <p>The <strong>hotseat</strong> is any of that collection of app
+      locations on the dock on the base of iOS homescreen. They have the advantage of always being shown regardless
+      of
+      which homescreen the user is on. Apple has set Safari to be in the hotseat by default (along with phone,
+      messages
+      and Apple Music), while users can change this setting manually by dragging the item out and another in, Apple
+      has
+      added significant friction by not making this automatic.</p>
+
+    <blockquote>
+      <p>Only about half (52%) of people understand that their default browser is
+        opened when they, for example, click on a link in an email or document.</p>
+      <p>[..]</p>
+      <p>over half (53%) also erroneously believed that their default browser would
+        automatically be pinned to their task-bar.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf&sa=D&source=editors&ust=1718648881401770&usg=AOvVaw2oJwEtl600_gmhSMqomfdn">
+            Mozilla – “Can browser choice screens be effective?” paper</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Being selected as the default browser does not grant the hotseat. This means it is
+      entirely possible, and in fact likely that many existing users who have set a third party browser as their
+      default
+      browser will still have Safari or Chrome on certain versions of Android in the hotseat.</p>
+
+    <p>While this is of concern on both Android and iOS, due to the undermining of the meaning
+      of default browser, an additional concern is introduced on iOS due to how Apple has implemented their choice
+      screen.</p>
+
+    <p>The DMA states this on choice screens:</p>
+
+    <blockquote>
+      <p>
+        This includes <strong class="stressed">prompting a choice screen, at the moment
+          of the users’ first use of an</strong> online
+        search engine, virtual assistant or <strong class="stressed">
+          web browser of the gatekeeper</strong>
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+            Digital Markets Act - Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple has interpreted the DMA very directly here and will only show the choice screen
+      upon Safari being clicked, unlike Google which does it immediately upon system software update.</p>
+
+    <p>In Apple’s design, Safari’s interface actually loads and then the choice
+      screen is a full screen overlay over Safari. This has the psychological effect of making the choice screen seem
+      more like an interruption rather than part of the setup of the device. While this was more problematic in
+      Apple’s initial design which included a giant skip button (labeled “not now”) at the bottom
+      (which would essentially choose Safari), this still seems to be a nudge to users to quickly choose a browser and
+      get back to their initial task.</p>
+
+    <blockquote>
+      <p>People are significantly more likely to choose a pre-installed browser as
+        their default when the choice screen is shown at first use of the
+        browser [...] from 11% to 19%</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf&sa=D&source=editors&ust=1718648881404212&usg=AOvVaw0lCGCBNKUDZoKZXQ6z1ES6">
+            Mozilla – “Can browser choice screens be effective?” paper</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple's design then creates the problematic scenario where the choice screen will
+      be shown even if Safari is not the default browser. Apple is clearly aware of this based on the careful phrasing
+      of their speech at the workshop:</p>
+
+    <blockquote>
+      <p>In terms of what's being required here by the DMA
+        our focus is on <strong class="stressed">presenting this choice</strong> even more
+        clearly to consumers <strong class="stressed">the first time you use Safari</strong>.
+        Obviously there are not choices being presented when
+        you use other browsers on iOS. So we are complying
+        <strong class="stressed">from our perspective with the spirit here</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881405837&usg=AOvVaw15yzvVFfwmNVsjNMNwfb2e">
+            Apple representative at DMA Workshop</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Showing the choice screen when Safari is not the default is clearly against the intent
+      of the act and Apple needs to update the choice screen to only show if Safari is the default browser. The
+      default
+      browser not automatically granting the hotseat, significantly compounds and re-enforces this problem. While it
+      is
+      possible for users to manually change this, this style of friction significantly undermines browser competition.
+      Operating system gatekeepers know this and this is precisely why they are so resistant to such a change.
+    </p>
+
+    <p>It should be assumed that because Apple has displayed the choice screen when third
+      party browsers were already set as default, that they would have already gained users for Safari that they would
+      otherwise not have.</p>
+
+    <p>A reasonable remedy here would be to re-run the choice screen for all users that picked
+      Safari upon such an inappropriate choice screen being shown. If Apple does not store that information, it can
+      simply re-run the choice screen for all Safari users.</p>
+
+    <h3 id="periodic-choice-screen">
+      <a class="header-anchor" href="#periodic-choice-screen" aria-hidden="true">#</a>
+      3.2.6. Periodic Choice Screens
+    </h3>
+
+    <p>The act aims to nullify the power operating system gatekeepers grant themselves by
+      setting the defaults on the operating system. In particular, the "default browser" to their own and
+      placing their browser in a prominent location by default.</p>
+
+    <p>A one-off choice screen may have an impact, perhaps even a significant one, but that
+      impact will fade and will not achieve this goal of the act. It therefore seems appropriate that the choice
+      screen
+      is re-shown to users at an appropriate interval. </p>
+
+    <p>We believe then, that the choice screen should be shown whenever users encounter a new
+      reinstallation event, such as purchasing a new phone, restoring from an old phone or a factory reset.</p>
+
+    <p>This allows the choice screen to have a lasting impact. While it will not remove the
+      immense self privilege of the defaults the operating system gatekeeper sets, it will at least make a significant
+      dent. Critical mass is important for browsers as it strongly affects website developers’ interest in
+      supporting them and dictates their funding, which dictates their development budget.</p>
+
+    <p>We believe the act would support the display of choice screen on devices in which the
+      user is either transferring or restoring their settings to that device. As of the time of writing this document
+      (iOS 17.5), this is not implemented by Apple.</p>
+
+    <h2 id="resolved-issues">
+      <a class="header-anchor" href="#resolved-issues" aria-hidden="true">#</a>
+      3.3. Resolved Issues
+    </h2>
+
+    <h3 id="option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default">
+      <a class="header-anchor" href="#option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default" aria-hidden="true">#</a>
+      3.3.1. Option to Change Default Browser Hidden if Gatekeepers
+      Browser is the Default Browser
+    </h3>
+
+    <p>For the first 13 years of iOS it was impossible to change the default browser, it was locked to
+      Safari. Then in iOS 14 (released on 2020-09-06), <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/21444995/ios-14-default-browsers-chrome-edge-firefox-duckduckgo-safari&sa=D&source=editors&ust=1718648881409211&usg=AOvVaw3V5cIS7JNps5dNNbdj3KBG">
+        Apple added the ability to change it</a>. However as part of this update, Apple specifically coded
+      the
+      astonishing brazen dark pattern of hiding the option to change the
+      default browser in Safari
+      settings,<em>if Safari was already default</em>.
+      If Safari was <em>not the
+        default browser</em>, the option to change the default browser became
+      prominently shown.
+    </p>
+
+    <p>In our own testing, we found that, after <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/?comments%3D1&sa=D&source=editors&ust=1718648881410178&usg=AOvVaw3EaC6Q3IiGTl2U-VfiLyLD">significant
+        publicity</a> (<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881410620&usg=AOvVaw3NaISNMXGfU85vff9JLTGM">generated
+        by OWA</a>), Apple has quietly fixed this issue globally in iOS 17.5, which was released
+      on 2024-05-13, long past Apple’s cutoff compliance date for the DMA of 2024-03-07. While we are pleased
+      they
+      have taken the step to fix this without being directly compelled to do so, we felt given the clear intent,
+      brazenness and late compliance, that it was important context worth including. You can see this below.</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image6.png" alt="Safari's settings screen not showing the default browser choice">
+        <img src="/images/apple-dma-report/image8.png" alt="Safari's settings screen showing the default browser choice">
+      </p>
+      <figcaption>
+        Left: When Safari is the default /
+        Right: When Firefox is the default (Note the option to change default
+        browser has appeared)
+      </figcaption>
+    </figure>
+
+    <p>We asked Apple directly about this at the Apple DMA Workshop.
+      You can see our question,<a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/&sa=D&source=editors&ust=1718648881411550&usg=AOvVaw1d862rWLxvNdKkiyEhjtLp">their
+        answer, and our analysis of their answer in this article</a>,
+      which was later <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/&sa=D&source=editors&ust=1718648881411844&usg=AOvVaw3EI3nw5miDrcgV7hQPvSyF">covered
+        on ArsTechnica</a>.</p>
+
+    <p>In other browsers on iOS the option is always shown regardless of whether they are the
+      default browser or not.</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image7.png" alt="Firefox's settings screen showing Safari as the default browser choice">
+        <img src="/images/apple-dma-report/image10.png" alt="Firefox's settings screen showing Firefox as the default browser choice">
+      </p>
+      <figcaption>
+        Left: When Safari is the default /
+        Right: When Firefox is the default (always shown on other browsers settings pages)
+      </figcaption>
+    </figure>
+
+    <p>Hiding the option to change the default browser if the gatekeeper's browser is the default was
+      a very clear violation of Article 13(4) as it clearly sought to undermine the users autonomy of choice.
+    </p>
+
+    <h2 id="remedies">
+      <a class="header-anchor" href="#remedies" aria-hidden="true">#</a>
+      4. Remedies
+    </h2>
+
+    <p>Here we propose three tranches of remedies which we believe are both justified and
+      proportionate. Some remedies require time and/or pre-requisite remedies in order to be effective. Remedies in
+      this
+      document are ordered to ensure that either competitive benefits are delivered earlier or to unlock future
+      remedies. In this way, we propose a program of continual improvement in the competitive landscape, delivering
+      wins
+      at every step along the path.</p>
+
+    <h2 id="tranche-1">
+      <a class="header-anchor" href="#tranche-1" aria-hidden="true">#</a>
+      4.1. Tranche 1
+    </h2>
+    <h3 id="browser-engine-entitlement-contract">
+      <a class="header-anchor" href="#browser-engine-entitlement-contract" aria-hidden="true">#</a>
+      4.1.1. Browser Engine Entitlement Contract
+    </h3>
+    <h4 id="remove-non-security-terms">
+      <a class="header-anchor" href="#remove-non-security-terms" aria-hidden="true">#</a>
+      4.1.1.1. Remove Non-Security Terms
+    </h4>
+
+    <p>Apple’s browser engine entitlement contract defines the conditions with which
+      browser vendors must comply with to be granted access by Apple to hardware and software features on iOS. Article
+      6(7) authorizes the gatekeeper to take such measures, but exclusively in order to preserve the security of the
+      operating system.</p>
+
+    <p>However, as discussed in <a href="#Apples-new-browser-engine-entitlement-contract">section
+        3.1</a>, Apple has incorporated into this contract a vast number of rules that do not
+      relate to security. These rules are therefore non-compliant with the DMA, and we recommend that Apple should
+      be
+      compelled to remove them.</p>
+
+    <p><strong>Apple should remove all non-security-related rules from this contract</strong>.</p>
+
+    <h4 id="dual-engine-browser">
+      <a class="header-anchor" href="#dual-engine-browser" aria-hidden="true">#</a>
+      4.1.1.2. Dual Engine Browser
+    </h4>
+
+    <p>Apple will need to remove the following rule from its browser engine entitlement
+      contract, and not add an equivalent rule elsewhere, such as in its app store guidelines:</p>
+
+    <blockquote>
+      <p>2.2 (page 1): “Be a separate binary from any Application that uses the
+        system-provided web browser engine”</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/contact/request/download/web_browser_engine.pdf&sa=D&source=editors&ust=1718648881414677&usg=AOvVaw1HgqKTOZfiAP12OAIK74ue">
+            Apple Browser Engine Entitlement Contract</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This rule is a significant barrier to browser vendors porting their real browsers to
+      iOS and defacto causes them to lose all their EU users on their existing browser app on iOS.</p>
+
+    <p>We cover this in greater depth in <a href="#must-not-use-browser-engine-of-operating-system">Section
+        3.1.2</a>.</p>
+
+    <h4 id="allow-browser-vendors-to-keep-their-existing-EU-customers">
+      <a class="header-anchor" href="#allow-browser-vendors-to-keep-their-existing-EU-customers" aria-hidden="true">#</a>
+      4.1.1.3. Allow Browser Vendors to keep their existing EU customers
+    </h4>
+
+    <p>Apple has chosen to restrict browser competition on iOS to the EU. Apple’s
+      actions seek to force third-party browser vendors to build, develop, and maintain two versions of their apps for
+      iOS while Apple’s own Safari bears no such costs.</p>
+
+    <p>Apple’s rules appear to force browser vendors to ship a brand new version of
+      their app in the EU, rather than update existing apps to use their own engines. This will cause browser vendors
+      to
+      lose existing customers, as consumers will need to manually download the new browser.</p>
+
+    <p>This complexity and friction is a direct result of Apple’s own anti-competitive
+      actions over the past 15 years. Apple’s insistence that competitors will only be allowed to compete on a
+      level playing field (with their own engines) in the EU is already a high burden, and this rollout plan would
+      levy
+      additional transition costs on competitors. It is reasonable and proportionate that Apple takes steps to
+      mitigate
+      the damage they appear intent on causing. </p>
+
+    <p>Forcing browser vendors to ship two distinct products in Europe will lead to end user
+      confusion and significant harm to these browser vendors. We do not believe that such an approach would be either
+      fair or compliant with the DMA.</p>
+
+    <p>Apple should not be forcing browser vendors to reacquire existing users. Apple will
+      need to implement a solution where browser vendors can use their own engines and keep their existing EU
+      users.</p>
+
+    <p>Specifically, we are seeking the Commission to compel Apple to allow browser vendors to
+      update their apps for EU consumers to their own engines. With this remedy, we are not asking that the Commission
+      compel Apple to make any changes outside the EU. It is between Apple and other global regulators if they add any
+      complex code or logic to restrict browser competition on iOS to the EU.</p>
+
+    <p>Apple has a number of options to comply with this remedy and have the opportunity to
+      suggest other alternatives that may solve the underlying issue. They are:</p>
+
+    <dl>
+      <dt>Solution A.</dt>
+      <dd><a href="#solution-a-allow-browser-engines-globally">Allow Browser Engines Globally</a></dd>
+      <dt>Solution B.</dt>
+      <dd><a href="#solution-b-two-binaries-for-one-bundle-id">Two Binaries for One Bundle ID</a></dd>
+      <dt>Solution C.</dt>
+      <dd><a href="#solution-c-global-dual-engine-binary-with-toggle">Global Dual Engine Binary with Toggle</a></dd>
+    </dl>
+
+    <p>Solution A and C would only require contract changes and the most minimal technical
+      changes.</p>
+
+    <p>We cover this in greater depth in <a href="#must-be-new-and-separate-app">Section
+        3.1.3</a>.</p>
+
+    <h4 id="requirement-to-use-apple-components">
+      <a class="header-anchor" href="#requirement-to-use-apple-components" aria-hidden="true">#</a>
+      4.1.1.4. Requirement to use Apple Components
+    </h4>
+
+    <p>Apple will need to remove any rule or suggestion that browser vendors are obligated to
+      replace parts of their browser engine with particular Apple layout, rendering or user interface components.
+    </p>
+
+    <p>Importantly, browser vendors need the right, but not the obligation, to use these
+      libraries and components.</p>
+
+    <p>We cover this in greater depth in
+      <a href="#requirement-to-use-apple-components">Section 3.1.10</a>.
+    </p>
+
+    <h4 id="remove-viral-terms">
+      <a class="header-anchor" href="#remove-viral-terms" aria-hidden="true">#</a>
+      4.1.1.5. Remove Viral Terms
+    </h4>
+
+    <p>“Apple Materials” is an inappropriately vague term that expands
+      Apple’s Browser Engine Entitlement Contract to include a great many non-security rules. The way it is
+      phrased is that any imperative statement in any document referenced from the contract or referenced from those
+      documents in cascade is a binding rule.</p>
+
+    <p>As this is purely a contract for API access, Apple is required to only have strictly
+      necessary and proportionate rules to protect the integrity of the operating system. Apple is also required to
+      justify all of these rules as being so.</p>
+
+    <p>As such, these viral terms must be removed and Apple should clearly present all
+      security rules that they wish third-party browser vendors to abide by in order to access APIs necessary for
+      building iOS browsers, preferably in a single document.</p>
+
+    <p>Any update to this document should be public and all relevant parties should be alerted
+      to the new proposed changes. Barring exceptional circumstances, changes should be known by browser vendors and
+      outside groups months in advance. </p>
+
+    <p>We cover this in greater depth in <a href="#viral-terms">Section
+        3.1.6</a>.</p>
+
+    <h4 id="security-rules-must-be-clear">
+      <a class="header-anchor" href="#security-rules-must-be-clear" aria-hidden="true">#</a>
+      4.1.1.6. Security Rules must be Clear
+    </h4>
+
+    <p>All security rules for browser vendors must be clear and upfront.</p>
+
+    <p>It is important that browser vendors can be confident they are abiding by all security
+      rules. In the event that Apple wishes to introduce rules that are not strictly necessary, proportionate,
+      justified
+      or that violate Article 5(7) then browser vendors will need time to respond and, if appropriate, notify the
+      Commission.</p>
+
+    <p>Specifically, Apple must publish all security rules for browsers in a single document.
+      Apple must commit to these rules being available, complete and accurate. In the event Apple wishes to update
+      this
+      document, it must notify all parties and give significant advanced warning of the exact changes it is making,
+      and
+      the justification of the necessity and proportionality of said changes. Apple will need to attest to the fact
+      that
+      the updated or new rules do not conflict with Article 5(7).</p>
+
+    <h4 id="justify-all-security-rules">
+      <a class="header-anchor" href="#justify-all-security-rules" aria-hidden="true">#</a>
+      4.1.1.7. Justify All Security Rules
+    </h4>
+
+    <p>We believe that Apple should be required to provide a security justification for each
+      individual rule attached to obtaining the API access required by browsers using their own engine: Why is it
+      strictly necessary and proportionate to prevent this access from compromising the integrity of the operating
+      system, hardware or software features provided by Apple as per the wording and intent of the act.</p>
+
+    <p>Any rule that cannot be justified, or where the justification is inappropriate or
+      insufficient, should be removed or modified.</p>
+
+    <p>We cover this in greater depth in <a href="#lack-of-justification-of-security-terms">Section
+        3.1.5</a>.</p>
+
+    <h4 id="penalties-for-security-rule-violation-must-be-proportionate-and-justified">
+      <a class="header-anchor" href="#penalties-for-security-rule-violation-must-be-proportionate-and-justified" aria-hidden="true">#</a>
+      4.1.1.8. Penalties for Security Rule Violation must be
+      Proportionate and Justified
+    </h4>
+
+    <p>Apple’s current penalties, as described, do not take into account the need for
+      proportionality. </p>
+
+    <p>The phrase “in Apple’s sole discretion” is not consistent with the
+      fact that Apple will need to justify each of its security measures. </p>
+
+    <p>The language of the contract should be updated to make it clear that the penalties will
+      be proportional and that Apple will provide detailed evidence and reasoning to support any penalty it might
+      choose
+      to impose.</p>
+
+    <p>We cover this in greater depth in <a href="#severe-and-unreasonable-penalties">Section
+        3.1.9</a>.</p>
+
+    <h4 id="justify-and-update-non-proportionate-security-terms">
+      <a class="header-anchor" href="#justify-and-update-non-proportionate-security-terms" aria-hidden="true">#</a>
+      4.1.1.9. Justify and Update Non-Proportionate Security
+      Terms
+    </h4>
+
+    <p>Apple has granted itself the ability to force any browser vendor to remove any browser
+      API that contains a vulnerability, no matter how minor and no matter how much effort the browser vendor has
+      taken
+      to mitigate the vulnerability.</p>
+
+    <p>This is particularly important, as the primary reason that the DMA grants browsers the
+      right to use their own browser engine is to prevent gatekeepers (such as Apple) from determining the
+      functionality
+      and standards for third-party browsers. Allowing Apple to ban third-party browsers from offering functionality
+      on
+      unjustified or non-existent security justifications would severely undermine this goal.</p>
+
+    <p>This appears to grant Apple broad powers to use unnecessary and disproportionate
+      security measures to block rival browsers from providing functionality that is distinct from Safari, preventing
+      one of the core aims of the act in allowing browser vendors to port their own engines.</p>
+
+    <p>This clause must be removed or modified to be strictly necessary and proportionate.
+      Apple must be required to provide clear and convincing evidence of necessity and proportionality of any
+      individual
+      execution of such a rule.</p>
+
+    <p>We cover this in greater depth in <a href="#vulnerability-disclosure">Section
+        3.1.4.2.2</a>.</p>
+
+    <h4 id="security-disclosure">
+      <a class="header-anchor" href="#security-disclosure" aria-hidden="true">#</a>
+      4.1.1.10. Security Disclosure
+    </h4>
+
+    <p>Apple has proposed a security disclosure requirement in their browser engine API
+      contract. We welcome this security disclosure policy, provided it applies equally to Safari. Our concern is that
+      if Apple can avoid full disclosure while, at the same time, compelling other vendors to disclose
+      vulnerabilities,
+      Apple may use these disclosures to falsely claim superior security or create a pretense for delisting other
+      browsers from their app store. Our recommendation would be for Apple to keep this policy but to also abide by it
+      for their own browser.</p>
+
+    <p>We cover this in greater depth in <a href="#vulnerability-disclosure">Section
+        3.1.4.2.2</a>.</p>
+
+    <h3 id="safari-and-other-apple-services-get-special-placement">
+      <a class="header-anchor" href="#safari-and-other-apple-services-get-special-placement" aria-hidden="true">#</a>
+      4.1.2. Safari and other Apple Services get Special Placement
+    </h3>
+
+    <p>On the settings page for iOS, pre-installed Apple apps are not placed with the other apps. Instead
+      they are given a special, far more prominent location, in the settings. Other third-party apps are shown in a
+      separate location further down the settings page. This divide suggests to
+      users that these are <em>official</em>apps they <em>should</em> be
+      using (which come pre-installed) and other apps are “alternative apps”.</p>
+
+    <p>These apps include:</p>
+    <ul>
+      <li>Siri</li>
+      <li>Apple App Store</li>
+      <li>Wallet and Apple Pay</li>
+      <li>Mail</li>
+      <li>Contacts</li>
+      <li>Calendar</li>
+      <li>Notes</li>
+      <li>Reminders</li>
+      <li>Freeform</li>
+      <li>Voice Memos</li>
+      <li>Phone</li>
+      <li>Messages</li>
+      <li>FaceTime</li>
+      <li>Safari</li>
+      <li>Stocks</li>
+      <li>Weather</li>
+      <li>Translate</li>
+      <li>Apple Maps</li>
+      <li>Compass</li>
+      <li>Measure</li>
+      <li>Health</li>
+      <li>Journal</li>
+      <li>Apple TV</li>
+      <li>Photos</li>
+      <li>Camera</li>
+      <li>Books</li>
+      <li>Podcasts</li>
+      <li>Game Center</li>
+    </ul>
+
+    <p>It indicates to the user that these apps are special and that, while it may be
+      mechanically possible for some of these apps to be replaced by third party apps, the non-neutral nature of the
+      interface arguably seeks to dissuade users from changing the default.</p>
+
+    <p>In particular the fact that Safari has a separate and elevated position from other
+      browsers is, we believe, in contravention of Article 6(3), Article 13(6) and Recital 70 which state:</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow and technically enable
+          end users to easily change default settings on the operating system</strong>, virtual assistant and
+        web browser of the gatekeeper that direct or steer end users to products or services provided by the
+        gatekeeper.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881425413&usg=AOvVaw3u8K2uJAyJI76O1dKICYkT">
+            Digital Markets Act – Article 6(3)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The gatekeeper shall not degrade the conditions or quality of any of the
+        core platform services provided to business users or end users who avail themselves of the rights or choices
+        laid
+        down in Articles 5, 6 and 7, or make the exercise of those rights or choices
+        unduly difficult, <strong class="stressed">including by offering choices to the end-user in a non-neutral
+          manner, or by subverting end
+          users’ or business users' autonomy, decision-making, or free choice via the structure, design,
+          function
+          or manner of operation of a user interface or a part thereof</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881426274&usg=AOvVaw3zwMSogO3thbJiOCPUer4R">Digital
+            Markets Act – Article 13(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">Gatekeepers should not engage in behaviour that
+          would undermine the effectiveness of the prohibitions and obligations</strong>
+        laid down in
+        this Regulation. Such behaviour <strong class="stressed">includes the design used by the
+          gatekeeper, the presentation of end-user choices in a
+          non-neutral
+          manner</strong>, or using the structure, function or manner of operation of a user interface
+        or a
+        part thereof to <strong class="stressed">subvert or impair user autonomy, decision-making, or
+          choice</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881427078&usg=AOvVaw3S8pwN918Ynpb1Fl4AWJfI">
+            Digital Markets Act – Recital 70</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple should move all of its apps and third party apps into the same location in
+      settings. In the event particular types of apps are of elevated importance such as app store, browser, photos,
+      or
+      backup provider, Apple could additionally place the current default in a special location in a neutral manner.
+    </p>
+
+    <p>This is an example mockup of what that might look like:</p>
+
+    <figure class="double">
+      <p>
+        <img src="/images/apple-dma-report/image9.png" alt="Example of list of settings">
+        <img src="/images/apple-dma-report/image12.png" alt="Example of a settings page with a list of defaut browsers">
+      </p>
+      <figcaption>
+        Possible Default Location and Default selection page for browsers
+      </figcaption>
+    </figure>
+
+    <p>The goal of this remedy is to indicate to the user that while these apps are
+      pre-installed by Apple, they are replaceable and have no elevated privileges over other third party apps. This
+      will encourage contestability of these services as per the intent of the act.</p>
+
+    <h3 id="safari-is-not-uninstallable">
+      <a class="header-anchor" href="#safari-is-not-uninstallable" aria-hidden="true">#</a>
+      4.1.3. Safari is Not Uninstallable
+    </h3>
+
+    <p>Apple is obligated under the act to make Safari uninstallable. This is psychologically
+      important as it indicates to users that Safari is just another app on their phone that can be uninstalled and
+      replaced, just like any other non-Apple app.</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow and technically enable
+          end users to easily un-install any software applications on the operating system of the
+          gatekeeper</strong>, without prejudice to the possibility for that gatekeeper to restrict such
+        un-installation in relation
+        to software applications that are essential for the functioning of the operating system or of the device and
+        which
+        cannot technically be offered on a standalone basis by third parties.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881428631&usg=AOvVaw0_HAerqa-EXIImBDFzstjB">Digital
+            Markets Act – Article 6(3)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly, the WKWebView and SFSafariViewController should be treated as system components, and
+      it should not be possible to uninstall them. Both of these components are used in a wide variety of native apps.
+      Many native apps use the WKWebView as a convenient way to render first/second party content and any remedy which
+      would break these apps would be unreasonable, disproportionate and counter-productive. Other apps use
+      SFSafariViewController when the user clicks on an external http/https link and should be allowed to continue to
+      do
+      so, provided <a href="#sfsafariviewcontroller-must-respect-browser-choice">Apple commits to making
+        SFSafariViewController respect the user’s choice of default browser</a>.
+    </p>
+
+    <p>We would also support it not being possible to uninstall the default browser until a
+      new default browser has been selected. An appropriate and neutral error message should be displayed if the user
+      attempts to do so.</p>
+
+    <p>We are uncertain if SFSafariViewController is built on top of Safari or the WKWebView.
+      In the event it is currently built on the WKWebView it is not a blocker to Safari being fully uninstallable.
+    </p>
+
+    <p>In the event it is currently mechanically bound to Safari it will need to be updated to instead
+      not impose a browser engine on end users and business users but rather interoperate with the users chosen
+      default
+      browser <a href="#sfsafariviewcontroller-must-respect-browser-choice">as discussed in 4.2.2</a>.
+      In the (likely rare) instance that the user's chosen default browser does not support interoperating with
+      SFSafariViewController then links can simply open in the user's default browser directly.</p>
+
+    <h3 id="implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers">
+      <a class="header-anchor" href="#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers" aria-hidden="true">#</a>
+      4.1.4. Implement Web App Install Prompts for iOS Safari and WKWebView browsers
+    </h3>
+
+    <p>According to Article 6(6), Gatekeepers, such as Apple, shall not <q>&gt;restrict
+        technically or otherwise the ability of end users to switch between, and subscribe to,
+        different software applications and services that are accessed using the core platform services of the
+        gatekeeper.</q></p>
+
+    <p>iOS and Safari are both implicated in delivering Web Apps, and both are designated core
+      platform services. Via its control of both iOS and Safari, Apple has long denied Web Apps the ability to prompt
+      the user to be installed, adding great friction to the process of installing them. Instead, the option to
+      install
+      a Web App is hidden away in a hard to find “share” menu option. Competing browser vendors were only
+      provided with access to this share menu function last year, and are still denied access to the necessary APIs
+      within WKWebView to implement the ability for websites to enable such user-driven prompts.</p>
+
+    <p>Apple has implemented many pieces of equivalent functionality to install native apps from their
+      own app store via Safari, including but not limited to <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/walled-gardens-report/%23app-clips&sa=D&source=editors&ust=1718648881430288&usg=AOvVaw0jcNHZRQcePrdPl4VAVOof">App
+        Clip Associated Domains</a>&nbsp;and <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/walled-gardens-report/%23smart-app-banners&sa=D&source=editors&ust=1718648881430560&usg=AOvVaw3GwzmrrhVwVIHyKDiupkIt">Smart
+        Banners</a>.</p>
+
+    <p>Due to the manner in which WKWebView-based browsers on iOS are implemented, only Apple
+      can effectively implement install prompts for them, and has steadfastly refused to do so despite consistent
+      developer requests.</p>
+
+    <p>We believe that Apple should be obligated to implement install prompts, including both
+      automatic prompts (akin to Smart Banners) and the ability to programmatically display prompts on a button click
+      from within websites that meet the minimum criteria for installation (e.g., providing a Web App Manifest). Apple
+      should also implement APIs already in use across the web to facilitate control over this behavior
+      (“onbeforeinstallprompt”). onbeforeinstallprompt is the technical term for the current
+      implementation,
+      it is an event that tells developers that it is possible to install the website as a web app, this means they
+      can
+      add a button to the page that will trigger showing the choice to the user. This allows developers to create
+      their
+      own install buttons.</p>
+
+    <blockquote>
+      <p>The beforeinstallprompt event fires when the browser has detected that a
+        website can be installed as a Progressive Web App.</p>
+      <p>There's no guaranteed time this event is fired, but it usually happens on page
+        load.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event&sa=D&source=editors&ust=1718648881431722&usg=AOvVaw2YkhPiSf2KacvbD5nYCk0w">
+            Mozilla Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Given that Apple has withheld this functionality for almost a decade, we believe that
+      Apple should not be able to delay discussions of the specifications as this could take months or even years.
+      Rather, they should implement the current specification as is currently available in other browsers which
+      support
+      the feature. After implementing the functionality, Apple can then propose any updates or upgrades.</p>
+
+    <p>Apple should not be allowed to add additional scare screens or other friction as it is
+      not necessary from a security perspective. The ability to install Web Apps via iOS Safari has been available for
+      almost 15 years without such measures, and Apple has not felt it was necessary to implement such measures. They
+      surely cannot be justified now, particularly after Apple’s strong claims regarding the security of its iOS
+      Web App container.</p>
+
+    <p>Web Apps are protected by the sandbox of the browser, which
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf&sa=D&source=editors&ust=1718648881432640&usg=AOvVaw2S_5bW7AyQ7s3-LOIcnBj-">Apple
+        states</a> is <q>&gt;orders of magnitude more stringent than the
+        sandbox for Native Apps</q>. This is important as it means that Apple does not have any
+      significant unmitigatable security objections to such a change.
+    </p>
+
+
+    <h3 id="app-store-rules-for-browsers-must-be-fair-reasonable-and-non-discriminatory">
+      <a class="header-anchor" href="#app-store-rules-for-browsers-must-be-fair-reasonable-and-non-discriminatory" aria-hidden="true">#</a>
+      4.1.5. App Store Rules for Browsers Must Be Fair, Reasonable, and Non-Discriminatory (FRAND)
+    </h3>
+
+    <p>Apple may be tempted to move proposed non-security rules regarding browsers from its
+      proposed browser engine entitlement contract to the broader app store guidelines, which it includes by reference
+      within the proposed Browser Engine Entitlement Addendum. By phrasing the browser engine contract as an addendum,
+      rather than a stand-alone contract, the terms of the entire “Apple Developer Program License
+      Agreement” is included.</p>
+
+    <p>A number of the rules within the engine entitlement addendum do not appear to be fair
+      or reasonable, including:
+    </p>
+
+    <ul>
+      <li>That the browser must be solely distributed in the EU</li>
+      <li>The browser must be a separate binary from one that uses the systems
+        browser engine</li>
+      <li>Apple may change the rules at any time with no notice</li>
+      <li>Apple makes no guarantees as to the accuracy of the rules</li>
+      <li>Apple can reject browsers for any reason at its sole
+        discretion</li>
+      <li>Apple can remove, suspend, break any API with no notice</li>
+      <li>Any breach of rules, no matter how minor, will allow Apple to block
+        or remove your application from all Apple platforms including macOS</li>
+    </ul>
+
+    <p>Apple should not be allowed to add rules for browsers to the app store guidelines or
+      apple program developer license that are unfair, unreasonable or discriminatory.</p>
+
+    <p>While we recognise that the DMA may not have the ability to compel Apple to allow
+      browsers to compete fairly on iOS globally, the unfairness of keeping this privilege exclusive to Safari (out of
+      browsers which ship their own engine) should be noted. The EU should consider any remedies available to lessen
+      this unfairness.</p>
+
+    <h3 id="app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43">
+      <a class="header-anchor" href="#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43" aria-hidden="true">#</a>
+      4.1.6. App Store Rules for Browsers Must Not Violate Article 5(7) and Recital 43
+    </h3>
+
+    <p>Under Article 5(7), Apple can not impose a browser engine on competing browsers. The
+      aim here outlined in Recital 43 is to prevent gatekeepers (such as Apple) from determining the functionality and
+      standards of rival browsers by imposing a browser engine.</p>
+
+    <p>That is, browser vendors must be free to compete in features, stability, security and
+      privacy. Under Article 13(4) Apple can not construct alternative rules or OS design choices that would undermine
+      and render Article 5(7) ineffective.</p>
+
+    <p>So any rule, including rules moved from Apple’s browser engine entitlement
+      contract into Apple’s app store rules, Apple developer program license contract or rules in documents
+      included by reference must be compliant with Article 5(7).</p>
+
+    <h3 id="testing-for-browser-vendors-and-developers-outside-the-EU">
+      <a class="header-anchor" href="#testing-for-browser-vendors-and-developers-outside-the-EU" aria-hidden="true">#</a>
+      4.1.7. Testing for Browser Vendors and Developers Outside the EU
+    </h3>
+
+    <p>Under Apple’s current proposal, browser vendors and companies that develop
+      websites for the EU, whose development teams are outside the EU, will be unable to test their websites or Web
+      Apps
+      in browsers on iOS that use their own engine - except for Safari. Apple's Safari will be the only browser
+      which uses its own engine that will be available globally.</p>
+
+    <p>Apple's browser engine entitlement contract makes no exception for test devices in
+      its rule that browsers using their own engine (other than Safari) must only be available (on iOS) in the EU.
+      Apple’s technical restrictions, launched as part of iOS 17.4, further indicate hostility towards
+      reasonable
+      exceptions for development and testing, with the OS using multiple mechanisms to geofence access to EU-specific
+      behavior to devices physically within the EU.</p>
+
+    <p>For Browser Vendors, the contract is less clear. It does reference “Authorized Test
+      Units” but offers no clarification. In practice, Apple appears to have a policy that all test units for
+      browser vendors must be physically located&nbsp;in the EU.
+    </p>
+
+    <blockquote>
+      <p>The Register has learned from those involved in the browser trade that
+        <strong class="stressed">
+          Apple has limited the development and testing of third-party browser engines to devices
+          physically located in the EU</strong>. That requirement adds an additional barrier to anyone
+        planning to develop and support a browser with an alternative engine in the EU.It effectively geofences
+        the development team. Browser-makers whose dev teams are located in the US will only be able to work on
+        simulators. While some testing can be done in a simulator, there's no substitute for testing on device
+        –
+        which means developers will have to work within Apple's prescribed
+        geographical boundary.
+      </p>
+      <p>‘The contract terms are bonkers and almost no vendor I'm
+        aware of will agree to them,’ lamented one industry veteran familiar with the making of browsers in
+        response
+        to an inquiry from The Register.</p>
+      <p>‘Even folks that may have signed something to be able to prototype can't
+        ship under the constraints Apple's trying to impose. They're so broad and sweeping as to try to duck
+        most
+        of the DMA by contract … which is certainly bold.’</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theregister.com/2024/05/17/apple_browser_eu/&sa=D&source=editors&ust=1718648881436388&usg=AOvVaw355MUPvT3HT1_MhipFl1sv">
+            Thomas Claburn – The Register</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Great story showing how it's clear Apple isn't serious about browser
+        engine competition in Europe.</p>
+      <p>We've got a blink build running well on the simulator but still have no idea if
+        it works on device 🤷.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://twitter.com/RickByers/status/1791609238000705824&sa=D&source=editors&ust=1718648881437283&usg=AOvVaw3x2Qhlue9Egb70lEr_E5lk">
+            Rick Byers – Web Platform Area Tech Lead, Chrome</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This places browser vendors and web developers attempting to reach EU customers via the
+      web at a significant disadvantage that Apple and Safari are not subject too. This greatly harms the goals of
+      interoperability and competition that the DMA sets out to allow.</p>
+
+    <p>This will harm EU end users by making these browsers less secure due to the inability
+      for any engineering team, geographically outside of the EU, being able to develop and test their products
+      accurately. Some, perhaps even most, browser vendors hire security experts from all around the world and some
+      security bugs (like JIT bugs) will need a real device to test and debug on. Not only would this put EU users at
+      risk, but it would also unfairly disadvantage the competing browser vendors.</p>
+
+    <p>Is it really reasonable for Apple to in effect force the entire development teams of
+      these mobile browsers to relocate to the EU? Would Apple accept a similar requirement for their own products in
+      another jurisdiction?
+    </p><p>This also prohibits automated on-device tests for browser vendors outside the EU.
+      Again, the end result of this will be poorer quality products as a result of Apple’s unreasonable
+      restriction.</p>
+
+    <p>Finally, of the millions of web developers and businesses outside the EU who serve EU
+      customers, but do not live in the EU, should Apple really be able to make it impossible for them to effectively
+      test their software on competing browsers?</p>
+
+    <p>We had hoped that Apple might reasonably foresee these complications and voluntarily
+      cease this continued anti-competitive behavior and make it possible for developers to test their products
+      outside
+      of the EU. Unfortunately, Apple seems content with making the web less interoperable and more difficult to
+      develop
+      for.</p>
+
+    <p>As the DMA is (likely) unable to compel Apple to allow browser vendors to compete on
+      iOS with their own engines globally, we propose two potential solutions: </p>
+
+    <ol>
+      <li>Relax the requirements on test devices so that browser vendors can
+        at least test their own browsers on test devices outside the EU. This seems an extremely reasonable request
+        and
+        Apple has no reason beyond malice and a belief they can’t legally be forced to do so to not comply with
+        it. If Apple believes it does have legitimate reasons it should publicly publish them so they can be
+        scrutinized. This part of the remedy solves the problem for allowing browser vendors to develop and test their
+        products.In the case that this scenario is actually a mistake on Apple’s part, and is just a lack
+        of foresight on the needs of developers in regards to testing, Apple should issue updated guidance that
+        browser
+        vendor test devices are exempt from this policy.</li>
+      <li>Any developer with an Apple developer account should be able to
+        download the EU versions of browsers globally onto their own iOS devices for the explicit purpose of testing.
+        This will allow them to test their software in these browsers, which is critical in allowing Web App/website
+        developers to compete. Apple should not be allowed to add undue friction, charge a fee, or restrict these
+        browsers in any way that might significantly undermine the extensive manual and automated testing that major
+        web
+        based products undergo. This will allow the millions of web developers that service the EU to test their
+        products.</li>
+    </ol>
+
+    <p>Apple may point to TestFlight as a possible solution, but this is insufficient. There
+      are hard usage caps of 10,000. &nbsp;Given there are 1.1 billion websites worldwide, we would anticipate that
+      the
+      number of developers that need to test for mobile browsers in the EU would be in the millions and likely
+      comparable to the number of developers who download beta versions of Firefox/Chrome/Edge.</p>
+
+    <p>Apple may also point at the xCode simulator as a possible solution, however this is not
+      acceptable, as many bugs will only appear on real devices, and development of user interfaces will often require
+      the developer to be able to interact with the device to test the responsiveness and feel of the interactions.
+      This
+      sort of testing is not possible in the simulator.</p>
+
+    <h3 id="allow-dev-beta-versions-of-browsers-on-non-beta-versions-of-iOS">
+      <a class="header-anchor" href="#allow-dev-beta-versions-of-browsers-on-non-beta-versions-of-iOS" aria-hidden="true">#</a>
+      4.1.8. Allow Dev/Beta Versions of Browsers on Non-Beta Versions of iOS
+    </h3>
+
+    <p>On other operating systems such as macOS, Windows, Linux, and Android, developers can
+      download multiple versions of the same browser including Stable, Beta, Dev, and Canary “channels”.
+      This allows developers of websites and Web Apps to test their products for compatibility and regressions prior
+      to
+      new versions of browsers being made available to consumers. This increases the quality and safety of both Web
+      Apps
+      and browsers.</p>
+
+    <p>Apple’s app store rules contains the following provision:</p>
+
+    <blockquote>
+      <p>2.2 Beta Testing</p>
+      <p>Demos, betas, and trial versions of your app don’t belong on the App Store
+        – use TestFlight instead. Any app submitted for beta distribution via TestFlight should be intended for
+        public distribution and should comply with the App Review Guidelines. Note, however, that apps using
+        TestFlight
+        cannot be distributed to testers in exchange for compensation of any kind, including as a reward for
+        crowd-sourced
+        funding. Significant updates to your beta build should be submitted to TestFlight App Review before being
+        distributed to your testers. To learn more, visit the TestFlight Beta Testing page.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/%23:~:text%3Dyour%2520review%2520notes.-,2.2%2520Beta%2520Testing,your%2520testers.%2520To%2520learn%2520more%252C%2520visit%2520the%2520TestFlight%2520Beta%2520Testing%2520page.,-2.3%2520Accurate%2520Metadata&sa=D&source=editors&ust=1718648881440321&usg=AOvVaw0yaW1C2oK9mQm0UGVD_7bQ">
+            Apple’s app store rules</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Due to this and limits imposed by Apple’s “Test Flight” program it is
+      practically ensured that Beta, Dev, and Canary versions of competing browsers are not widely available. The
+      number
+      of test users required for popular browsers, which are platforms in their own right, is extraordinary among
+      apps.</p>
+
+    <blockquote>
+      <p>TestFlight has a 10,000 user limit, which is a tiny fraction of the beta
+        population for web browsers with large user bases.The limitation becomes a maintenance burden for browser
+        developers: when reaching the limit, old users must be manually removed from the list. The user experience for
+        prerelease testers is more complicated than on other platforms: users must download the separate TestFlight
+        application, sign up for an access code, wait to receive it, and then paste it into the application.
+        Distributing
+        with a public link is not feasible because of the user limit restriction.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/mozilla/platform-tilt/issues/16&sa=D&source=editors&ust=1718648881441108&usg=AOvVaw37Wo0oErhk8W32fPxDFBdj">
+            Mozilla – Platform Tilt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Tying of browsers to OSes used to be commonplace, for example with Internet Explorer
+      and Microsoft Windows, but in the past 15 years this practice has been abandoned by most browser vendors. Apple
+      remains a notable exception, meaning iOS Safari can only be updated when the whole OS updates, and there can
+      only
+      be a single version of the WebView or Safari at any time. This raises costs on developers who may need to
+      procure
+      multiple iOS devices to adequately test.</p>
+
+    <p>Given that the purpose of the DMA is to allow rivals to compete to provide better
+      functionality, stability, and security, Apple should not be able to restrict browser vendors via app store rules
+      from providing Beta, Dev and Canary versions of their products provided they are clearly labeled and marketed as
+      such. Specifically, it should amend the rule to make an exemption for browsers.</p>
+
+    <p>Such competition will improve browser testing on iOS and may push Apple to make
+      long-needed improvements to provide equivalent functionality for Safari.</p>
+
+    <p>This change will not require any technical changes on Apple’s end nor will it
+      require the EU to make any extra-territorial requests. This simply requires Apple to update its contracts and
+      app
+      store rules to allow this critical use case.</p>
+
+    <h3 id="browser-choice-screen-on-ios">
+      <a class="header-anchor" href="#browser-choice-screen-on-ios" aria-hidden="true">#</a>
+      4.1.9. Browser Choice Screen on iOS
+    </h3>
+
+    <p>In order to comply with both the letter and intent of the Digital Markets Acts Article
+      6(3) and to make that compliance effective we believe that Apple should make the following changes:</p>
+
+    <ul>
+      <li>Allow browsers to show a single line of text explaining why
+        users should pick their browser on the choice screen directly. This line should be allowed to be at least up
+        to
+        150 characters long.</li>
+      <li>The browser choice screen should not be locked to or entrench Apple
+        app store. Both the browsers available and the calculation of the top 12 should include browsers downloaded
+        either directly or from other app stores. Browser vendors should be able to opt to provide their browsers
+        directly to users.</li>
+      <li>Once the user has chosen their browser, the selection flow should
+        continue to the home screen and download the chosen browser in the background, allowing the user to continue
+        their task. Making the user wait with a prominent cancel button undermines the autonomy of users.
+      </li>
+      <li>Apple should share aggregate statistics with browsers vendors about
+        the performance of their browser on the choice screen. This should be daily and automatic. Importantly this
+        needs to include enough detail to allow browser vendors to calculate the percentage of the times it is chosen,
+        per country, per day. Browser vendors should be free to publicly publish this data if they so choose.
+      </li>
+      <li>Being set as the default browser should grant the chosen browser the
+        <em>hotseat</em>. Under no circumstances should the choice screen show if
+        Safari is not already the default browser. Apple should re-show the choice screen to all users that
+        currently
+        have Safari as their default, and that the choice screen was inappropriately shown too, if they do not have
+        this
+        data it should be reshown to all users with Safari as the default.
+      </li>
+      <li>The choice screen should be shown whenever users encounter a new
+        reinstallation event, such as purchasing a new phone,
+        restoring from an old phone or a factory reset</li>
+    </ul>
+
+    <p>We cover this in greater depth in <a href="#choice-screens">Section
+        3.2 </a>.</p>
+
+    <h2 id="tranche-2">
+      <a class="header-anchor" href="#tranche-2" aria-hidden="true">#</a>
+      4.2. Tranche 2
+    </h2>
+
+    <p>Tranche 2 interventions are not less important than those proposed for Tranche 1 (or
+      for Tranche 3), but are instead proposed in a staged order to ensure that progress is made consistently.
+    </p>
+
+    <h3 id="web-app-installation-and-management-for-third-party-browsers">
+      <a class="header-anchor" href="#web-app-installation-and-management-for-third-party-browsers" aria-hidden="true">#</a>
+      4.2.1. Web App Installation and Management for third-party Browsers
+    </h3>
+
+    <blockquote>
+      <p>We all rely on browsers to use the internet on our phones, and the engines
+        that make them work have a huge bearing on what we can see and do. Right now, choice in this space is severely
+        limited and that has real impacts – preventing innovation and reducing competition from web apps. We
+        need to
+        give innovative tech firms, many of which are
+        ambitious start-ups, a fair chance to compete.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming%23:~:text%3DWe%2520all%2520rely,chance%2520to%2520compete.&sa=D&source=editors&ust=1718648881444309&usg=AOvVaw3WID0Rw0VySRuTGIcCaEfq">
+            Andrea Coscelli – Chief Executive of the UK's Competition and Markets Authority</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/&sa=D&source=editors&ust=1718648881444753&usg=AOvVaw10R8jfKTaGmZRSTzoj-pjg">First,
+        Apple claimed that they had to entirely remove Web App functionality</a>&nbsp;to avoid
+      sharing it with third-party browsers using their own engine.</p>
+
+    <blockquote>
+      <p><strong class="stressed">Addressing the complex security and privacy concerns
+          associated with web apps using alternative browser engines would require building an entirely new
+          integration
+          architecture that does not currently exist in iOS</strong> and was not practical to
+        undertake
+        given the other demands of the DMA and the very low user adoption of Home
+        Screen web apps. <strong class="stressed">And so, to comply with the
+          DMA’s requirements, we had to remove the Home Screen web apps
+          feature
+          in the EU</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu%238&sa=D&source=editors&ust=1718648881445389&usg=AOvVaw2l5xSV7Lfd5vKHUtvS0Qx4">
+            Apple’s statement</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>They then, <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/&sa=D&source=editors&ust=1718648881445935&usg=AOvVaw2Ye22bux_X4pKvP6SNOwpB">under
+        significant pressure, reversed that decision</a> and stated that they will keep the
+      current status-quo, implying that access to the underlying APIs required to run Web Apps would be locked to
+      the
+      WebKit implementation and that third-party browsers using their own engine would not be provided sufficient
+      API
+      access to contest it. That is, third-party browsers would continue to be unable to install and manage Web Apps
+      using their own engine.</p>
+
+    <blockquote>
+      <p>This support means Home Screen web apps continue to be built directly on
+        WebKit and its security architecture, and align with the security and privacy model for native apps on
+        iOS.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu%238&sa=D&source=editors&ust=1718648881446492&usg=AOvVaw3a0dPv3GUksfrsvgQZcUpY">
+            Apple’s statement</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This stance is in clear contravention of Article 5(7), 6(7) and 13(4). </p>
+
+    <p>It also undermines the Act’s core purpose in prohibiting imposing browser engines outlined
+      in Recital 43, which is to prevent gatekeepers from blocking third-party
+      browsers for implementing features for
+      <strong>“web software applications”</strong>
+    </p>
+
+    <p>Browser vendors require the ability to install, manage, and control Web Apps using
+      their own engines. This is the only way that browser vendors can compete in the provision of functionality,
+      stability, security and privacy for Web Apps.</p>
+
+    <p>As such, Apple must build, update, or provide access to all relevant APIs to install
+      Web Apps to browser vendors with the browser engine entitlement. OWA believes the Commission, and competitors,
+      are
+      owed a full and timely explanation of the implementation plan for these features.</p>
+
+    <h3 id="sfsafariviewcontroller-must-respect-browser-choice">
+      <a class="header-anchor" href="#sfsafariviewcontroller-must-respect-browser-choice" aria-hidden="true">#</a>
+      4.2.2. SFSafariViewController Must Respect Browser Choice
+    </h3>
+
+    <p>SFSafariViewController, Apple’s Remote-Tab In-App Browser (IAB) system continues
+      to self-preference Safari, denying users access to their default browsers when web pages are loaded within
+      third-party apps.</p>
+
+    <p>In order to respect the users choice of default browser as mandated in Article 6(3),
+      and to conform with Article 5(7) which prohibits the imposition of a browser engine on end users and business,
+      Apple must extend SFSafariViewController and provide an operating system API which other browsers can register
+      and
+      interoperate with it to be invoked when users click on links in non-browser apps. This can work in a manner
+      similar to how Android Custom Tabs works. Apple must provide an implementation plan to the Commission and should
+      share its documentation and timeline prior to release, as soon as practicable. OWA suggests this should take
+      less
+      than 6 months, even with Tranche 1 interventions underway as the engineering work is not large.</p>
+
+    <p>Apple may claim that the fact they allow Native Apps to implement their own in-app
+      browser means they are not imposing their browser engine on business users, however, this is an extremely high
+      friction barrier: In order not to use Safari's browser engine and instead use the default browser, these
+      businesses must invest to build their own WebView browser as opposed to simply calling the appropriate OS
+      API.</p>
+
+    <p>Further this also undermines the users choice of default browser by making all native apps that
+      call the system default remote tab browser use Safari instead of the users default browser. This, in turn, will
+      cause friction as Safari will not share user preferences and history with the user’s default browser,
+      resulting in an experience that is dubbed
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://infrequently.org/2022/06/apple-is-not-defending-browser-engine-choice/%23:~:text%3DThis%2520split%2520experience%2520causes%2520a%2520sort%2520of%2520pervasive%2520forgetfulness%252C%2520making%2520the%2520web%2520less%2520useful.&sa=D&source=editors&ust=1718648881448164&usg=AOvVaw2yUzgJK_cRyGGE5fKAqYE2">The
+        Forgetful Web</a>.
+    </p>
+
+    <p>We cover this in detail in our document
+      <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+        “OWA - DMA Interventions – In-App Browsers”
+      </a>
+    </p>
+
+    <h3 id="allow-third-party-browsers-to-ship-their-own-extensions">
+      <a class="header-anchor" href="#allow-third-party-browsers-to-ship-their-own-extensions" aria-hidden="true">#</a>
+      4.2.3. Allow Third-Party Browsers to Ship their Own Extensions
+    </h3>
+
+    <blockquote>
+      <p>Browser extensions are a key part of the web ecosystem and most popular
+        browsers support them. Browser extensions allow developers to add functionality to the browser providing
+        increased
+        utility, usability, and interoperability with applications installed
+        on the system.</p>
+
+      <p>
+        For distribution, popular browsers have established extension catalogs that are
+        available on the open web and curated by the browser vendors. Because extensions have elevated privileges,
+        developers submit them to be approved to ensure safety and compatibility. Browser vendors make their own
+        decisions
+        about the APIs available to extensions. Extensions for each browser are installed and managed within the
+        browser
+        resulting in a common user experience across platforms.</p>
+      <p>Safari supports extensions distributed on the iOS App Store. However, third-party
+        browsers are prevented from offering their own established extension functionality because it would violate
+        section 2.5.2 of the App Store Review Guidelines. To allow third-party browsers to offer the same
+        functionality
+        and be competitive with respect to browser extensibility, the App Store software requirements should be
+        relaxed to
+        permit third-party browsers to use their own extension catalogs. Third-party browsers could then use the
+        existing
+        web-based distribution model (where users can browse and install extensions directly from the browser)
+        allowing
+        for browser extensions to be used on iOS, similarly to other mobile
+        and desktop platforms.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/mozilla/platform-tilt/issues/15&sa=D&source=editors&ust=1718648881449989&usg=AOvVaw0UCIJSbY3WMmagSeZpalhv">
+            Mozilla – Platform Tilt</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Currently Apple does not allow, and has no plans to allow, third-party browsers to ship
+      their own extensions. Currently this functionality is exclusive to browsers that rely on the WKWebView and rely
+      on
+      extensions shipped via Apple's app store.</p>
+
+    <p>In order to compete fairly, browsers will need the ability to distribute extensions
+      directly. This is explicitly prohibited by Apple's current app store rules.</p>
+
+    <p>Apple will need to update their browser entitlement contract and app store rules to
+      allow browser vendors to compete in the provision of such functionality. </p>
+
+    <p>Under 5(7), browsers must be allowed to port their extension architecture.</p>
+
+    <h3 id="in-app-browsers-must-respect-browser-choice">
+      <a class="header-anchor" href="#in-app-browsers-must-respect-browser-choice" aria-hidden="true">#</a>
+      4.2.4. In-App Browsers Must Respect Browser Choice
+    </h3>
+
+    <p>Apple has encouraged and overseen an ecosystem of native apps downloaded via
+      Apple’s app store which ignore user choice of default browser on a massive scale.</p>
+
+    <p>In our document
+      <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+        “OWA - DMA Interventions - In-App Browsers”
+      </a>
+      we proposed the following remedies to fix the issue:
+    </p>
+
+    <ol>
+      <li>Designated Core Platform Services should respect the users choice of
+        default browser.</li>
+      <li>App store rules must mandate non-browser apps use the user's
+        chosen default browser for http/https links to third-party websites/Web Apps.</li>
+      <li>Apple must update SFSafariViewController to respect the user's
+        choice of default browser.</li>
+      <li>Third-party businesses must be provided an explicit and effective
+        technical opt-out from non-default in-app browsers.</li>
+      <li>OSes must provide a global user opt-out. Apps must also request
+        explicit permission from users.</li>
+      <li>Google must remove the ability to override the users choice of
+        default browser via Android Custom Tabs. </li>
+    </ol>
+
+    <p>Users' choice of default browser and the consequent competition is only effective
+      if that choice is respected.</p>
+
+    <h3 id="default-browser-dark-patterns-and-prompt-api">
+      <a class="header-anchor" href="#default-browser-dark-patterns-and-prompt-api" aria-hidden="true">#</a>
+      4.2.5. Default Browser Dark Patterns and Prompt API
+    </h3>
+
+    <blockquote>
+      <p>Apple currently introduces friction that impairs user choice of default browser. This
+        is explicitly forbidden in Recital 70, Article 6(3), and Article 13(4).</p>
+
+      <p>Given the substantial economic power of gatekeepers, it is important that
+        the obligations are applied effectively and are not circumvented. To that end, the rules in question should
+        apply
+        to any practice by a gatekeeper, irrespective of its form and irrespective of whether it is of a contractual,
+        commercial, technical or any other nature, insofar as the practice corresponds to the type of practice that is
+        the
+        subject of one of the obligations laid down by this Regulation. Gatekeepers should not engage in behaviour
+        that
+        would undermine the effectiveness of the prohibitions and obligations laid down in this Regulation.
+        <strong class="stressed">Such behaviour includes the design used by the gatekeeper, the presentation of
+          end-user
+          choices in a
+          non-neutral manner, or using the structure, function or manner of operation of a user interface or a part
+          thereof
+          to subvert or impair user autonomy, decision-making, or choice</strong>.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881453684&usg=AOvVaw0IZUbPqLtOupM1WwbkJHtS">
+            Digital Markets Act – Recital 70</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple introduces this friction in five ways:</p>
+
+    <ol>
+      <li>Third-party browsers cannot prompt users to change the
+        default
+        via a one-click system prompt.</li>
+      <li>Third-party browsers cannot detect whether they are the
+        default.</li>
+      <li>Safari's settings are prominently positioned on the iOS
+        settings page compared to third-party browsers.</li>
+      <li>Searching for "default" or "default
+        browser" in settings yields no results.</li>
+      <li>There is no centralized location for changing default
+        apps
+        (including browsers) on iOS.</li>
+    </ol>
+
+    <p>Combined, these factors significantly restrict users' free choice
+      in
+      selecting and switching between their choice of browser.</p>
+    <p>In order to be compliant with this specific aspect of the DMA, we
+      believe
+      Apple should make the following changes:</p>
+
+    <ol>
+      <li>Move the option to change default browser out of
+        the
+        browser settings and into a centralized location.</li>
+      <li>Have this option visible, even if Safari is the
+        only
+        currently installed browser.</li>
+      <li>Have this option show up in search if the user
+        searches for "default", "browser" or
+        "default browser".</li>
+      <li>Allow browsers to know if they are the current
+        default
+        browser.</li>
+      <li>Provide a system prompt to browsers (with an
+        option to
+        never ask again, as is usual for all permission prompts) that allows browsers to prompt the user to
+        one-click
+        set it as the new default browser. This is standard on most operating systems.</li>
+    </ol>
+
+    <h3 id="safari-is-locked-to-apple-pay">
+      <a class="header-anchor" href="#safari-is-locked-to-apple-pay" aria-hidden="true">#</a>
+      4.2.6. Safari is Locked to Apple Pay
+    </h3>
+
+    <p>Currently iOS Safari payments are locked to Apple Pay. As Safari is a core platform
+      service it is not allowed to impose a payment service on either end users or business users under Article 5(7).
+      Therefore, Safari must be upgraded to support third-party payment services including allowing them to reach
+      feature parity with Apple Pay.</p>
+
+    <p>This upgrade must also extend to all WKWebView-based browsers on iOS.</p>
+
+    <p>We would like to note that the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.w3.org/TR/payment-request/&sa=D&source=editors&ust=1718648881456112&usg=AOvVaw3QgN_G31XVXxM4o_IqTgDC">specific
+        standardized “PaymentRequest” Web API</a>&nbsp;that Apple is using is
+      actually designed to support multiple payment services and to our knowledge Safari is the only major browser
+      (possibly only browser) that has locked it to a particular payment provider.
+    </p>
+
+    <figure>
+      <img src="/images/apple-dma-report/image1.png" alt="A screencopy of Maciej Stachowiak's comment on Redit">
+    </figure>
+
+    <p>Maciej Stachowiak – Senior Director of Software Engineering at Apple has publicly
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://github.com/WebKit/standards-positions/issues/30&sa=D&source=editors&ust=1718648881456668&usg=AOvVaw2Y3F3BdZb8HhrAWRKQMUO2">stated
+        that</a> Apple will <q>only support the ApplePay
+        PaymentRequest
+        method to minimize user confusion and make sure that
+        PaymentRequest API payments always get the same level of
+        security and privacy protection</q>.
+    </p>
+
+    <p>This will need to be fixed in order for Apple to be in compliance with the payment
+      service aspect of Article 5(7).</p>
+
+    <h2 id="tranche-3">
+      <a class="header-anchor" href="#tranche-3" aria-hidden="true">#</a>
+      4.3. Tranche 3
+    </h2>
+
+    <p>Tranche 3 interventions include some of the most impactful, long-term changes, but OWA
+      recognises that they may not be possible within a quarter or two. As such, we suggest the DMA team provide
+      notice
+      of intent to require them early, but work with stakeholders to bring them about in a phased way.</p>
+
+    <h3 id="direct-browser-installation">
+      <a class="header-anchor" href="#direct-browser-installation" aria-hidden="true">#</a>
+      4.3.1. Direct Browser Installation
+    </h3>
+
+    <p>Apple is obligated under the act to allow native apps to be downloaded from a web page.
+      They have allowed, and interpreted it this way, for third-party app stores. The act states that Apple is only
+      allowed to have strictly necessary, proportionate and justified security measures to protect the integrity of
+      the
+      operating system. This means any security measures, such as warnings or scare screens, need to be heavily
+      justified by Apple as strictly necessary.</p>
+
+    <p>There is great fear in the industry that Apple wields app store review as a weapon to
+      punish competitors. This fear appears to be well justified.</p>
+
+
+    <p>On March 5th,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theverge.com/2024/3/14/24100944/spotify-ios-app-update-eu-apple-dma&sa=D&source=editors&ust=1718648881458141&usg=AOvVaw2ZzgW0BS305ZUxNj9AgR8w">Spotify
+        submitted an update to Apple</a> that puts links to Spotify’s website, along with
+      pricing information for different subscription options, directly in the EU version of its app, without using
+      Apple’s payment system. Despite
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theguardian.com/business/2024/mar/04/eu-fines-apple-18bn-over-app-store-restrictions-on-music-streaming%23:~:text%3DEU%2520fines%2520Apple%2520%25E2%2582%25AC1.8bn%2520over%2520App%2520Store%2520restrictions%2520on%2520music%2520streaming,-This%2520article%2520is%26text%3DApple%2520has%2520been%2520fined%2520%25E2%2582%25AC,streaming%2520services%2520such%2520as%2520Spotify&sa=D&source=editors&ust=1718648881458650&usg=AOvVaw1zOtC2jwLJYwnRdsFCXVcD">being
+        fined 1.8 billion by the EU</a> on this very topic, Apple refused to let the update
+      pass app review even though more than 2 weeks had passed since the update was submitted.
+    </p>
+
+    <blockquote>
+      <p>Moreover, Apple has demonstrated its ability to use its smartphone monopoly
+        to impose fee structures and <strong class="stressed">
+          manipulate app review to inhibit aggrieved parties from
+          taking advantage of regulatory and judicial solutions imposed on Apple</strong>
+        that attempt
+        to narrowly remedy harm from its conduct.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881459226&usg=AOvVaw0Q2nnateLkZN8bu5lbgsMa">DOJ
+            – Case 2:24-cv-04055</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>Specifically, Apple sets the conditions for apps it allows on the Apple App
+        Store through its App Store Review Guidelines. Under these guidelines, Apple has sole discretion to review and
+        approve all apps and app updates. Apple selectively exercises that discretion to its own benefit, deviating
+        from
+        or changing its guidelines when it suits Apple’s interests and allowing Apple executives to control app
+        reviews and decide whether to approve individual apps or updates. <strong class="stressed">Apple often
+          enforces
+          its App Store rules arbitrarily. And it frequently uses App Store rules and restrictions to penalize and
+          restrict
+          developers that take advantage of technologies that threaten to disrupt, disintermediate, compete with, or
+          erode
+          Apple’s monopoly power</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881459861&usg=AOvVaw1QDROcM1EIZglnz9UstC43">
+            DOJ – Case 2:24-cv-04055</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>there are endless horror stories around curation of the store. Apps are
+        rejected in arbitrary, capricious, irrational and inconsistent ways, often for breaking completely unwritten
+        rules.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.ben-evans.com/benedictevans/2020/8/18/app-stores&sa=D&source=editors&ust=1718648881460433&usg=AOvVaw1Bn71x5AQJrlI-4xMYhGBl">Benedict
+            Evans – Technology Writer</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>There's a lot of talk about the 30% tax that Apple takes from every app
+        on the App Store. The time tax on their developers to deal with this unfriendly behemoth of a system is just
+        as bad if not worse</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://twitter.com/samj0hn/status/1431001795904561160&sa=D&source=editors&ust=1718648881460912&usg=AOvVaw0YQG4by2ysJkHAkLgltDuL">Samantha
+            John – CEO Hopscotch</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Given that third-party browsers using their own engine already need to comply with
+      extensive security rules in order to be allowed access to the relevant APIs, there is no security justification
+      for any additional scare screens or warnings.</p>
+
+    <p>Currently, only a few browser vendors offer their browser through the macOS app store.
+      It seems plausible that browsers will want to abandon the iOS app store at some point in the future to avoid
+      having to deal with any unreasonable app store guidelines that Apple might impose.</p>
+
+    <p>A key idea in the DMA is that gatekeeper services, such as the Apple’s app store, offered on
+      top of operating system core platform services such as iOS are optional, both for users and businesses.
+      Businesses
+      should be free to distribute directly and users should be free to get software directly from third-party
+      developers. If Apple wishes to retain users and business on their app store they must compete to make it more
+      attractive. As mentioned before, the only leeway they are given by the act to intervene in these direct
+      interactions is via strictly necessary, proportionate and justified security measures to protect the integrity
+      of
+      the operating system.</p>
+
+    <p>This will be beneficial to competition as it will remove a significant source of power
+      Apple has over these browser vendors. However, this future is only possible if the process for installing a
+      browser directly is made frictionless and painless.</p>
+
+    <p>We believe that in order to comply with the DMA, Apple should:
+    </p><ul>
+      <li>Allow browsers to be installed directly from their own
+        websites.</li>
+      <li>Not place any friction or scare screens in the installation
+        process.</li>
+      <li>Not place any rules that aim to inhibit or make more expensive
+        installations that are not via Apple’s app store.</li>
+    </ul>
+
+    <h3 id="allow-users-to-switch-the-distribution-method-of-native-apps">
+      <a class="header-anchor" href="#allow-users-to-switch-the-distribution-method-of-native-apps" aria-hidden="true">#</a>
+      4.3.2. Allow Users to Switch the Distribution Method of Native Apps
+    </h3>
+
+    <p>The DMA obligates gatekeepers to allow business users to promote and choose the
+      distribution channel that they consider most appropriate for the purpose of interacting with any end users;
+      those
+      business users have already acquired core platform services provided by the gatekeeper.</p>
+
+    <p>This means that business users need to be able to switch the distribution channel of
+      individual native apps downloaded by Apple's app store to either direct download or to be managed by another
+      app store.</p>
+
+    <blockquote>
+      <p>In certain cases, for instance through the imposition of contractual terms and
+        conditions, gatekeepers can restrict the ability of business users of their online intermediation services to
+        offer products or services to end users under more favourable conditions, including price, through other
+        online
+        intermediation services or through direct online sales channels. Where such restrictions relate to third-party
+        online intermediation services, they limit inter-platform contestability, which in turn limits choice of
+        alternative online intermediation services for end users. Where such restrictions relate to direct online
+        sales
+        channels, they unfairly limit the freedom of business users to use such channels. To ensure that business
+        users of
+        online intermediation services of gatekeepers can freely choose alternative online intermediation services or
+        direct online sales channels and differentiate the conditions under which they offer their products or
+        services to
+        end users, it should not be accepted that gatekeepers limit business users from choosing to differentiate
+        commercial conditions, including price. Such a restriction should apply to any measure with equivalent effect,
+        such as increased commission rates or de-listing
+        of the offers of business users.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3D(39),of%2520business%2520users.&sa=D&source=editors&ust=1718648881463000&usg=AOvVaw18UQv_k81GLcUs46IcQRvh">Digital
+            Markets Act – Recital 39 </a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>To prevent further reinforcing their dependence on the core platform
+        services of gatekeepers, and in order to promote multi-homing,
+        <strong class="stressed">the business users of
+          those gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate for the purpose of interacting with any end users that those business users have already
+          acquired
+          through core platform services provided by the gatekeeper</strong> or through other
+        channels.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881463665&usg=AOvVaw3jChM1pLkezpnYS_54aAUx">
+            Digital Markets Act – Recital 40</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow business
+          users</strong>, free of charge, <strong class="stressed">to communicate and
+          promote offers,
+          including under different conditions, to end users acquired via its
+          core platform service</strong> or through other channels, and to conclude contracts
+        with those end users, <strong class="stressed">regardless of whether, for that purpose, they use
+          the core platform services of the
+          gatekeeper</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881464536&usg=AOvVaw30v9JNrpHRcZi7Yc_JqqZR">Digital
+            Markets Act – Article 5(4)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Currently the only way of doing this is the extremely awkward process of entirely
+      uninstalling an app (and thus deleting) all its data, then reinstalling it via either the third party app store
+      or
+      directly from the developers website.</p>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall not restrict technically or
+          otherwise the ability of end users to switch between</strong>, and subscribe to,
+        <strong class="stressed">different software applications and services that are accessed using the core
+          platform services of
+          the
+          gatekeeper</strong>, including as regards the choice of Internet access services for end
+        users.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881465478&usg=AOvVaw2abSXAj0PQYoWnsU_vauD7">Digital
+            Markets Act – Article 6(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>In this case the core platform service would be the operating system iOS which is
+      restricting the ability of users to switch apps between app stores, or being managed directly by the
+      developers.</p>
+
+    <p>Switching which store or developer is controlling a particular app should be
+      straightforward. To not do so is by design of the operating system and its interfaces undermine effective
+      compliance with Recital 39, Recital 40, Article 5(4) and Article 6(6). Apple should build appropriate interfaces
+      to facilitate such a switch.</p>
+
+    <p>This also comes with the advantage that should any individual app store become defunct,
+      there would now be a mechanism to not orphan apps on that app store. It would also apply great pressure on app
+      stores to be reasonable otherwise risk businesses and users switching their existing apps en masse to an
+      alternative. Enabling this competitive pressure would benefit both business and consumers.</p>
+
+    <p>Finally, Apple must allow businesses the right to be able to promote this switch, and
+      its advantages such as price decreases or extra features, to users which have downloaded the app via Apple's
+      app store. There should also be no prohibition via app store rules or contracts on promoting direct download or
+      third party app stores in adverts on other third party apps in Apple's app store. This should also include
+      the
+      case where a business wishes to discontinue offering their app via a particular app store and wishes to promote
+      alternative options for users to switch too.</p>
+
+    <p>Apps will need the ability to detect which source is managing their distribution, i.e
+      which app store or direct download. An API will need to exist which provides this to the app. This is to allow
+      the
+      app to appropriately alter its features, interfaces or displayed prices.</p>
+
+    <p>This change will bring significant advantages for consumers and businesses. It will
+      allow app stores to be more easily contested by third parties and reduce the entrenchment of the existing body
+      of
+      installed apps. This will lead to better prices, more competition and greater choice for consumers.</p>
+
+    <h3 id="direct-install-browsers-should-be-included-in-choice-screens">
+      <a class="header-anchor" href="#direct-install-browsers-should-be-included-in-choice-screens" aria-hidden="true">#</a>
+      4.3.3. Direct Install Browsers Should Be Included In Choice Screens
+    </h3>
+
+    <p>There is no plausible reason for Apple to exclude browsers from choice screens if they are not
+      listed within its app store. Choice screens attempt to remedy the harm from Apple’s historic
+      self-preferencing by setting its browser as the default. The article seeks to prevent gatekeepers that might
+      "favour its own or third-party services or products on its operating
+      system", and so it does not make sense that participation in systems designed to
+      redress harms caused by favoring of their own services and products must then rely on forced participation in
+      them
+      unduly.</p>
+
+    <p>Entrants that choose to entirely avoid Apple's app store should not be penalized
+      for this choice. Thus, browsers that are available for direct download should be eligible to appear on the
+      choice
+      screen.</p>
+
+    <blockquote>
+      <p><strong class="stressed">To prevent further reinforcing their dependence on
+          the core platform services of gatekeepers, and in order to promote multi-homing, the business users of those
+          gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate</strong> for the purpose of interacting with any end users that those business
+        users have already acquired through core platform services provided by the gatekeeper or through other
+        channels.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881467487&usg=AOvVaw1UQA5ne_qECkJfRecRGfXG">Digital
+            Markets Act – Recital 49</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is important that Apple does not entrench an existing core platform service in the
+      process of satisfying other obligations of the DMA. In the context of both the intent and letter of the DMA,
+      locking all browsers to its app store both mechanically and via its rules does not appear to be
+      compliant.Apple must publish the mechanisms for including a “direct install” version of a
+      browser on the choice screen. Browser vendors should be allowed to distribute both via the AppStore and
+      directly,
+      and be able to opt to have the choice screen connected to their direct install version.</p>
+
+    <h3 id="apple-should-make-notarization-for-directly-downloaded-browsers-automatic">
+      <a class="header-anchor" href="#apple-should-make-notarization-for-directly-downloaded-browsers-automatic" aria-hidden="true">#</a>
+      4.3.4. Apple Should Make Notarization for Directly Downloaded Browsers Automatic
+    </h3>
+
+    <p>Apple has announced that it intends to notarize apps that are not downloaded by its app
+      store but that it will keep this review strictly limited to security.</p>
+
+    <blockquote>
+      <p>Notarization for iOS apps is a baseline review that applies to all apps,
+        regardless of their distribution channel, focused on platform policies for security and privacy and to
+        maintain
+        device integrity. Through a combination of automated checks and human review, Notarization will help ensure
+        apps
+        are free of known malware, viruses, or other security threats, function as promised, and don’t expose
+        users
+        to egregious fraud.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/%23:~:text%3DNotarization%2520for%2520iOS%2520apps%2520is,expose%2520users%2520to%2520egregious%2520fraud.&sa=D&source=editors&ust=1718648881468503&usg=AOvVaw0LVacnSgX1qObVNiqFiS9g">Apple
+            – On Notarization </a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>It is our opinion that this policy for third-party browsers which are downloaded
+      directly is unproportionate, unnecessary and will in fact worsen security.</p>
+
+    <p>It is important to note that what Apple is proposing is not equivalent to the system
+      Apple has for notarization of macOS software which is a fast and automated process.</p>
+
+    <blockquote>
+      <p>Notarize your macOS software to give users more confidence that the
+        Developer ID-signed software you distribute has been checked by Apple for
+        malicious components. <strong class="stressed">Notarization of macOS
+          software is not App Review</strong>.
+        The Apple notary
+        service is
+        an automated system that scans your software for malicious content, checks for code-signing issues, and
+        returns
+        the results to you quickly. If there are no issues, the notary service generates a ticket for you to staple to
+        your software; the notary service also publishes that ticket online where Gatekeeper can find
+        it.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution&sa=D&source=editors&ust=1718648881469461&usg=AOvVaw2a19uy3X592wknrH83gQY9">Apple
+            – on macOS Notarization</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Were Apple’s proposal simply to apply automatic checks including for code
+      signatures that verify the developer is the same developer with the browser entitlement, that would be perfectly
+      acceptable.</p>
+
+    <p>Apple’s language however makes it clear that this is “app store
+      review” in disguise, although nominally locked to security issues. </p>
+
+    <p>Our concern is that Apple will introduce considerable delay and friction into the
+      process of updating browsers. We are also concerned, given Apple’s known abuse of their Apple app store
+      review process, that if Apple is in a dispute with a third-party browser, they may attempt to use blocking of
+      updates on security ground as a weapon to gain concessions from browser vendors or otherwise wield the fear of
+      such a rejection as a tool to limit third-party browsers to compete.</p>
+
+    <p>“Patch gap” is the amount of time between a vulnerability being discovered
+      and it being patched on consumers devices. It is a critical aspect of security that this gap is as small as
+      possible.</p>
+
+    <p>There is a strong argument that behavior mentioned in the previous two remedies, such as Apple
+      preventing an update to Spotify for two weeks, and the pattern of behavior as
+      outlined in
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881470593&usg=AOvVaw1kmwUiWh-rtCWIBL5x-IUR">the
+        DOJ complaint</a>, means that delays can often be arbitrary and significant.
+    </p>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/distribute/app-review/%23:~:text%3DOn%2520average%252C%252090%2525%2520of%2520submissions%2520are%2520reviewed%2520in%2520less%2520than%252024%25C2%25A0hours.&sa=D&source=editors&ust=1718648881471002&usg=AOvVaw3VVOjJsMjU4C9sG97qu_Cc">Even
+        the 90% in 24 hours for app review</a> that Apple claims it
+      achieves with its app store
+      will
+      significantly worsen patch gap. For reference the macOS notarization
+      process is automated
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow%23:~:text%3DAfter%2520you%2520upload%2520your%2520app%252C%2520the%2520notarization%2520process%2520typically%2520takes%2520less%2520than%2520an%2520hour.&sa=D&source=editors&ust=1718648881471373&usg=AOvVaw3C-TGqnwFX2p2KH6sJXPYv">and
+        takes less than 1 hour</a>.
+    </p>
+
+    <blockquote>
+      <p>Apple suppresses such innovation through a web of contractual restrictions
+        that it selectively enforces through its control of app distribution and its ‘app
+        review’ process</p>
+      <p>[...]</p>
+      <p>Apple often claims these rules and restrictions are necessary to protect user
+        privacy or security, but Apple’s documents tell a different story. In reality, Apple imposes certain
+        restrictions to benefit its bottom line by thwarting direct and disruptive competition for its iPhone platform
+        fees and/or for the importance of the iPhone platform itself.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.justice.gov/opa/media/1344546/dl?inline&sa=D&source=editors&ust=1718648881472163&usg=AOvVaw3_fbqsCbHlSsjBfYYGSBgn">DOJ
+            Complaint against Apple</a>
+        </cite>
+      </p>
+    </blockquote>
+    <p>Browser vendors have their own dedicated security teams which have worked for decades to secure
+      their own browsers. <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html&sa=D&source=editors&ust=1718648881472593&usg=AOvVaw2Lt_y4jme5TgZPwxd4_1PU">Apple
+        has a worse track record than Firefox and Chrome</a>&nbsp;when it comes to patch
+      gap.</p>
+
+    <figure>
+      <img src="/images/apple-dma-report/image11.png" alt="Histogram of days from fix landed in public to fix shipped">
+      <figcaption>
+        <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.google.com/url?q%3Dhttps://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html%26sa%3DD%26source%3Ddocs%26ust%3D1716007764601184%26usg%3DAOvVaw32MDv4LcTjodz660Hjb1sg&sa=D&source=editors&ust=1718648881473149&usg=AOvVaw0KlDiGM4zL20QQeB0rmC9i">Google
+          Project Zero - Statistics on Patch Gap</a>
+      </figcaption>
+    </figure>
+
+    <p>iOS users remain vulnerable to known bugs in Safari longer than users of alternative browsers on
+      every other OS. This picture is made even clearer by OS update rates. Since Safari requires a full operating
+      system update, further steps (and attendant delay) is introduced in getting patches into user’s hands,
+      than
+      if the browser updated like a “normal app” separate from OS updates (the standard on all other
+      modern
+      OSes). Safari requires the user to update their entire operating system,
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.ubackup.com/phone-backup/how-long-does-an-ios-update-take.html%23:~:text%3DUpdating%2520to%2520the%2520latest%2520iOS%2520takes%2520about%252030%2520minutes%2520on%2520average.&sa=D&source=editors&ust=1718648881473638&usg=AOvVaw2stizh6LpxGOKURlp-nGgZ">a
+        process that makes the device unusable for up-to 30 minutes</a>.
+    </p>
+
+    <p>Apple is presumably claiming this right to review under the security provision in 6(4)
+      which states: </p>
+
+    <blockquote>
+      <p>The gatekeeper shall not be prevented from taking, to the extent that they
+        are strictly necessary and proportionate, measures to ensure that third-party software applications or
+        software
+        application stores do not endanger the integrity of the hardware or operating system provided by the
+        gatekeeper,
+        provided that such measures are duly justified by the gatekeeper.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881474304&usg=AOvVaw1FBVxSXRa_HMW6s-eyvUMi">Digital
+            Markets Act – Article 6(4)</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>However, this does mean the security measure, in this case the need to notarize the
+      third-party browsers, needs to:</p>
+
+    <ul>
+      <li>Be strictly necessary</li>
+      <li>Be proportionate</li>
+      <li>Be to prevent browsers from endangering the integrity of the
+        hardware or operating system provided by the gatekeeper</li>
+      <li>Be justified by Apple</li>
+    </ul>
+
+    <p>Given there is a strong argument that Apple will in fact worsen security via this
+      policy, the onus is on Apple to state a convincing argument on how they intend to improve security with this
+      policy, including what additional staffing specifically for third-party browser vendors they are intending on
+      hiring to implement it.</p>
+
+    <p>Apple will need to convincingly show why it is strictly necessary and proportionate for
+      them to enforce this when all the major browser vendors have their own dedicated security teams.</p>
+
+    <p>They will also need to show why simple rules such as patching at a regular cadence or
+      committing to fixing vulnerabilities within a particular time period are not sufficient. For all these rules,
+      Safari should be the benchmark; No browser should be penalized for doing a better job at security than
+      Safari.</p>
+
+    <p>Apple should guarantee that notarization for third-party browsers, with the browser
+      entitlement which are downloaded outside Apple’s app store, is a fast and automatic process. </p>
+
+    <p>Our recommendation is that Apple’s only recourse against third-party browsers
+      with serious security issues, which they refuse to fix in a timely manner or that are compromising the operating
+      system against the interests of the user, is the option to revoke their browser engine entitlement.</p>
+
+    <p>This needs to be paired with strong financial penalties for Apple, in the event it
+      takes such an action without sufficient evidence.</p>
+
+    <p>This setup would remove Apple’s ability to bully browser vendors via threatening
+      to delay updates on bogus security grounds, while still granting the ability to outright remove malicious or
+      incompetent browsers where strictly necessary, reasonable and justified.</p>
+
+    <p>Apple should be subject to a SLA (Service Level Agreement) in return for the
+      ability to impose automated notarization on third parties. It would be our recommendation that the SLA for
+      notarization should be less than an average of 15 minutes with a maximum of 1 hour. It is important that Apple
+      not
+      be left free to abuse the ability to delay app updates. This delay would be solely within Apple’s control
+      and no third party software provider would have the ability to improve upon the speed of Apple’s
+      notarization.</p>
+
+    <p>A key metric directly downloaded browsers and third party app stores will compete on is
+      the ability to provide my timely updates. Allowing Apple the ability to selectively block or make arbitrarily
+      slow
+      (potentially weeks) particular updates with no explanation significantly undermines competition with Apple's
+      app store and grants Apple great power to bully developers who have opted to distribute outside of Apple’s
+      app store.</p>
+
+    <h3 id="apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu">
+      <a class="header-anchor" href="#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu" aria-hidden="true">#</a>
+      4.3.5. Apple Should Not Break Updates for EU Residents Traveling Outside The EU
+    </h3>
+
+    <p>Apple has stated that it will prevent all updates for apps downloaded from third-party
+      app stores that are outside the EU for more than 30 days.</p>
+
+    <p>Apple has not released any explicit statement on what will happen to browsers using their own
+      engine downloaded from Apple’s app store if the user (an EU resident) leaves the EU for greater than 30
+      days. Given <a href="#testing-for-browser-vendors-and-developers-outside-the-EU">Apple is attempting to block even browser
+        vendors from testing on their own test devices outside the EU</a>, it seems likely they
+      will attempt to extend a similar policy to third party browsers which use their own engine even if they are
+      downloaded from Apple’s app store.</p>
+
+    <p>We would like a statement from Apple clarifying that this does not apply to browsers
+      with the browser engine entitlement.</p>
+
+    <blockquote>
+      <p><span>“If you leave the European Union, you can continue to open and use apps that
+          you previously installed from alternative app marketplaces. Alternative app marketplaces can continue updating
+          those apps for up to 30 days after you leave the European Union, and you can continue using alternative app
+          marketplaces to manage previously installed apps. However, you must be in the European Union to install
+          alternative app marketplaces and new apps from alternative app marketplaces.”</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://support.apple.com/en-us/118110%23:~:text%3DIf%2520you%2520leave%2520the%2520European,apps%2520from%2520alternative%2520app%2520marketplaces.&sa=D&source=editors&ust=1718648881477157&usg=AOvVaw2jwLLE_kBl0PIrksiBUvyP">
+            Apple’s statement on breaking updates for EU residents outside the EU for greater than 30 days</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Importantly:</p>
+
+    <ul>
+      <li>This has no exemption for EU residents.</li>
+      <li>This rule will block security updates.</li>
+      <li>Safari is immune to this rule (as it is only available on
+        Apple’s app store)</li>
+      <li>No other gatekeeper has taken such extreme measures to limit the
+        competition the DMA allows to the EU.</li>
+    </ul>
+
+    <p>Apple has not included any arguments in their statement on why EU residents traveling
+      for longer than 30 days cease to be EU residents, nor any discussion on how they will ensure that this policy
+      does
+      not apply to any EU residents.</p>
+
+    <p>Under
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://home-affairs.ec.europa.eu/system/files_en?file%3D2020-09/schengen_brochure_dr3111126_en.pdf&sa=D&source=editors&ust=1718648881478801&usg=AOvVaw1wS3AbOSVuhRr03d8LYEtP">Schengen
+        agreements</a>, EU residents have the legal right to freedom of movement between all 29
+      Schengen countries, and the legal right to stay in each of the 29 countries up to 90 days without the need to
+      apply for a travel visa or permit, as there are no borders between these countries. Importantly, among these
+      29,
+      there are countries like Switzerland, Norway and Iceland, which are not members of the EU. Meaning that, for
+      example, a German citizen can legally visit and stay in their summer cottage in Switzerland for up to 90 days.
+    </p>
+
+    <p>In the same spirit, the EU and the US have mutual visa-free travel agreements, allowing an EU
+      citizen to travel to the US with an
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://esta.cbp.dhs.gov/esta&sa=D&source=editors&ust=1718648881479291&usg=AOvVaw2EYq-tfnXdiyq-5ZvwDHc4">ESTA
+        visa</a> for up to 90 days without losing their status as an EU resident.
+    </p>
+
+    <p>Meaning that, a Swedish citizen can legally visit their parents in Norway for up to 90
+      days, then fly to Iceland and spend an additional 90 days with their siblings, then fly to the US to visit their
+      friends for another 90 days, then spend their summer in Switzerland for up to 90 days, and so can legally stay
+      away from the EU for even a year or more if they wish, whilst continuing to be an EU resident throughout.
+    </p>
+
+    <p>In addition, according to the
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://europa.eu/youreurope/citizens/work/taxes/income-taxes-abroad/index_en.htm%23:~:text%3Dyou%2520will%2520usually%2520be%2520considered%2520tax%252Dresident%2520in%2520the%2520country%2520where%2520you%2520spend%2520more%2520than%25206%2520months%2520a%2520year&sa=D&source=editors&ust=1718648881479914&usg=AOvVaw3TK0F7Q_uk3ZOGs-ZvURF7">EU
+        / EEA VAT and taxation law</a>, which includes non-EU countries such as Norway and
+      Iceland, EU residents are only considered tax residents of another member state after 6 months. A rule which
+      is
+      more or less globally harmonized to simplify global taxation of individuals. Meaning that the residents of EU
+      member states are only legally considered tax-residents of another country after having spent 6 months in the
+      destination country.
+    </p>
+
+    <p>This means that for a very large number of EU residents traveling outside the EU, or
+      working outside the EU, Apple’s arbitrary 30-days rule to prevent app updates actually puts EU
+      residents’ cyber-safety and security at great risk. Apps subjected to this policy, in particular browsers,
+      will cease to receive security updates.</p>
+
+    <p>This 30-day policy greatly contradicts Apple’s justification claiming that their
+      biggest priority is the safety of their users, as they could simply remove the arbitrary 30-day rule, or
+      increase
+      it to something more reasonable, such as 6 months to a year or more to accommodate and match the legal rights of
+      EU residents.</p>
+
+    <p>Even if this policy is scoped by Apple to not apply to browsers shipped on their app
+      store, should browsers choose to abandon Apple's app store in the future they will be subject to Apple's
+      decision. Allowing browsers the option to ship outside of Apple's app store is an important option to weaken
+      Apple's ability to dictate to browsers their form and functionality, will allow browsers to reduce the time
+      to
+      deploy security patches and will improve their ability to compete fairly and effectively. The right to choose
+      how
+      to distribute to users is codified in the DMA under Recital 40, Article 5(4) and Article 6(6).</p>
+
+    <blockquote>
+      <p>To prevent further reinforcing their dependence on the core platform
+        services of gatekeepers, and in order to promote multi-homing,
+        <strong class="stressed">the business users of
+          those gatekeepers should be free to promote and choose the distribution channel that they consider most
+          appropriate for the purpose of interacting with any end users that those business users have already acquired
+          through core platform services provided by the gatekeeper</strong> or through other
+        channels.
+      </p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881481152&usg=AOvVaw0NdHxb9BcUk4CiNjLnaLJf">Digital
+            Markets Act – Recital 40</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p><strong class="stressed">The gatekeeper shall allow business
+          users</strong>, free of charge, <strong class="stressed">to communicate and promote offers,
+          including under different conditions, to end users acquired via its
+          core platform service</strong> or through other channels, and to
+        conclude contracts with those end users,<strong class="stressed">
+          regardless of whether, for that purpose,
+          they use the core platform services of the
+          gatekeeper</strong>.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881481971&usg=AOvVaw35fLxNt4H9CJDwtVAQtFoX">Digital
+            Markets Act – Article 5(4)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <blockquote>
+      <p>The gatekeeper shall not restrict technically or
+        otherwise the ability of end users to switch between, and subscribe to, <span class="c10">different software applications and services that are accessed using the core platform services of
+          the
+          gatekeeper, including as regards the choice of Internet access services for end
+          users.”</span></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG%23:~:text%3DGiven%2520the%2520substantial%2520economic%2520power%2520of,thresholds%2520laid%2520down%2520in%2520this%2520Regulation.&sa=D&source=editors&ust=1718648881482817&usg=AOvVaw06_MmwqwZqlPCz3WB0T24j">Digital
+            Markets Act – Article 6(6)</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple should not be able to break important updates (including security updates) for EU residents
+      who are traveling outside the EU. Apple will need to remove or update this policy to be compliant with the
+      DMA.</p>
+
+    <h3 id="h.2szc72q">4.3.6. Opt-In Rights Contract Should Be Removed</h3>
+
+    <p>All businesses serving EU customers should automatically have all of the rights granted
+      to them under the DMA. They should not have to opt-in to those rights under different rules or punitive pricing
+      changes.</p>
+
+    <p>Business users in the act are defined as:</p>
+
+    <blockquote>
+      <p>‘business user’ means any natural or legal person acting in a
+        commercial or professional capacity using core platform services for
+        the purpose of or in the course of
+        providing
+        goods or services to end users</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881483928&usg=AOvVaw3zTjOfqv4HNyMFIkGRac2a">Digital
+            Markets Act</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>This is a broad definition that currently covers almost every business supplying an app
+      on the iOS app store.</p>
+
+    <p>Apple should not be able to either contract businesses out of their rights under the
+      DMA, or attach a price to those rights. </p>
+
+    <p>This is not how any law functions. For example, Apple can not sell iPhones to consumers
+      at two different prices, one which abides EU's laws on deceptive advertising, and one that does not; The law
+      applies to all of Apple's services and hardware.</p>
+
+    <p>Similarly, Apple should not be able to segment business users into ones for which Apple
+      has to abide by the DMA and another for which they do not have to. Rather, Apple should have to automatically
+      abide by the DMA for all business users operating within the EU, that is every business that supplies
+      applications
+      to EU residents.</p>
+
+    <p>Apple should remove its new "alternative contract" and update its existing
+      contract such that all business users within the EU are automatically moved onto terms compliant with the DMA.
+      All
+      of Apple’s pre-existing contracts which apply to the business interactions between end users and business
+      users in the EU must be updated to comply with the DMA. Business users should not have the choice of being on
+      non-DMA compliant terms. This false choice allows gatekeepers a method of circumventing their responsibilities.
+      &nbsp;</p>
+
+    <h3 id="core-technology-fee-should-be-removed">
+      <a class="header-anchor" href="#core-technology-fee-should-be-removed" aria-hidden="true">#</a>
+      4.3.7. Core Technology Fee Should Be Removed
+    </h3>
+
+    <p>Apple's proposal also includes plans for how they would allow third-party native
+      app stores to compete with their own on iOS. This is directly compelled by the act.</p>
+
+    <p>Apple's proposal seems designed to prevent any free app from ever even considering
+      moving to a third-party native app store on iOS, or being available for direct download from its own
+      website.</p>
+
+    <p>In order to list their app on a third-party app store or on their own website, the app
+      developer must sign an alternative contract allowing them the rights granted under the DMA. However, this
+      alternative contract comes with significantly different pricing.</p>
+
+    <p>If you choose the second contract, Apple will waive some app store fees but will add a
+      new fee called “Core Technology Fee”, summarized as a 50 cent charge per-user per-year, past the
+      first
+      million downloads.</p>
+
+    <p>Critically, and to OWA’s astonishment,<strong>this also includes
+        downloads from the Apple app store</strong>.</p>
+
+    <p>In Apple's own words the fee is: </p>
+
+    <blockquote>
+      <p>The Core Technology Fee (CTF) is an element of the new business terms in the
+        European Union (EU) that reflects the value Apple provides developers through ongoing investments in the
+        tools,
+        technologies, and services that enable them to build and share innovative apps with users around the world.
+        Developers can choose to remain on the App Store’s current business terms or adopt the new business
+        terms
+        for iOS apps in the EU.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/core-technology-fee/&sa=D&source=editors&ust=1718648881486130&usg=AOvVaw1WG5m49ItADLW86-BYUwyg">Apple
+            Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>They also explain:</p>
+
+    <blockquote>
+      <p>The Core Technology Fee (CTF) reflects Apple’s investment in the
+        tools, technology, and services that enable developers to build and share their apps with Apple users.
+        <strong class="stressed">That includes more than 250,000 APIs</strong>, TestFlight, Xcode, and so
+        much more. These tools create a lot of value for developers, whether or not they share their apps on the App
+        Store.
+      </p>
+      <p><strong class="stressed">The CTF only applies to developers who adopt the new terms for alternative
+          distribution and payment processing</strong></p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/&sa=D&source=editors&ust=1718648881486892&usg=AOvVaw0tdCGVsupR9pcPd7Meex4m">Apple
+            Documentation</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+
+    <p>That is, Apple explicitly states that the fee covers access to iOS’s APIs.
+    </p>
+
+    <p>The DMA specifically precludes any fee for software or hardware API access:</p>
+
+    <blockquote>
+      <p>Article 6(7) The gatekeeper shall allow providers of services and providers of
+        hardware, <strong class="stressed">free of charge</strong>, effective interoperability with, and
+        access for the purposes of interoperability to, the same hardware and software features accessed or controlled
+        via
+        the operating system or virtual assistant listed in the designation decision pursuant to Article 3(9) as are
+        available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business
+        users and alternative providers of services provided together with, or in support of, core platform services,
+        free
+        of charge, effective interoperability with, and access for the purposes of interoperability to, the same
+        operating
+        system, hardware or software features, regardless of whether those features are part of the operating system,
+        as
+        are available to, or used by, that gatekeeper when providing such services.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881487923&usg=AOvVaw0cEm-CbWqyVu4gQ7ekkjU2">Digital
+            Markets Act</a>
+          <br>(emphasis added)
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>“Free of charge” being the key and unambiguous phrase.</p>
+
+    <p>For the remaining items, given that it is not possible (or at least very difficult) to
+      distribute to iOS without Xcode (by Apple’s design), it is not clear how developers could avoid using
+      these
+      tools. Many developers would love the ability to be able to develop for iOS without being forced to use Xcode or
+      TestFlight, as this would allow developing for iOS without requiring an Apple Mac computer. It seems
+      unreasonable
+      to charge for usage of software libraries when you have, by contract and technical setup, prevented developers
+      from using competing libraries.</p>
+
+    <p>Astonishingly, Apple has added wording that you are <strong>unable to switch back
+        to the standard contract</strong> if you are unhappy with the new contract, while still
+      granting themselves the right to change either contract at any time.</p>
+
+    <blockquote>
+      <p>Developers who adopt the new business terms at any time will not be able to
+        switch back to Apple’s existing business terms for their EU apps. Apple will continue to give developers
+        advance notice of changes to our terms, so they can make informed choices about their businesses moving
+        forward.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/support/dma-and-apps-in-the-eu/%23dev-qa:~:text%3DDevelopers%2520who%2520adopt%2520the%2520new%2520business%2520terms%2520at%2520any%2520time%2520will%2520not%2520be%2520able%2520to%2520switch%2520back%2520to%2520Apple%25E2%2580%2599s%2520existing%2520business%2520terms%2520for%2520their%2520EU%2520apps.%2520Apple%2520will%2520continue%2520to%2520give%2520developers%2520advance%2520notice%2520of%2520changes%2520to%2520our%2520terms%252C%2520so%2520they%2520can%2520make%2520informed%2520choices%2520about%2520their%2520businesses%2520moving%2520forward.&sa=D&source=editors&ust=1718648881489154&usg=AOvVaw1Q2bn7Mave9xGQd8gACzaa">Apple
+            Documentation</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Next, it is worth considering how much it would cost for a browser
+      to list on one of these
+      third-party app stores. <a rel="noreferrer" target="_blank" href="https://www.demandsage.com/iphone-user-statistics/">
+        iOS has 1.65 billion users</a>. So that is
+      16.5 million users for each 1% browser market share. If a
+      browser
+      vendor dares to list their app on a third-party store, even once, and
+      <strong>even if no one
+        downloads it</strong> from that third-party store, Apple will bill them <strong>$8.25
+        million per year per 1% market share every year with no recourse</strong> to change back to
+      the previous contract.
+    </p>
+
+    <p>It seems clear this is designed to make it as difficult as possible for free apps to
+      list on third-party app stores, depriving alternative app stores of these apps, and preventing their ability to
+      succeed.</p>
+
+    <p>Apple should remove the Core Technology Fee entirely, and listing on a third-party app store
+      should not be able punitively change additional fees to a business’s
+      apps on the Apple app store in
+      <strong>retaliation</strong> for listing on other app stores on iOS.
+    </p>
+
+    <p>Under pressure Apple has added some exceptions to Core Technology Fee
+      including:</p>
+
+    <ul>
+      <li>Nonprofit organizations</li>
+      <li>Developers who’s apps collectively have less than 1 million
+        users.</li>
+      <li>A phase-in period of 3 years for developers that hit $10 million+
+        revenue</li>
+      <li>Students, hobbyists, and other non-commercial developers with a
+        no-revenue business.</li>
+    </ul>
+
+    <p>The last one is important as it is designed to prevent businesses from listing a free app either
+      directly via their website or third party app stores if they have
+      <strong>any</strong> apps with
+      revenue.
+    </p>
+
+    <p>None of these concessions solve the underlying problem. Apple is attempting to charge
+      fees on interactions between customers and businesses of which they have no part and provide no service beyond
+      that which comes with their operating system by default. These are apps not installed via Apple’s app
+      store
+      on devices that Apple has already sold at incredibly high margins to consumers. This type of behavior is clearly
+      against both the intent and letter of the DMA. </p>
+
+    <p>If Apple wishes to make additional revenue from consumers who purchase their devices in
+      the EU, they need to do it by making their app store and their optional services (Safari, iCloud, Apple TV,
+      Apple
+      Music etc) more attractive. They should not attempt to siphon revenue from consumers and businesses which are
+      opting to not use either for particular apps. </p>
+
+    <p>Further they should not apply punitive pricing to these same apps on their own app
+      store for daring to list outside of it.</p>
+
+    <h4 id="the-fair-price-for-api-access">
+      <a class="header-anchor" href="#the-fair-price-for-api-access" aria-hidden="true">#</a>
+      4.3.7.1. The Fair Price for API Access
+    </h4>
+
+    <p>Even though the DMA explicitly sets the cost of access to these APIs at zero, it is
+      worthwhile discussing what the “fair” price is.</p>
+
+    <h5 id="value-of-ip-in-apis">
+      <a class="header-anchor" href="#value-of-ip-in-apis" aria-hidden="true">#</a>
+      4.3.7.1.1. Value of IP in APIs
+    </h5>
+
+    <p>Clearly Apple does not believe that they have IP rights over the general category of
+      each of these APIs, otherwise with their over billion USD a year legal budget they would have sued other
+      operating
+      systems for violating their IP (eg Windows, Android, Linux etc).</p>
+
+    <p>So the question arises does the IP in Apple's iOS API's actually provide value
+      or is the real value being able to have sufficient access to the operating system hardware and software to
+      provide
+      needed functionality to consumers. It is important to remember that only Apple has control over what APIs are
+      available on iOS and so all of them are by definition made by Apple and likely contain Apple's IP even if
+      they
+      are stock standard and available on every operating system. In a sense it is like Apple is simply charging for
+      the
+      ability to have certain functionality on iOS rather than charging for the value of the IP in those APIs.
+    </p>
+
+    <p>One thought experiment to illustrate this is, to imagine for a particular API that
+      Apple also implemented a replica of Androids equivalent for that API for iOS. &nbsp;Developers are then asked
+      whether and how much more they would be willing to pay for Apple's version of the API containing Apple's
+      IP instead of using the Android APIs. If the answer is zero or low then we believe that the amount Apple should
+      be
+      allowed to charge under should be equally low as this would indicate the the value of the IP in this case was
+      low
+      or zero. </p>
+
+    <h5 id="comparable-licenses">
+      <a class="header-anchor" href="#comparable-licenses" aria-hidden="true">#</a>
+      4.3.7.1.2. Comparable licenses
+    </h5>
+
+    <p>Another avenue for deciding reasonable prices is to look at the comparable licenses
+      charged to other developers. Other operating systems such as Windows, macOS, Linux, ChromeOS and Android all do
+      not charge for access to system APIs. That is the comparable cost of licenses charged to other developers on
+      other
+      platforms is zero.</p>
+
+    <p>It is worth noting that iOS also does not currently charge for API access. Nowhere in
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/review/guidelines/&sa=D&source=editors&ust=1718648881492740&usg=AOvVaw2XYSmUlj7BbRVcE5Hg-w73">Apple’s
+        iOS guidelines</a> or in their
+      <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://developer.apple.com/app-store/features/&sa=D&source=editors&ust=1718648881493031&usg=AOvVaw1V4Tqtdr3r51DahsTf07XE">app
+        store features list</a> do they mention that they are waiving API access fees in
+      return for particular conditions or the App Store 15-30% revenue sharing arrangement.
+    </p>
+
+    <h5 id="apple-developer-fee">
+      <a class="header-anchor" href="#apple-developer-fee" aria-hidden="true">#</a>
+      4.3.7.1.3. Apple Developer Fee
+    </h5>
+
+    <p>Apple also charges all developers $100 USD per a year to be part of the developer
+      program. With 34 million registered developers, this is a business worth at least $100m a year to Apple, quite
+      plausibly significantly higher than the budget Apple has for API development for iOS. Apple currently plans to
+      charge this developer fee even to developers that do not distribute via their app store but rather distribute
+      directly or via third party app stores.</p>
+
+    <p>The fact that Apple already derives considerable income directly from developers
+      wishing to distribute an app on their operating system is a significant factor.</p>
+
+    <blockquote>
+      <p>I get it — saying “Spotify pays Apple nothing’ is a much
+        stronger lobbying position than ‘Spotify pays Apple just $99 a year, the same as every other
+        developer’. But only if it is, you know, true. And Apple makes hundreds of millions of dollars a year
+        from
+        charging that fee to developers as standard, which complicates the narrative that the App Store is only funded
+        by
+        commission on sales.</p>
+      <p>I tried asking Apple how they squared this, and a spokesperson repeated the claim
+        that Spotify paid $0 to Apple. When I asked if I could explicitly write that
+        ‘Apple claimed that Spotify
+        is
+        not charged the developer fee’, though, the company stopped replying to my emails. Spotify had no such
+        bashfulness, and confirmed that they pay the fee like all major developers.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.theguardian.com/technology/2024/mar/05/techscape-open-source-software-cryptocurrency&sa=D&source=editors&ust=1718648881494238&usg=AOvVaw20Oj1qsGGJeQB3WlrhCgVr">Alex
+            Hern - The Guardian</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p>Apple policy personnel are clearly aware of this and have previously directly lied in
+      order to obscure this point.</p>
+
+    <h5 id="why-apple-should-not-be-allowed-to-charge-for-api-access">
+      <a class="header-anchor" href="#why-apple-should-not-be-allowed-to-charge-for-api-access" aria-hidden="true">#</a>
+      4.3.7.1.4. Why Apple Should Not be Allowed to Charge for API Access
+    </h5>
+
+    <p>We believe that charging for access to APIs is deeply problematic for a number of
+    </p>
+    <p>reasons, and may end up being used as a tool to significantly hinder competition by
+      potentially unscrupulous gatekeepers.</p>
+
+    <p>In mandating that such API access must be free, we believe that the authors of the DMA
+      had tremendous foresight into the games that large gatekeepers would play were they granted such a weapon to use
+      against those who would contest their hardware and services.</p>
+
+    <p>They should not be able to charge for the following reasons:</p>
+
+    <ul>
+      <li>Could be a mechanism to hinder competition</li>
+      <li>Gatekeepers effectively can’t charge themselves</li>
+      <li>Face no competitive pressure to lower prices for API access</li>
+      <li>Will lock out smaller players</li>
+      <li>Consumers not the gatekeepers own their devices</li>
+      <li>Difficult to enforce reasonable pricing</li>
+      <li>No benefit to consumers but potential for considerable harm</li>
+      <li>Is not and will not be the gatekeepers’ primary business
+        model</li>
+    </ul>
+
+    <p>Allowing such fees opens the door to Apple and other gatekeepers to charge unreasonable
+      prices and lock out competition and is in our view a strictly worse option than mandating free access to these
+      APIs.</p>
+
+    <h5 id="the-faire-price-is-zero">
+      <a class="header-anchor" href="#the-faire-price-is-zero" aria-hidden="true">#</a>
+      4.3.7.1.5. The Fair Price is Zero
+    </h5>
+
+    <p>Given these APIs have no significant value above what is offered on other operating systems, the
+      fact developers are in fact forced to use them via virtue of it being the only choice on iOS, that developers
+      are
+      already paying Apple $100 USD per year and that allowing Apple to charge for this access will lead to
+      considerable
+      harm for consumers by suppressing the contestability of third party services, the fair price for these APIs is
+      zero.</p>
+
+    <h3 id="apple-should-publish-a-new-more-detailed-compliance-plan">
+      <a class="header-anchor" href="#apple-should-publish-a-new-more-detailed-compliance-plan" aria-hidden="true">#</a>
+      4.3.8. Apple Should Publish a New More Detailed Compliance Plan
+    </h3>
+
+    <p>The act states in Recital 68:</p>
+
+    <blockquote>
+      <p>In addition, a clear and comprehensible non-confidential summary of such
+        information should be made publicly available while taking into account the legitimate interest of gatekeepers
+        in
+        the protection of their business secrets and other confidential information. This non-confidential publication
+        should enable third parties to assess whether the gatekeepers comply with the obligations laid down in this
+        Regulation.</p>
+      <p>
+        <cite>
+          <a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://eur-lex.europa.eu/legal-content/EN/TXT/?toc%3DOJ%253AL%253A2022%253A265%253ATOC%26uri%3Duriserv%253AOJ.L_.2022.265.01.0001.01.ENG&sa=D&source=editors&ust=1718648881496493&usg=AOvVaw0RopEp5JWJlI2o6J6HyRCz">Digital
+            Markets Act – Recital 68</a>
+        </cite>
+      </p>
+    </blockquote>
+
+    <p><a rel="noreferrer" target="_blank" href="https://www.google.com/url?q=https://www.apple.com/legal/dma/dma-ncs.pdf&sa=D&source=editors&ust=1718648881496856&usg=AOvVaw0pSO6gijT11fYH94IefoGE">Apple's
+        compliance report</a> is woefully lacking in detail relative to the reports created
+      by the other gatekeepers. Key parts of Apple's compliance plan are not mentioned even in passing, for
+      example
+      phrases such as "Core Technology Fee" or "CTF" do not appear once in the document.</p>
+
+    <p>The lack of detail in Apple's compliance report makes it impossible for
+      <q>third parties to assess whether the gatekeepers comply with the obligations laid down in
+        this
+        Regulation</q>.
+    </p>
+
+    <p>By comparison:</p>
+
+    <dl>
+      <dt>Microsoft</dt>
+      <dd>421 pages</dd>
+      <dt>Google</dt>
+      <dd>271 pages</dd>
+      <dt>Meta</dt>
+      <dd>57</dd>
+      <dt>Bytedance</dt>
+      <dd>52 pages</dd>
+      <dt>Amazon</dt>
+      <dd>32 pages</dd>
+      <dt><strong class="stressed">Apple</strong></dt>
+      <dd><strong class="stressed">12 pages</strong></dd>
+    </dl>
+
+    <p>Without a full and detailed compliance report from Apple, it makes it significantly
+      more difficult for us, or any other party, to analyze their compliance.</p>
+
+    <p>The commission should consider requiring Apple to release a more detailed compliance report where
+      redactions from their existing confidential submission to the Commission are strictly limited to "business
+      secrets and other confidential information". In the event that their confidential submission is lacking
+      sufficient detail they should be forced to rectify it or be fined.
+
+    </p>
+
+    <h2 id="toward-a-brighter-future">
+      <a class="header-anchor" href="#toward-a-brighter-future" aria-hidden="true">#</a>
+      5. Toward A Brighter Future
+    </h2>
+
+    <p>OWA believes that the Web’s unmatched track record of safely providing
+      frictionless access to information and services has demonstrated that it can enable a more vibrant digital
+      ecosystem. The web’s open, interoperable, standards-based nature creates an inclusive environment that
+      fosters competition, delivering the benefits of technology to users more effectively and reliably than any
+      closed
+      ecosystem.</p>
+
+    <p>OWA’s goal is to ensure that browser competition is carried out under fair terms,
+      that user choice in browsers matters, and that web applications are provided equal access and rights necessary
+      to
+      safely contest the market for digital services.</p>
+
+    <p>By standing firm against Apple’s malicious compliance and forcing them to comply with their
+      obligations under the act as intended, the Commission can improve interoperability, contestability, and fairness
+      leading to lower priced and higher quality apps
+      — not only for the EU but for the entire world.</p>
+
+    <p><strong>OWA believes competition, not walled gardens, leads to the brightest future for
+        consumers, businesses, and the digital ecosystem.</strong></p>
+
+    <h2 id="references">
+      <a class="header-anchor" href="#references" aria-hidden="true">#</a>
+      6. References
+    </h2>
+
+    <ul class="references">
+      <li><a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">
+          The Digital Markets Act</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">
+          MOBILE ECOSYSTEMS MARKET STUDY - APPLE RESPONSE TO INTERIM REPORT</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">
+          Mozilla says Apple’s new
+          browser rules are ‘as painful as possible’ for Firefox</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+          HTML 5 poses a threat to Flash and the App Store</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+          OWA - It’s Official, Apple kills Web Apps in the EU</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+          OWA - Apple Backs Off Killing Web Apps</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+          Mobile ecosystems market study interim report</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">
+          Apple sales fall in nearly all countries</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">
+          No one's talking about the Apple Vision Pro anymore</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis">
+          Apple’s App Store grossed more than $85 billion in 2022</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+          $18B-20B in annual payments from Google to Apple</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+          DOJ Complaint against Apple</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">
+          OWA - Japan ends the #AppleBrowserBan</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">
+          OWA - New Digital Competition Laws for Australia</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">
+          OWA - Open Web Advocacy 2023 in Review</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">
+          OWA - UK passes Digital Markets, Competition and Consumers Bill</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+          Apple says iMessage on Android ‘will hurt us more than help us</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/contact/request/download/web_browser_engine.pdf">
+          Web Browser Engine Entitlement Addendum for Apps in the EU</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements">
+          Apple Developer Documentation - Entitlements</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://newosxbook.com/ent.jl?osVer=iOS17&exec=/Applications/MobileSafari.app/MobileSafari#:~:text=com.apple.bluetooth.internal%3A%20true">
+          OS X/iOS Entitlement Database</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/">
+          Hardware and the web: the balance between usefulness, security and privacy</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/9/3/22654197/apple-app-store-editorial-scams-refunds">
+          Eight things Apple could do to prove it actually cares about App Store users</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://appleinsider.com/articles/20/08/13/epic-skirts-apples-30-commission-fee-by-implementing-direct-payments">
+          Epic skirts Apple's 30% commission fee by implementing 'direct
+          ' payments</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://embed.documentcloud.org/documents/21043943-2016-january-friedman-how-many-apps-through-pipe/#document/p1">
+          Apple’s head of fraud on “App Store Review”</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.intego.com/mac-security-blog/xcodeghost-malware-infected-100-million-ios-users-and-apple-said-nothing/">
+          XcodeGhost Malware Infected 100+ Million iOS Users and Apple Said Nothing</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/">
+          Apple pays hackers six figures to find bugs in its software. Then it sits on
+          their findings</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html#:~:text=%22This%20bug%20is%20subject%20to%20a%2090%20day%20disclosure%20deadline.%20If%20a%20fix%20for%20this%20issue%20is%20made%20available%20to%20users%20before%20the%20end%20of%20the%2090%2Dday%20deadline%2C%20this%20bug%20report%20will%20become%20public%2030%20days%20after%20the%20fix%20was%20made%20available.%20Otherwise%2C%20this%20bug%20report%20will%20become%20public%20at%20the%20deadline.%22">
+          Project Zero team at Google - Vulnerability Disclosure FAQ</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/">
+          Apple Developer Program License Agreement</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/app-store/review/guidelines/">
+          Apple App Review Guidelines</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/BrowserEngineKit">
+          Apple - BrowserEngineKit </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/OpenWebAdvocacy/OpenWebCompetitionPlatform/issues/11">
+          Open Web Competition Platform - Alternate browser engines on iOS must be able to </a>
+        bring their own rendering architecture
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/web-platform-tests/interop/issues/84">
+          Interop - Extend Scrolling to cover Body Scroll Issues
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://techcrunch.com/2023/07/25/apple-att-antitrust-france/">
+          Apple’s app tracking triggers statement of objections from French competition
+          authority</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/">
+          When you ‘Ask app not to track,’ some iPhone apps keep snooping
+          anyway</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.pymnts.com/cpi-posts/uks-cma-raises-concerns-may-delay-googles-third-party-cookie-phase-out/">
+          UK’s CMA Raises Concerns, May Delay Google’s Third-Party Cookie
+          Phase-Out</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62052c52e90e077f7881c975/Google_Sandbox_.pdf">
+          UK’s CMA - Decision to accept commitments offered by Google in
+          relation to its Privacy Sandbox Proposals</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.techdirt.com/2021/08/31/apples-dedication-to-privacy-is-missing-when-it-comes-to-workforce-employees-say/">
+          Apple's Dedication To Privacy Is Missing When It Comes To Its
+          Workforce, Employees Say</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://twitter.com/doctorow/status/1459914164152016905">
+          Cory Doctorow - Apple has a tactical commitment to your privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2021/05/17/technology/apple-china-censorship-data.html">
+          Censorship, Surveillance and Profits: A Hard Bargain for Apple in China
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.apple.com/au/privacy/">
+          Apple - Privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.forbes.com/sites/daviddoty/2023/02/08/apple-the-story-behind-its-new-ad-offerings-to-retailers-restaurants-hotels-other-location-based-businesses/#:~:text=Apple%20seems%20to%20be%20growing,coming%20up%20fast%20if%20quietly">
+          Apple: The Story Behind Its New Ad Offerings To Retailers, Restaurants, Hotels,
+          Other
+          Location-Based Businesses</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.apple.com/legal/privacy/data/en/app-store/">
+          Apple - App Store &amp; Privacy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://9to5mac.com/2021/09/02/apple-personalized-ads-targeting-ios-15/#:~:text=For%20iOS%2015%20users%2C%20Apple%20has%20begun%20prompting,well%20as%20for%20targeting%20App%20Store%20Search%20Ads">
+          iOS 15 now prompts users if they want to enable Apple personalized ads, after
+          it was
+          previously on by default</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/63f61bc0d3bf7f62e8c34a02/Mobile_Ecosystems_Final_Report_amended_2.pdf">
+          UK CMA’s &nbsp;- Mobile ecosystems - Market study final report
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.nytimes.com/2008/07/26/business/26nocera.html">
+          Apple’s Culture of Secrecy
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.wired.com/2008/09/apple-imposes-n/">
+          Apple Imposes NDA For App Store Rejections
+        </a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://fortune.com/2023/04/18/tech-nda-illegally-muzzle-whistleblowers-sec/">
+          ‘It’s concerning’: Tech firms are using NDAs to illegally
+          muzzle
+          whistleblowers by threatening to sue them for talking, SEC says</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email">
+          Apple execs discuss why the Mac App Store has not been successful in internal
+          email</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#ADPLA5.3">
+          Apple - &nbsp;Notarized Applications for macOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf">
+          Mozilla - “Can browser choice screens be effective?” paper</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/">
+          OWA - Apple's one weird trick to stop you changing your default browser</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/?comments=1">
+          Report: People are bailing on Safari after DMA makes changing defaults easier</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/walled-gardens-report/#app-clips">
+          OWA - App Clips</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/walled-gardens-report/#smart-app-banners">
+          OWA - Smart App Banners</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event">
+          Mozilla Documentation beforeinstallprompt</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2024/05/17/apple_browser_eu/">
+          Apple says if you want to ship your own iOS browser engine in EU, you need to
+          be there</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://twitter.com/RickByers/status/1791609238000705824">
+          Rick Byers - On how Chrome can’t test their own browser on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/mozilla/platform-tilt/issues/16">
+          Platform Tilt - Beta testing on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming#:~:text=We%20all%20rely,chance%20to%20compete">
+          CMA plans market investigation into mobile browsers and cloud gaming</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/dma-and-apps-in-the-eu#8">
+          Apple - On removing Web App Support</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://infrequently.org/2022/06/apple-is-not-defending-browser-engine-choice/#:~:text=This%20split%20experience%20causes%20a%20sort%20of%20pervasive%20forgetfulness%2C%20making%20the%20web%20less%20useful">
+          Apple Is Not Defending Browser Engine Choice</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf">
+          Digital Markets Act - Interventions In-App Browsers</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://github.com/mozilla/platform-tilt/issues/15">
+          Platform Tilt - Browser extension support on iOS</a>
+      </li>
+      <li>
+        <a rel="noreferrer" target="_blank" href="https://www.w3.org/TR/payment-request/">
+          W3C - Payment Request API</a>
+      </li>
+      <li><a rel="noreferrer" target="_blank" href="https://github.com/WebKit/standards-positions/issues/30">
+          WebKit - standards-positions - Safari will be locked to Apple Pay</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/3/14/24100944/spotify-ios-app-update-eu-apple-dma">
+          Spotify says its iPhone app updates in the EU are getting held up by Apple</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theguardian.com/business/2024/mar/04/eu-fines-apple-18bn-over-app-store-restrictions-on-music-streaming#:~:text=EU%20fines%20Apple%20%E2%82%AC1.8bn%20over%20App%20Store%20restrictions%20on%20music%20streaming,-This%20article%20is&text=Apple%20has%20been%20fined%20%E2%82%AC,streaming%20services%20such%20as%20Spotify">
+          EU fines Apple €1.8bn over App Store restrictions on music streaming</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.ben-evans.com/benedictevans/2020/8/18/app-stores">
+          App stores, trust and anti-trust</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://twitter.com/samj0hn/status/1431001795904561160">
+          Samantha John - CEO Hopscotch on App Store Review</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution">
+          Apple - Notarizing macOS software before distribution</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/distribute/app-review/#:~:text=On%20average%2C%2090%25%20of%20submissions%20are%20reviewed%20in%20less%20than%2024%C2%A0hours">
+          Apple - App Review 90% in less than 24 hours</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow#:~:text=After%20you%20upload%20your%20app%2C%20the%20notarization%20process%20typically%20takes%20less%20than%20an%20hour">
+          Apple - Notarizing macOS software typically less than 1 hour</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html">
+          Google Project Zero - Patch Gap</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.ubackup.com/phone-backup/how-long-does-an-ios-update-take.html#:~:text=Updating%20to%20the%20latest%20iOS%20takes%20about%2030%20minutes%20on%20average">
+          How long does an iOS Update Take - 30 mins</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://support.apple.com/en-us/118110#:~:text=If%20you%20leave%20the%20European,apps%20from%20alternative%20app%20marketplaces">
+          Apple - About alternative app distribution in the European Union</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://home-affairs.ec.europa.eu/system/files_en?file=2020-09/schengen_brochure_dr3111126_en.pdf">
+          The Schengen area</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://esta.cbp.dhs.gov/esta">
+          ESTA - Electronic System for Travel Authorization</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://europa.eu/youreurope/citizens/work/taxes/income-taxes-abroad/index_en.htm#:~:text=you%20will%20usually%20be%20considered%20tax%2Dresident%20in%20the%20country%20where%20you%20spend%20more%20than%206%20months%20a%20year">
+          You will usually be considered tax-resident in the country where you spend more
+          than 6 months a year</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/core-technology-fee/">
+          Apple - Core Technology Fee</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/support/dma-and-apps-in-the-eu/">
+          Apple - Update on apps distributed in the European Union</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://developer.apple.com/app-store/features/">
+          Apple - App Store Features</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.theguardian.com/technology/2024/mar/05/techscape-open-source-software-cryptocurrency">
+          How much does Spotify really pay Apple?</a></li>
+      <li><a rel="noreferrer" target="_blank" href="https://www.apple.com/legal/dma/dma-ncs.pdf">
+          Apple’s Non-Confidential Summary of DMA Compliance Report</a></li>
+    </ul>
+
+    <h2 id="open-web-advocacy">
+      <a class="header-anchor" href="#open-web-advocacy" aria-hidden="true">#</a>
+      7. Open Web Advocacy
+    </h2>
+
+    <p>Open Web Advocacy is a not-for-profit organization made up of a loose group of
+      software engineers from all over the world, who work for many different companies and have come together
+      to fight
+      for the future of the open web by providing regulators, legislators and policy makers the intricate
+      technical
+      details that they need to understand the major anti-competitive issues in our industry and potential ways
+      to solve
+      them.</p>
+    <p><span>It should be noted that all the authors and reviewers of this document are software
+        engineers and not economists, lawyers or regulatory experts. The aim is to explain the current situation,
+        outline
+        the specific problems, how this affects consumers and suggest potential regulatory remedies. </span></p>
+    <p><span>This is a grassroots effort by software engineers as individuals and not on behalf of
+        their employers or any of the browser vendors. We are available to regulators, legislators and policy
+        makers for presentations/Q&amp;A and we can provide expert technical analysis on topics in this area. </span></p>
+    <p><span>For those who would like to help or join us in fighting for a free and open future for
+        the web, please contact us at:</span></p>
+
+    <dl>
+      <dt>Email</dt>
+      <dd><a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a></dd>
+      <dt>Web/ Web</dt>
+      <dd><a rel="noreferrer" target="_blank" href="http://open-web-advocacy.org">http://open-web-advocacy.org</a></dd>
+      <dt>Mastodon</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://mastodon.social/@owa">@owa@mastodon.social</a></dd>
+      <dt>Twitter / X</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://twitter.com/OpenWebAdvocacy">@OpenWebAdvocacy</a></dd>
+      <dt>LinkedIn</dt>
+      <dd><a rel="noreferrer" target="_blank" href="https://www.linkedin.com/company/open-web-advocacy">https://www.linkedin.com/company/open-web-advocacy</a>
+      </dd>
+    </dl>

--- a/src/ja/pages/applebrowserban.md
+++ b/src/ja/pages/applebrowserban.md
@@ -1,0 +1,19 @@
+---
+title: Apple Browser Ban
+permalink: /ja/apple-browser-ban/
+metaDesc: 'Learn more about the #AppleBrowserBan campaign run by Open Web Advocacy.'
+layout: layouts/page.njk
+translated: false
+---
+
+Apple's ban of third party browsers on iOS is deeply anti-competitive, starves the Safari/WebKit team of funding and has stalled innovation for the past 10 years and prevented Web Apps from taking off on mobile.
+
+## What is the Apple browser ban?
+
+You might wonder what we're talking about: Chrome, Firefox and others are available in the Apple AppStore!  All is not what it seems. 
+
+When you download Chrome, Firefox or any other browser that isn't Safari on an Apple device, that browser is forced to use Safari's rendering engine WebKit. Chrome normally uses Chromium, and Firefox Gecko. However, Apple will not allow those browsers to use their own engines. Without the ability to use their own engines, those browsers are unable to bring you their latest and greatest features, and can only go so far as whatever WebKit has added.
+
+This behaviour is anti-competitive, and lessens the web experience for users on Apple devices.
+
+You can read more about this behaviour in our [Walled Garden Report](/walled-gardens-report/), and also show your understanding and support of lifting the Apple browser ban by using the hashtag [#AppleBrowserBan](https://twitter.com/search?q=%23AppleBrowserBan&f=live)

--- a/src/ja/pages/blog.md
+++ b/src/ja/pages/blog.md
@@ -1,0 +1,30 @@
+---
+title: News
+permalink: /ja/blog/
+metaDesc: Check out the most recent blog posts from Open Web Advocacy.
+templateEngineOverride: njk
+translated: false
+---
+{% extends 'layouts/base.njk' %}
+{% block content %}
+<h1 class="post-title">{{ title }}</h1>
+  {% for item in collections.blog %}
+
+
+  <article class="h-entry blog-index">
+    <div class="[ post ] [ flow wrapper ]">
+      <h2 class="post-title"><a href="{{ item.url | locale_url }}" class="post-list__link">{{ item.data.title }}</a></h2>
+      {% set date = item.data.date %}
+      {% set author = item.data.author %}
+      {% set tags = item.data.tags %}
+      {% include "partials/post-meta.njk" %}
+      <div class="post-content flow">
+        {{ item.content | excerpt }} <a href="{{ item.url | locale_url }}">Continue reading</a>
+      </div>
+    </div>
+  </article>
+
+
+   
+  {% endfor %}
+{% endblock %}

--- a/src/ja/pages/contributors.html
+++ b/src/ja/pages/contributors.html
@@ -1,0 +1,67 @@
+---
+title: Contributors & Supporters
+permalink: /ja/contributors/
+metaDesc: Team of contributors to the Open Web Advocacy initiative
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Open Web Advocacy is a not-for-profit organization made up of a loose group of software engineers from all over the world,
+  who work for many different companies who have come together to fight for the future of the open web by providing regulators,
+  legislators and policy makers the intricate technical details that they need to understand the major anti-competitive issues
+  in our industry and potential ways to solve them.</p>
+
+<p>Open Web Advocacy was started in March 2021 by brothers Alex and James Moore. 
+  Early contributors include Stuart Langridge and Bruce Lawson were interviewed for a piece in The Register &ndash;
+  <strong>
+  <a href="https://www.theregister.com/2022/02/28/apple_apps_challenge/">Web devs rally to
+  challenge Apple App Store browser rules</a></strong>,
+  and we have listed coverage on our <a href="{{'/press/' | locale_url}}">press page</a>.
+</p>
+
+<p>A number of our contributers wish to remain private as they are concerned that publicly confronting gatekeepers will cause
+issues with their jobs or businesses.</p>
+
+<p>Please note that contributions by individals do not necessarily reflect an endorsement by their employers.</p>
+
+<ul class="contributors">
+  {% for person in contributors %}
+    <li>
+      <div class="main-data">
+        <p>
+          <img src="/images/contributors/{{ person.avatar }}" alt="" />
+          <strong>
+            {{ person.name }}
+            <span>({{ person.countries | join(',&nbsp;') | safe}})</span>
+          </strong>
+        </p>
+        <p>{{ person.what | safe }}</p>
+      </div>
+      <p class="social">
+        {% if person.github %}<a href="https://github.com/{{ person.github }}">Github</a>{% endif %}
+        {% if person.mastodon and person.github %} / {% endif %}
+        {% if person.mastodon %}<a href="{{ person.mastodon }}">Mastodon</a>{% endif %}
+        {% if person.twitter and (person.github or person.mastodon) %} / {% endif %}
+        {% if person.twitter %}<a href="https://twitter.com/{{ person.twitter }}">Twitter</a>{% endif %}
+        {% if person.linkedIn and (person.github or person.mastodon or person.twitter) %} / {% endif %}
+        {% if person.linkedIn %}<a href="{{ person.linkedIn }}">LinkedIn</a>{% endif %}
+        {% if person.email and (person.github or person.mastodon or person.twitter or person.linkedIn) %} / {% endif %}
+        {% if person.email %}<a href="mailto:{{ person.email }}">Email</a>{% endif %}
+        {% if person.website and (person.github or person.mastodon or person.twitter or person.linkedIn or person.email) %} / {% endif %}
+        {% if person.website %}<a href="{{ person.website }}">Website</a>{% endif %}
+      </p>
+    </li>
+  {% endfor %}
+
+  {% if contributors.length % 2 !== 0%}
+    <li></li>
+  {% endif%}
+</ul>
+
+<p>If you are a contributor or a supporter and wish to be listed above please <a href="mailto:contactus@open-web-advocacy.org">contact us.</a></p>
+
+<p>If you would like to support/contribute you can <a href="{{'/donate' | locale_url}}">donate</a> or join our community on
+  <a href="https://discord.com/invite/x53hkqrRKx">Discord</a> to get more deeply involved. Can't spare the
+  cash or time? Keep up with what we're up to and help spread the word by following us on
+  <a href="https://twitter.com/OpenWebAdvocacy">Twitter</a> and/or <a href="https://mastodon.social/@owa">Mastodon</a>
+  .</p>

--- a/src/ja/pages/digital-markets-act.md
+++ b/src/ja/pages/digital-markets-act.md
@@ -1,0 +1,13 @@
+---
+title: Digital Markets Act
+permalink: /ja/digital-markets-act/
+metaDesc: Learn more about the European Union Digigtal Markets Act
+layout: layouts/page.njk
+translated: false
+---
+
+The Digital Markets Act is a landmark piece of regulation from the European Union.  
+
+The Act aims to ensure that major tech platforms behave in a fair way online, and specifically to the interest of Open Web Advocacy, it ensures that players like Apple, Google and others must make access to the Open Web fairer by allowing a diverse range of browsers to compete. 
+
+You can find out more about the DMA on the [EU's own website](https://commission.europa.eu/strategy-and-policy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en), along with our own posts discussing how the DMA is affecting browser competition [on our blog](https://open-web-advocacy.org/tag/eu/).

--- a/src/ja/pages/donate.html
+++ b/src/ja/pages/donate.html
@@ -1,0 +1,137 @@
+---
+title: Donate
+permalink: /ja/donate/
+metaDesc: Donate to Open Web Advocacy
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Regulators in the UK, EU, Japan, Australia and the USA have begun investigating Apple's ban
+  on third-party browser engines and are considering interventions to enable Web Apps to compete
+  with native. Most significantly, wording to this effect has been included in the EU's 
+  landmark tech act, the Digital Markets Act.</p>
+
+<p>This was not inevitable. Over the past two years, Open Web Advocacy has extensively 
+  briefed regulators and legislators about the Web's potential to counterbalance the 
+  mobile app duopoly.</p>
+
+<p>Almost certainly as a direct result of our advocacy Apple has hired dozens of additional 
+  staff to work on WebKit and Safari. This extra bandwidth and regulatory pressure has directly contributed
+  to the addition of long-delayed features such as push notifications and app badging for Web Apps. 
+  WebKit staff numbers are secret, but we believe this is a significant percentage increase.</p>
+
+<p><strong>Competition, or at least the threat of it, works.</strong></p>
+
+<p>OWA needs your help to continue applying pressure to restore competition and to make
+  universal web apps a reality. You can make a real difference to ensure the future of the
+  web by supporting this work. We rely on donations to challenge unbelievably wealthy 
+  gatekeepers who have every incentive to hold the web back.</p>
+
+<div class="prom-banner">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p>If you love what we're doing and would like to support our work, please consider
+      <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a> or by getting your company to support us.</p>
+    <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+      to ensure the future of Browser competition and Web Apps</p>
+
+    <div>
+        <p><a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG" class="donate-button">Donate Now
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+<h2>We need help</h2>
+
+<p>Collectively we have volunteered several thousand hours promoting and advocating these issues. While we have had significant success, we believe that in order to fulfil our aims it will require having a few of us work full time on this for the next 1 - 3 years to keep up with the sheer volume of work required to push this with multiple regulators. Ideally any regulatory solution should be enacted in as many jurisdictions as possible.</p>
+
+<p>Apple has not lifted their ban on competing browser engines on iOS, Web Apps can’t compete with Native Apps because they are treated unfairly and are missing many features that are exclusive to Native Apps. Thus far, no regulator has yet compelled gatekeepers to fix these issues.</p>
+
+<p>With your help, it will allow us to document, explain, promote and push these issues to ensure they get fixed.</p>
+
+<h2>How will the money be spent?</h2>
+
+<p>All money will be spent on furthering the aims listed above, primarily through talking to
+  regulators, publishing documents that outline the key arguments, talks, promoting the issues
+  via the news/social media and talking to the industry including, developers, OS & Browser
+  Vendors as well as small and large development companies.</p>
+
+<h2>What have we achieved so far?</h2>
+
+<p>Prior to our advocacy work there was very limited discussion by regulators about browsers on mobile device. To our knowledge there <b>was no discussion of Browser Engines or Web Apps</b> by regulators till Open Web Advocacy began highlighting its vital importance in multiple filings to a range of regulators. Typically the only remedy mentioned was browser ballots to overcome the gatekeepers deciding the default browser.</p>
+
+<p>We believe we have achieved some important milestones:</p>
+
+
+<h3>UK’s Competition and Markets Authorities Mobile Ecosystems Report</h3>
+<p>We have discussed the issues extensively with the CMA and they dedicated many pages of their report to Apple's banning of third party browser engines (effectively a browser ban), Webkit is mentioned 122 times throughout the report.<p>
+
+<p>They propose forcing Apple to lift this ban:</p>
+<blockquote>
+    <p>Importantly, due to the WebKit restriction, Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS. This not only restricts competition (as it materially limits the potential for rival browsers to differentiate themselves from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, potentially depriving iOS users of useful innovations they might otherwise benefit from.</p>
+
+    <p>...</p>
+
+    <p>Overall, the evidence that we have seen does not suggest that the WebKit restriction is justified by security concerns. We note that Apple benefits financially from weakening competition in browsers via the browser engine ban</p>
+
+    <p>...</p>
+
+    <p>On this basis, the evidence we have gathered suggests that removal of the WebKit restriction has the potential to deliver strong benefits to competition, consumers, and digital businesses in the UK</p>
+
+    <cite><a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1096277/Mobile_ecosystems_final_report_-_full_draft_-_FINAL__.pdf">UK CMA - Mobile ecosystems Market Study - Final Report</a></cite>
+</blockquote>
+
+<p>This is an excellent document and the CMA outline many of the arguments in great detail.</p>
+
+<p>Additionally the CMA have launched a <a href="https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming">market investigation reference</a> into browsers and cloud gaming of which the key remedy discussed is removing Apple's ban on third party browser engines. <a href="https://www.ashurst.com/en/news-and-insights/legal-updates/quickguide---the-use-of-market-studies-and-market-investigations-in-uk-competition-law/">Market investigation references</a> are the UK's regulator next step after Market Studies, they are only launched if the CMA has convincing evidence of adverse effects to competition and have strong remedy powers.</p>
+
+<h3>Important Changes to the Digital Markets Act</h3>
+
+<p>The European Union has added Browser, Browser Engines and Web Apps to the <a href="https://en.wikipedia.org/wiki/Digital_Markets_Act">Digital Markets Act</a>.</p>
+
+<p>Specifically the following section:</p>
+<blockquote>
+    <p>In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users.</p>
+    <cite><a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital Markets Act</a></cite>
+</blockquote>
+
+
+<h3>Push Notifications/Badging on iOS</h3>
+
+<p>Shortly after our initial consultations with regulators it was quietly announced that Apple was working on Push Notifications for iOS despite there being no signal on the feature for the previous decade, a feature that Native Apps have had since the launch of the App Store. Later Apple very publicly announced that they would be bringing Push Notifications to iOS at Apple Worldwide Developers Conference 2022. This feature was released in <a href="https://twitter.com/OpenWebAdvocacy/status/1626308216861904896">iOS 16.4</a> along with a host of positive Safari/Webkit changes such as Badging. We believe this and the significant uptick in work on Safari is a direct result of our advocacy.</p>
+
+
+<h3>Additional Staff/Funding for Webkit/Safari</h3>
+
+<p>Additionally after our initial consultations with regulators, Apple moved to place more than 60 Webkit/Safari job adverts. We do not know the exact size of the Webkit team but suspect this is a significant percentage increase in the team. This is excellent news for consumers and developers who will all benefit from more features and less bugs in Safari. While we firmly believe that true browser competition is needed for iOS, Apple increasing Safari’s funding is a very positive step.</p>
+
+
+<h3>Other Regulators are investigating</h3>
+
+<p>We have had extensive discussion with other government agencies such as Japan’s HDMC, Australia ACCC and the US’s NTIA. These regulators are now investigating these issues. These regulators have publicly proposed removing Apple restrictions on third party browsers in their latest reports (see <a href="https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf">Japan's HDMC report</a>, <a href="https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf">Australia's ACCC report</a> and <a href="https://www.ntia.gov/sites/default/files/publications/mobileappecosystemreport.pdf">the US's NTIA report</a>).
+
+
+<h2>Help Out</h2>
+
+<p>You can <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">donate</a> or join our community on 
+  <a href="https://discord.com/invite/x53hkqrRKx">Discord</a> to get more deeply involved. Can't spare the 
+  cash or time? Keep up with what we're up to and help spread the word by following us on 
+  <a href="https://twitter.com/OpenWebAdvocacy">Twitter</a> and/or <a href="https://mastodon.social/@owa">Mastodon</a>
+  .</p>
+</p>
+
+<div class="prom-banner">
+  <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+  <p>If you love what we're doing and would like to support our work, please consider
+    <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a> or by getting your company to support us.</p>
+  <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+    to ensure the future of Browser competition and Web Apps</p>
+
+  <div>
+      <p>
+        <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG" class="donate-button">Donate Now
+          <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a>
+      </p>
+  </div>
+</div>

--- a/src/ja/pages/files.html
+++ b/src/ja/pages/files.html
@@ -1,0 +1,15 @@
+---
+title: Files
+permalink: /ja/files/
+metaDesc: An index of the documents available on the site
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Here is a list of files available in this directory of the site:</p>
+
+<ul>
+  {% for file in files %}
+    <li><a href="{{ file.uri }}">{{ file.name }}</a> [{{ file.size }}]</li>
+  {% endfor %}
+</ul

--- a/src/ja/pages/getinvolved.md
+++ b/src/ja/pages/getinvolved.md
@@ -1,0 +1,20 @@
+---
+title: Get Involved
+permalink: /ja/get-involved/
+metaDesc: Learn how to get involved with Open Web Advocacy's efforts.
+layout: layouts/page.njk
+translated: false
+---
+
+Join us in advocating for the open web. There are many ways you can help, from contacting legislators and regulators to helping collect and document evidence of anti-competitive behavior.
+
+Unlike groups who operate on behalf of major organizations, we are unbacked, unfunded and rely on individuals to contribute their time and expertise. If you believe in the future of the web, you can help make that future a reality.
+
+Specifically, we are looking for people with any of the following:
+
+1. A strong passion for an open web
+2. Experience working with web technologies
+3. Experience with internet or technology policy
+4. Experience with advocacy or grassroots campaigning efforts
+
+If you are excited about the work we do and want to learn more, you can do so by contacting us via <a href="https://discord.gg/x53hkqrRKx">Discord</a>, <a href="https://twitter.com/OpenWebAdvocacy">Twitter</a>, <a href='https://mastodon.social/@owa' rel='me'>Mastodon</a> or send us an <a href="mailto:contactus@open-web-advocacy.org">email</a>.

--- a/src/ja/pages/glossary.html
+++ b/src/ja/pages/glossary.html
@@ -1,0 +1,140 @@
+---
+title: Glossary
+permalink: /ja/glossary/
+metaDesc: Learn language used in Open Web Advocacy's efforts.
+layout: layouts/page.njk
+translated: false
+---
+
+<dl class="glossary">
+  <dt id="third-party-browser">Third Party Browser</dt>
+  <dd>
+    <p>A web browser developed by a company other than the gatekeeper
+    which includes a layout engine and rendering engine either selected or built by the company.</p>
+  </dd>
+
+  <dt id="native-app">Native App</dt>
+  <dd>
+    <p>An app written using a gatekeeper’s proprietary frameworks and APIs which are
+    provided by the operating system.
+    On iOS (Apple’s operating system for iPhone and iPad) these are currently
+    exclusively delivered through Apple’s App Store.</p>
+  </dd>
+
+  <dt id="web-app">Web App</dt>
+  <dd>
+    <p>A Web Application, Web App or Progressive Web App (PWA) is an application developed using Web technologies, such as HTML, CSS, JavaScript and WebAssembly. Web Apps use Web Browsers as the <strong>engine</strong> to run the Web App. The capabilities of a Web Apps depends on the level of advancement of the Web Browser that they run on. Web Assembly allows developers to bring existing software, for example game engines or photoshop, and port/convert them so they run on the web or as a web-app.</p>
+
+    <p>Web Apps can be made to run offline, can run as smoothly as native apps and can support high performance applications, but this functionality depends on the Web Browser. Web Apps offer more privacy and security than native apps. Web Apps are universal, in that they can be written once and then run on all devices. This is in comparison with native apps that have to be rewritten for each platform that they target.</p>
+
+    <p>To the end user a well written Web App should be indistinguishable from a native app.</p>
+  </dd>
+
+  <dt id="webview-browser">WebView Browser</dt>
+  <dd>
+    <p>A web browser that does not include its own engine, and instead uses an engine or an unmodified <strong>Webview</strong> provided by the OS. For example, all browsers on iOS other than Safari on iOS are WebView browsers, in that they do not render the website or run the code for the site and instead hand that job onto Safari WebView.</p>
+  </dd>
+
+  <dt id="pwa">PWA (Progressive Web App)</dt>
+  <dd>
+    <p>Can be used interchangeably with Web App, although PWA is used to describe modern Web
+    Apps with functionality that is typically associated with native apps rather than websites
+    (i.e. installation on device, Offline Storage, Device API access etc).</p>
+  </dd>
+
+  <dt id="gatekeeper">Gatekeeper</dt>
+  <dd>
+    <p>The company that controls the operating system and the apps that run on that operating
+    system (i.e. Apple with iOS, Google with Android).</p>
+  </dd>
+
+  <dt id="browser-vendor">Browser Vendor</dt>
+  <dd>
+    <p>The entity that makes the browser.</p>
+  </dd>
+
+  <dt id="default-browser">Default Browser</dt>
+  <dd>
+    <p>A user’s default browser.</p>
+
+    <p>When a user taps a link, the link’s target website will open in the user’s
+    current default browser separately from any app.</p>
+
+    <p>For example, when a user receives a message containing a link and they tap on it,
+    the focused application will change from their SMS application to the Default Browser
+    (e.g. Firefox) and the website will load in that browser outside of the app.</p>
+
+    <p>This is the default behaviour of operating systems since the 90s and preserves user
+    choice in browsers. It also ensures the privacy and security settings of their browser
+    (including extensions) are applied when browsing sites from these links. This default
+    behaviour enables browser competition and respects user choice.</p>
+
+    <p>Mobile operating systems do not always respect this choice.</p>
+  </dd>
+
+  <dt id="remote-tab-iab">Remote Tab IAB</dt>
+  <dd>
+    <p>A tab from a real browser, but shown inside an app.
+
+    <p>This can occur when a user taps a link and the website loads within the current
+    application (i.e. it does not switch to a browser application) but the site is still
+    rendered using the user’s chosen (default) browser. Twitter for Android implements
+    this pattern using Chrome Custom Tabs (&ldquo;CCT&rdquo;) in the default configuration. It is
+    important to note that while CCT contains the word Chrome, under default settings
+    it will load the users’ default browser even if it is not-chromium, for example
+    Firefox (Gecko).</p>
+
+    <p>User’s default browser choices &mdash; whether Firefox, Edge, Chrome, or Opera &mdash;
+    are respected when the user’s default browser is &ldquo;projected&rdquo; through a Remote Tab
+    IAB. This behaviour strikes a balance between developer interests in not &ldquo;losing&rdquo;
+    users to external applications (browsers) and the user’s agency in choosing and
+    configuring their own browser.</p>
+
+    <p>By default this does not undermine user choice, however on Android there is an
+    option in CCT, which is the component that is used to enable Remote Tab IAB to
+    specify a single engine. This can be used to undermine user choice like in the
+    Android Google Search App. On iOS this always uses Safari whether or not it is
+    the user’s default browser, disrespecting the choices of users that select
+    different default browsers.</p>
+  </dd>
+
+  <dt id="webview-iab">WebView IAB</dt>
+  <dd>
+    <p>An OS-Provided Component for Rendering Web Content.</p>
+
+    <p>Many apps provide an IAB based on the OS-provided webview component. Historically,
+    this was grounded in reasonable motivations by app authors, but as Remote Tab Browsers
+    have become available, the problems with WebVIew IABs have become evident.</p>
+
+    <p>Apps that implement WebView IABs:</p>
+
+    <ol>
+      <li>Do not respect the user’s choice of browser, undermining competition.</li>
+      <li>Reduce functionality relative to &ldquo;real&rdquo; browsers. WebViews are not designed
+      to be drop-in replacements for browsers, and significant work is needed to fill in the gaps;
+      work that many apps do not put in.</li>
+
+      <li>Rely on the operating system to update the WebView component, potentially exacerbating
+      security risks that real browser vendors do work to mitigate.</li>
+
+      <li>Can MITM (Man in the middle) connections to third parties, which means they can
+      intercept all data sent and received to the website without the User’s knowledge or
+      consent. This creates silent tracking/privacy & security risks.</li>
+
+      <li>Can monitor every click, tap, input and interaction with a WebView.</li>
+
+      <li>May not mitigate known security risks in outdated system WebViews (e.g. on older
+        devices), putting users at high risk compared to loading websites in real browser.</li>
+
+      <li>May fail to implement key features (e.g., Push Notifications), despite the underlying
+       WebView providing APIs that would allow it.</li>
+    </ol>
+
+    <p>WebViews are not fully functioning browsers and applications that use them when Remote
+    Tab IAB systems are available are undermining user’ choice in browsers. They also may
+    damage the wider Web ecosystem by causing bugs and removing functionality critical to the content they load.</p>
+
+    <p>A variant of System WebView IABs are IABs built on application-provided browser
+    engines (e.g., Mozilla’s GeckoView, which can be embedded in many native apps).</p>
+  </dd>
+</dl>

--- a/src/ja/pages/owa-promotional.html
+++ b/src/ja/pages/owa-promotional.html
@@ -1,0 +1,267 @@
+---
+title: OWA Promotional Resources
+permalink: /ja/owa-promotional/
+metaDesc: Open Web Advocacy logo and promotional images
+layout: layouts/page.njk
+translated: false
+---
+
+<p>Our logo and communication illustrations are free for you to
+print and apply to any design item you can think of.
+We'd love to see your support for the open web!</p>
+
+<h2>OWA Logo</h2>
+
+<ul class="thumbs">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange-transparent.svg" download="owa-logo-transparent">
+        <img src="/images/prom-gallery/logo-full-orange-transparent.svg"
+          width="154"
+          height="187"
+          alt="Download SVG of Owa Full Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange-transparent.png" download="owa-logo-transparent-png">
+        <img src="/images/prom-gallery/logo-full-orange-transparent.png"
+          width="154"
+          height="187"
+          alt="Download PNG of Owa Full Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 8Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/owa-home-logo.svg" download="owa-home-logo">
+        <img src="/images/owa-home-logo.svg"
+          width="154"
+          height="187"
+          alt="Download SVG of Owa Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/owa-home-logo.png" download="owa-home-logo-png">
+        <img src="/images/prom-gallery/owa-home-logo.png"
+          width="154"
+          height="187"
+          alt="Download PNG of Owa Logo/ Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/owa-logo.svg" download="owa-logo">
+        <img src="/images/owa-logo.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / White with transparent background" /></a>
+      <figcaption>White/ transparent <span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a class="wide" href="/images/prom-gallery/logo-full-horizontal.svg" download="owa-full-logo-horizontal">
+        <img src="/images/prom-gallery/logo-full-horizontal.svg"
+          width="300"
+          height="160"
+          alt="Download Owa Full Horizontal Logo / Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a class="wide" href="/images/prom-gallery/logo-full-horizontal.png" download="owa-full-logo-horizontal-png">
+        <img src="/images/prom-gallery/logo-full-horizontal.png"
+          width="300"
+          height="160"
+          alt="Download PNG Owa Full Horizontal Logo / Orange with transparent background" /></a>
+      <figcaption>Orange/ transparent <span>(PNG, 8Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-white.svg" download="owa-logo-full-white">
+        <img src="/images/prom-gallery/logo-full-white.svg"
+          width="154"
+          height="187"
+          alt="Download Full Owa Logo / White on squared orange background" /></a>
+      <figcaption>Full White/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-full-orange.svg" download="owa-logo-full-orange">
+        <img src="/images/prom-gallery/logo-full-orange.svg"
+          width="154"
+          height="187"
+          alt="Download Full Owa Logo / Orange on squared black background" /></a>
+      <figcaption>Full Orange/ dark <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-white-round.svg" download="owa-logo-round-white">
+        <img src="/images/prom-gallery/logo-white-round.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / White on round orange background" /></a>
+      <figcaption>White/ orange round<span>(SVG, 6Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/logo-orange-round.svg" download="owa-logo-round-orange">
+        <img src="/images/prom-gallery/logo-orange-round.svg"
+          width="154"
+          height="187"
+          alt="Download Owa Logo / Orange on round black background" /></a>
+      <figcaption>Orange/ dark round<span>(SVG, 6Ko)</figcaption>
+    </figure>
+  </li>
+</ul>
+
+<h2>Stickers</h2>
+
+<ul class="thumbs">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-01.svg" download="owa-applebrowserban">
+        <img src="/images/prom-gallery/sticker-applebrowserban-01.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 12Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-01w.svg" download="owa-applebrowserban-white">
+        <img src="/images/prom-gallery/sticker-applebrowserban-01w.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / White" /></a>
+      <figcaption>#AppleBrowserBan Orange/ white <span>(SVG, 14Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-02.svg" download="owa-applebrowserban-02">
+        <img src="/images/prom-gallery/sticker-applebrowserban-02.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Round Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 22Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-03.svg" download="owa-applebrowserban-03">
+        <img src="/images/prom-gallery/sticker-applebrowserban-03.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Orange" /></a>
+      <figcaption>#AppleBrowserBan White/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-04.svg" download="owa-applebrowserban-04">
+        <img src="/images/prom-gallery/sticker-applebrowserban-04.svg"
+          width="154"
+          height="187"
+          alt="Download #AppleBrowserBan sticker / Black on Orange" /></a>
+      <figcaption>#AppleBrowserBan Black/ orange <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+</ul>
+
+<h2>For Your Goodies</h2>
+
+<ul class="thumbs goodies">
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-owa-full.svg" download="t-owa-full">
+        <img src="/images/prom-gallery/tshirt-v2.jpg"
+          alt="Download Full Owa Logo for t-shirts" /></a>
+      <figcaption>Open Web Advocacy<span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-unlock-the-web.svg" download="tshirt-unlock-web">
+        <img src="/images/prom-gallery/tshirt-unlock-web.jpg"
+          alt="Download Unlock the Web t-shirt image" /></a>
+      <figcaption>OWA/ Unlock the Web<span>(SVG, 19Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/t-applebrowserban.svg" download="owa-abb">
+        <img src="/images/prom-gallery/tshirt-v3.jpg"
+          alt="Download #AppleBrowserBan t-shirt image" /></a>
+      <figcaption>#AppleBrowserBan <span>(SVG, 13Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/loving-openweb.svg" download="loving-openweb">
+        <img src="/images/prom-gallery/tshirt-v5.jpg"
+          alt="Download Loving the Open Web t-shirt image/ White" /></a>
+      <figcaption>Loving the Open Web since 1990 <span>(SVG, 24Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/loving-openweb-02.svg" download="loving-openweb-2">
+        <img src="/images/prom-gallery/tshirt-v6.jpg"
+          alt="Download Loving the Open Web t-shirt image/ Black" /></a>
+      <figcaption>Loving the Open Web since 1990 (alternative) <span>(SVG, 21Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/webapps.svg" download="owa-webapps">
+        <img src="/images/prom-gallery/tshirt-v4.jpg"
+          alt="Download Web Apps are Apps t-shirt image" /></a>
+      <figcaption>Web Apps Are Apps <span>(SVG, 7Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/mug-unlock-the-web.svg" download="mug-unlock-web">
+        <img src="/images/prom-gallery/mug-unlock-web.jpg"
+          alt="Download Unlock the Web mug image" /></a>
+      <figcaption>OWA/ Unlock the Web <span>(SVG, 20Ko)</span></figcaption>
+    </figure>
+  </li>
+  <li>
+    <figure>
+      <a href="/images/prom-gallery/sticker-applebrowserban-05.svg" download="owa-applebrowserban-03">
+        <img src="/images/prom-gallery/mug-v0.jpg"
+          alt="Download #AppleBrowserBan mug image" /></a>
+      <figcaption>#AppleBrowserBan Mug <span>(SVG, 7Ko)</span></figcaption>
+    </figure>
+  </li>
+</ul>
+
+<div class="license">
+  <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/">
+    Open Web Advocacy logo is licensed under
+     <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/?ref=chooser-v1"
+       target="_blank" rel="license noopener noreferrer">
+       CC BY-NC-ND 4.0
+       <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1" alt=""><img src="https://mirrors.creativecommons.org/presskit/icons/nd.svg?ref=chooser-v1" alt=""></a>
+  </p>
+  <p xmlns:cc="http://creativecommons.org/ns#" >
+    Open Web Advocacy Promotional Resources</a> [except OWA logo] by
+      <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://gericci.me/">
+        A P Ricci</a> are licensed under
+    <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-NC-SA 4.0
+      <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a>
+  </p>
+</div>

--- a/src/ja/pages/policy.md
+++ b/src/ja/pages/policy.md
@@ -1,0 +1,8 @@
+---
+title: Policy
+permalink: /ja/policy/
+metaDesc: Learn more about the policy stances held by Open Web Advocacy.
+layout: layouts/page.njk
+translated: false
+---
+

--- a/src/ja/pages/press.html
+++ b/src/ja/pages/press.html
@@ -1,0 +1,56 @@
+---
+title: Press Coverage
+permalink: /ja/press/
+metaDesc: The Open Web Advocacy on the Press
+layout: layouts/page.njk
+translated: false
+---
+
+{% macro pressEntry(entry) %}
+<li lang="{{ entry.lang | default('en') }}">
+  <div class="press-entry">
+    <a href="{{ entry.url }}">{{ entry.title }}</a>
+    <div class="press-details">
+      {% if entry.publisher %}
+      published by "{{ entry.publisher }}"
+      {% else %}
+      published on {{ entry.url | hostnameFilter }}
+      {% endif %}
+      {% if entry.date %}
+      - <time datetime="{{ entry.date | w3DateFilter }}" class="dt-published">{{ entry.date | dateFilter }}</time>
+      {% endif %}
+    </div>
+  </div>
+</li>
+{% endmacro %}
+
+
+{% if collections.press | length > 0 %}
+<h2>OWA Press mentions</h2>
+{% for yearlyData in collections.press %}
+{% if collections.press | length > 1 %}
+<h3 id="owa_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
+<ul class="press-list">
+  {% for entry in yearlyData.entries %}
+  {{ pressEntry(entry) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endif %}
+
+{% if collections.links | length > 0 %}
+<h2>Related links</h2>
+{% for yearlyData in collections.links %}
+{% if collections.links | length > 1 %}
+<h3 id="related_{{ yearlyData.year }}">{{ yearlyData.year }}</h3>
+{% endif %}
+<ul class="press-list">
+  {% for entry in yearlyData.entries %}
+  {{ pressEntry(entry) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endif %}
+
+<p><strong>Last updated:</strong> <time datetime="2024-02-19">Feb 19th, 2024</time></p>

--- a/src/ja/pages/privacy.md
+++ b/src/ja/pages/privacy.md
@@ -1,0 +1,64 @@
+---
+title: Privacy Policy
+permalink: /ja/privacy/
+metaDesc: Learn about your privacy when using the Open Web Advocacy website.
+layout: layouts/page.njk
+translated: false
+---
+
+This website is provided by the members of the Open Web Advocacy group.
+
+## What data we collect
+
+The personal data we collect from you includes:
+
+- Questions, queries or feedback you leave, including your name & email address if you contact us via email.
+
+We use Netlify as our hosting provider for this website. Details regarding the information they collect can be found on their [data protection commitment page](https://www.netlify.com/gdpr-ccpa).
+
+## Why we need your data
+
+We collect your personal data in order to:
+
+- Gather feedback to improve our services.
+- Respond to any feedback you send us, if you’ve asked us to.
+
+## What we do with your data
+
+We will share your data if we are required to do so by law - for example, by court order, or to prevent fraud or other crime.
+
+We will not:
+
+- Sell or rent your data to third parties.
+- Share your data with third parties for their marketing purposes.
+
+## Linked content & services
+
+If you follow a link to a service or website, that is not directly part of this https://open-web-advocacy.org website, you will be subject to the privacy terms of that service
+or website instead of the terms laid out here.
+
+### Commonly linked services
+
+Below is a non-exhaustive list of services we knowingly link to within our site, along with that service's privacy terms:
+
+- Discord - [Privacy Policy](https://discord.com/privacy)
+- Twitter - [Privacy Policy](https://twitter.com/en/privacy)
+
+## Children’s privacy protection
+
+Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain data about anyone under the age of 13.
+
+## Contact us or make a complaint
+
+Contact us via [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org) if you:
+
+- Have a question about anything in this privacy notice.
+- Think that your personal data has been misused or mishandled.
+
+If you have any concerns about our use of your personal information, you can make a complaint to us at the above email address or contact the local privacy authority for your region.
+
+## Changes to this policy
+
+We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.
+
+Last updated 31 March 2022

--- a/src/ja/pages/walled-gardens.md
+++ b/src/ja/pages/walled-gardens.md
@@ -1,0 +1,2810 @@
+---
+title: Bringing Competition to Walled Gardens
+permalink: /ja/walled-gardens-report/
+layout: layouts/paper.njk
+metaDesc: >-
+  The full Bringing Competition to Walled Gardens report, published by Open Web
+  Advocacy.
+subtitle: Third-Party Browsers & Web Apps - VERSION 1.2
+paperName: OWA - Bringing Competition to Walled Gardens - v1.2
+paperSize: 7.7MB
+translated: false
+---
+
+## 2. Preface
+
+*To the Safari/Webkit Team*,
+
+To anyone who works on Safari/Webkit who reads this document, the authors would like to note that all criticism of Safari/Webkit is aimed squarely at Apple and Apple's upper management.
+We would like to acknowledge your many groundbreaking contributions to the Web over the past two decades.
+
+As people that have dedicated their lives to building browsers we know you care deeply about the open web and may privately disagree with Apple's anti-competitive practices. We also understand that Safari/Webkit’s funding and which features are approved is entirely controlled from above. We understand that building a browser is an enormous, complex undertaking and that it’s not possible to keep up with a modern feature set while making the platform stable without significant investment, despite the hard-work and dedication of each individual.
+
+We also understand that Apple operates under a paranoid air of strict secrecy which can make it difficult for you to engage properly with the development community and that employees can be fired for even mild criticism of the company making it hard for effective change from within. We hope that this document can help start that change.
+
+Our main aim is to ensure open competition so that the Web and Web Apps can compete against the closed proprietary ecosystems. The future of the web is apps, if native can do it, so can the web except with privacy and security built in by design. It is our strong hope that Webkit will meaningfully participate in this future.
+
+Many of us have developed with Safari and Webkit since it first came out and were inspired to build mobile web apps by Steve Job’s 2007 speech with the platform that your team built. The web we use today is built on your legacy.
+It is our hope that with this competition Apple will come to realize the great importance of Safari and Webkit to their overall business goals and will provide the resources and funding to make it the best, most private, stable and feature rich browser available.
+
+**Thank-you for your hard work and for everything you’ve given us**, we hope you will continue to fight for a better open-web.
+
+
+
+## 3. Introduction
+
+The entire future of the **consumer application industry** is being heavily limited by Apple’s ban of third-party browsers. These actions prevent cross-compatibility between devices, and create significant barriers for new market entrants. For businesses and consumers, it greatly increases costs and enables Apple to lock them into their closed ecosystem. This reduces competition for both browsers and applications, and shifts the cycle of investment and funding from an open and free platform to proprietary closed platforms, driving up prices for consumers and developers.
+
+**Apple has banned** competing **Third-Party Browsers** from their iOS devices (iPhone and iPad) by requiring that all browser vendors use Safari’s WebView ([2.5.6 App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.)). Browser vendors are not allowed to ship their browsers which they have spent hundreds of thousands of hours developing and instead are forced to produce a separate browser which is essentially a thin wrapper or skin around the WebKit engine in Apple’s own browser, Safari.
+
+Critically this browser ban prevents the *emergence* of an *open and free universal platform* for apps, where developers can build their application once and have it work across all consumer devices, be it desktop, laptop, tablet or phone. Instead it forces companies to create multiple separate applications to run on each platform, significantly raising the cost and complexity of development and maintenance. These costs are in addition to the 15% - 30% tax charged by the App Store. This greater cost is ultimately passed on to consumers in the form of higher fees, more bug prone applications and the applications not being available on all platforms. This then decreases competition with other manufacturers by depriving them of a healthy library of apps. The costs of developing an interoperable application that works identically are pushed so high that only well funded companies can afford it and as a result many useful or otherwise profitable applications never get built.
+
+Apple is preventing the interoperable, standards-based web from becoming a viable alternative to the native proprietary ecosystems on offer from Apple and Google. In the absence of competition, the poor state of Apple’s own browser and integration of Web Apps has the effect of pushing developers and users towards the gated ecosystem of the App Store. Safari and Apple’s WebView frequently suffer simultaneous, critical application breaking bugs which spill into competing iOS browsers because they cannot bring their own engines which might not contain these bugs.
+
+In a clear conflict of interest with third-party browsers, **[Apple receives 15b USD per year for search engine placement](https://9to5mac.com/2021/08/25/analysts-google-to-pay-apple-15-billion-to-remain-default-safari-search-engine-in-2021/)** in Safari while ensuring other browsers can not effectively compete on iOS, its most popular operating system. Mozilla, a non-profit, produces a browser that consistently bests Apple’s in security and standards conformance with revenues of [less than $500 million per year](https://assets.mozilla.net/annualreport/2019/mozilla-fdn-2019-short-form-0926.pdf).
+
+A lack of market pressure, combined with [alleged systemic underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/#:~:text=We%20asked%20Apple%20about%20the%20IndexedDB%20bug%20and%20whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition.%20We%20would%20be%20stunned%20if%20it%20chose%20to%20reply.) over many years, prevents the web from becoming a viable application platform. The only way for developers to create stable, capable applications is to invest in Apple’s proprietary platform, which it taxes and retains exclusive control over.
+
+Individual companies benefit greatly from locking users in and their competitors out. Apple hides behind claims of extra security and privacy when, in fact, their restrictions deprive the consumer of choice and locks their data and purchases into Apple’s walled garden. This prevents or adds great friction to users moving to competing platforms by hampering interoperability.
+
+Web Apps add an extra layer of security and privacy controls to native application platforms, improving on the operating system’s built-in controls leading to enhanced user safety. If allowed, Web Apps can offer equivalent functionality with greater privacy and security for demanding use-cases that are traditionally the domain of less secure native apps. A free & universal development and distribution platform is what leads to competition and an investment cycle in free and open software that benefits businesses and consumers.
+
+**Two key remedies** from regulation can serve to restore meaningful competition:
+
+1. **Reversing Apple’s ban** on competing browsers and browser engines
+2. Compelling **full integration and functionality** for apps built with open web technology, including on competing browsers
+
+The future of consumer application development depends on these changes.
+
+
+
+### 3.1 This Document
+
+This document outlines the primary issues related to Browsers and Web Apps and the future of consumer application development.
+
+
+
+### 3.2 Open Web Advocacy
+
+Open Web Advocacy is a loose group of software engineers from all over the world, who work for many different companies who have come together to fight for the future of the open web by providing regulators, legislators and policy makers the intricate technical details that they need to understand the major anti-competitive issues in our industry and potential ways to solve them.
+
+It should be noted that all the authors and reviewers of this document are software engineers and not economists, lawyers or regulatory experts. The aim is to explain the current situation, outline the specific problems, how this affects consumers and suggest potential regulatory remedies.
+
+This is a grassroots effort by software engineers as individuals and not on behalf of their employers or any of the browser vendors. We came together with the hope of creating a better world since no major company has been pushing for this change in recent years. The majority of the engineers behind this document have decided to remain anonymous as no individual feels comfortable going up against the world’s most valuable company, particularly one that is so litigious.
+
+We are available to regulators, legislators and policy makers for presentations / Q&A and we can provide expert technical analysis on topics in this area.
+
+For those who would like to help or join us in fighting for a free and open future for the web, please contact us at:
+
+<dl>
+  <dt>Email</dt>
+  <dd><a href="mailto:contactus@open-web-advocacy.org">contactus@open-web-advocacy.org</a></dd>
+  <dt>Twitter</dt>
+  <dd><a href="https://twitter.com/OpenWebAdvocacy">@OpenWebAdvocacy</a></dd>
+  <dt>Web</dt>
+  <dd><a href="https://open-web-advocacy.org">https://open-web-advocacy.org</a></dd>
+</dl>
+
+
+
+### 3.3 Definitions
+
+**"Third-Party Browser"** - A web browser developed by a company other than the gatekeeper which includes a layout engine and rendering engine either selected or built by the company.
+
+**"Native App"** - An app written using a gatekeeper’s proprietary frameworks and APIs which are provided by the operating system. On iOS (Apple’s operating system for iPhone and iPad) these are currently exclusively delivered through Apple’s App Store.
+
+**"Web App"** - A Web Application, Web App or Progressive Web App (PWA) is an application developed using Web technologies, such as HTML, CSS, JavaScript and WebAssembly. Web Apps use Web Browsers as the "engine" to run the Web App. The capabilities of a Web Apps depends on the level of advancement of the Web Browser that they run on. **WebAssembly** allows developers to bring existing software, for example game engines or photoshop, and port/convert them so they run on the web or as a web-app.
+
+Web Apps can be made to run offline, can run as smoothly as native apps and can support high performance applications, but this functionality depends on the Web Browser. Web Apps offer more privacy and security than native apps. Web Apps are universal, in that they can be written once and then run on all devices. This is in comparison with native apps that have to be rewritten for each platform that they target.
+
+To the end user a well written Web App should be indistinguishable from a native app.
+
+**"WebView Browser"** - A web browser that does not include its own engine, and instead uses an engine or an unmodified "WebView" provided by the OS. For example all browsers on iOS other than Safari on iOS are WebView browsers, in that they do not render the website or run the code for the site and instead hand that job onto Safari WebView.
+
+**"PWA (Progressive Web App)"** - Can be used interchangeably with Web App, although PWA is used to describe modern Web Apps with functionality that is typically associated with native apps rather than websites (i.e. installation on device, Offline Storage, Device API access etc). For the purposes of this document Web App and PWA will be treated identically.
+
+**"Gatekeeper"** - The company that controls the operating system and the apps that run on that operating system (i.e. Apple with iOS, Google with Android).
+
+**"Browser Vendor"** - The entity that makes the browser.
+
+
+
+## 4. Effective Competition?
+
+> Businesses that face effective competition dare not raise prices, or cut down on quality standards, for fear of losing customers to their competitors (and so losing money)
+> <cite>[Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)</cite>
+
+> For the foreseeable future, iOS will be the dominant access pathway, passport, monetizer and platform for not just digital life, but virtual ones. Apple holds this role because it makes best-in-class hardware, offers the best apps, and operates the most lucrative app store.
+> <cite>[Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)</cite>
+
+iOS Safari faces no effective competition as Apple has banned the engines that differentiate other browsers. Customers have little recourse short of buying another phone.
+
+The development, maintenance and lost opportunity costs of supporting a buggy browser that misses key features are mostly hidden from them. It is hard for consumers to see a missing feature or an entire Web App that didn’t get built (due to poor support in iOS Safari). When they do encounter a bug caused by Safari they are more likely to blame the Web App than the browser. The user may get the impression that the web is buggy, slow and that native apps are better, which then has negative flow on effects for the entire web ecosystem.
+
+Businesses have little recourse as they can not suggest their customers install another real browser (there are none) and they are unwilling to lose more than half their mobile customers (51% in the UK, 66% in Japan, 56% in Australia, 46% in the US). Additionally iOS users tend to be wealthier and [spend more](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/) making them a higher priority for companies. In the end the majority of large businesses simply throw in the towel and make an iOS Native App and in doing so agree to pay Apple 15-30% of their revenue.
+
+As such, Apple faces little effective competitive pressure to improve the quality of their iOS Safari browser and has incentives to inhibit it from competing with native. Thus Apple’s decade long prohibition on competition for Safari on iOS has a compounding anti-competitive effect as companies sink money into non-interoperable native iOS applications instead of Web Apps.
+
+Even Apple executives appear to be aware only their stranglehold on iOS installation is allowing their 30% tax on revenue, something they can not achieve on macOS.
+
+> Neither is on the store because they don't have to be. They can be on Mac and distribute to users without sharing the revenue with us
+> <cite>[Philip Schiller - Apple Upper Management - On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)</cite>
+
+
+
+## 5. Apple is Holding Back the Open Web
+
+> Instead, Apple is inhibiting this future Internet. And it does so via tolls, controls, and technologies that not only deny what made and still makes the open web so powerful, but also prevents competition, and prioritize Apple’s own profits.
+> <cite>[Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)</cite>
+
+> Making the web less useful makes apps more useful, from which Apple can take its share; similarly, it is notable that Apple is expanding its own app install product even as it is kneecapping the industry’s.
+> <cite>[Ben Thompson - Stratechery](https://stratechery.com/2020/apple-and-facebook/)</cite>
+
+
+
+### 5.1. Steve Jobs' Original Vision for iOS
+
+Steve Jobs’ original vision for third-party apps on iOS was quite different from today’s status quo.
+
+The following is a transcript of a speech he gave announcing Web Apps as the platform for third-party iOS developers, including his thoughts on security, deployment, and criticisms of other distribution models (emphasis added):
+
+> Now, what about developers?
+>
+> We have been trying to come up with a solution to expand the capabilities of iPhone by allowing developers to write great apps for it, and yet keep the iPhone reliable and secure. And we’ve come up with a very **sweet solution**.
+>
+> Let me tell you about it.
+>
+> So, we’ve got an innovative new way to create applications for mobile devices, really innovative, and it’s all based on the fact that iPhone has the full Safari inside. The full Safari engine is inside of iPhone and it gives us **tremendous capability**, more than there’s ever been in a mobile device to this date, and so you can write **amazing Web** 2.0 and Ajax apps that **look exactly and behave exactly like apps on the iPhone**!
+>
+> And these apps can **integrate perfectly** with iPhone services: they can make a call, they can send an email, they can look up a location on Google Maps. After you write them, you have **instant distribution**.
+>
+> You **don’t have to worry about distribution**: just put them on your internet server. And they’re really easy to update: just change the code on your own server, **rather than having to go through this really complex update process**.
+>
+> They’re secured with the same kind of security you’d use for transactions with Amazon, or a bank, and they run securely on the iPhone so they don’t compromise its reliability or security.
+>
+> And guess what: **there’s no SDK**! You’ve got everything you need, if you know how to write apps **using the most modern web standards**, to write amazing apps for the iPhone today.
+>
+> You can go live on June 29.
+>
+> <cite>[Steve Jobs - Original Announcement of Third-Party Apps (2007)](https://www.youtube.com/watch?v=p1nwLilQy64)</cite>
+
+**Apple invented mobile Web Apps**, but ultimately decided on a proprietary closed ecosystem.
+
+
+
+### 5.2 Apple Claims that Web Apps are a Viable Alternative to the App Store
+
+[Web Apps are applications](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) installed from the browser that utilize the user's browser to give users an experience on par with Native apps. They are interoperable between operating systems, have a [very tight security/privacy model](very tight security/privacy model) and are capable of amazing things.
+
+Apple’s original vision for applications on iOS was Web Apps, and [today they still claim](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf) Web Apps are a viable alternative to the App Store. Apple CEO Tim Cook made a similar claim last year in Congressional testimony when [he suggested](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) the web offers a viable alternative distribution channel to the iOS App Store. They have also [claimed](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple) this during a court case in Australia with Epic.
+
+Despite this Web Apps are not currently a viable competitor to the iOS App Store for three reasons:
+
+1. **Browser Ban** <br />
+Apple’s Safari is the only browser on iOS as all other browsers have been effectively banned
+2. **Missing Features** <br />
+Apple has refused to implement key features (some for more than 10 years) that would allow Web Apps to compete with the App Store, both in iOS and in Safari.
+3. **Bugs** <br />
+Apple's iOS Safari is significantly more buggy and unstable than its rivals making it unviable as a platform for applications.
+
+
+
+### 5.3 Apple has effectively banned all Third-Party browsers
+
+The Apple App Store Review Guidelines contain the [following rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+Webkit is the engine that powers Safari and several Linux browsers. Apple also produces a "WebKit framework" that is included in its operating systems (macOS, iOS, iPadOS, tvOS, and watchOS).
+
+In practice, Section 2.5.6 is a requirement that iOS and iPadOS browsers from Google, Microsoft, Mozilla, Samsung, Opera cannot use their own engines the way they do everywhere else. These engines take hundreds of thousands of engineer hours to develop, and are excluded from Apple’s most successful consumer operating systems. Competing browser vendors are only allowed to produce shells around a very specific, unaltered version of Safari’s WebView; a component whose features Apple dictates.
+
+All rival iOS browsers in the App Store are essentially Safari under the hood. This Browser Ban is unique to Apple’s iOS.
+
+> **Apple has a browser monopoly on iOS**, which is something Microsoft was never able to achieve with IE
+> <cite>[Scott Gilbertson - The Register](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/?td=keepreading-top)</cite>
+
+> All of this is compounded by yet another Apple policy: no third-party browser engines. You can install apps like Chrome, Firefox, Brave, DuckDuckGo, and others on the iPhone — but fundamentally they’re all just skins on top of Apple’s WebKit engine. That means that **Apple’s decisions on what web features to support on Safari are final**. If Apple were to find a way to be comfortable letting competing web browsers run their own browser engines, a lot of this tension would dissipate.
+> <cite>[Dieter Bohn and Tom Warren - The Verge](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)</cite>
+
+> So it’s not just one browser that falls behind. It’s all browsers on iOS. The whole web on iOS falls behind. And iOS has become so important that **the entire web platform is being held back as a result**.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/chrome-is-the-new-safari-and-so-are-edge-and-firefox/)</cite>
+
+> because **WebKit has literally zero competition on iOS**, because Apple doesn’t allow competition, the incentive to make Safari better is much lighter than it could (should) be.
+> <cite>[Chris Coyier - CSS Tricks](https://css-tricks.com/ios-browser-choice)</cite>
+
+> What Gruber conveniently failed to mention is that Apple’s banning of third-party browser engines on **iOS is repressing innovation in web apps.**
+> <cite>[Richard MacManus - NewsStack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)</cite>
+
+No other major operating system imposes a ban on integrated third-party browsers (browsers that include their own engines). Microsoft Windows, Android, Linux, and Apple’s own macOS all enable choice of integrated browser. Even Google’s ChromeOS, named after its browser, is more open to competing engines than iOS.
+
+Despite this uniquely anti-competitive situation, Apple has managed to evade regulatory oversight. Browser choice is what drives the technology forward which ultimately results in better, faster, more reliable software for users.
+
+Microsoft’s IE6 was once the dominant browser with a 95% market share <sup>1</sup> due to its pre-installation on Windows. Without competition on the Windows platform, browser development remained stagnant for years until Firefox’s market share triggered Microsoft to start investing in browsers once again. At no point did Microsoft ban competing browsers as Apple has done.
+
+<sup>1</sup> ["Usage share of web browsers - Wikipedia."](https://en.wikipedia.org/wiki/Usage_share_of_web_browsers) Accessed 23 Jun. 2021.
+
+
+
+#### 5.3.1 Hobbled Competition even within Safari clones
+
+Apple's hobbling of third-party browsers doesn't stop at mandating a specific version of Webkit, Apple provides Safari significant unfair advantages.
+
+The major issues include:
+
+1. **Full Screen Video** <br />
+Safari is allowed to make video full screen, the other "browsers" are prevented from doing so, except on iPad. <br />
+It is hard to see the rationale for allowing it on iPad but disabling it on iPhone.
+
+2. **Full Screen Games** <br />
+Canvas, a software component, which is essential for Games can not be made full screen. **Apple derives most of their App Store revenue from games**.
+
+3. **No Web Apps** <br />
+The other "browsers" can not install Web Apps. Only Safari can.
+
+4. **Extensions** <br />
+Only Safari can use extensions which are used by many users, including to block advertising.
+
+5. **Apple Pay** <br />
+Apple limits the integration of Apple Pay with the other browsers.
+
+6. **In-App Browsers** <br />
+Regardless of the user’s default browser setting, iOS will always force the user to use Safari instead of the user’s choice of browser. An In-App Browser is a browser that you would see inside an application like twitter when you visit a link from inside the application.
+
+
+
+### 5.4 Safari Lags Behind and is Missing Key Features
+
+It’s well known in the web-development industry that Safari is far behind on critical web-features (emphasis added).
+
+> The reason we **lost Safari on Windows** is the same reason we are **losing Safari on Mac. We didn't innovate or enhance Safari**. If you want to compete on something across all platforms, it needs to be the best. We had an amazing start on Safari and then **stopped innovating**. Now, we are starting to work on Safari again but look at Chrome. They put out releases at least every month while we basically do it **once a year**
+> <cite>[Eddy Cue - Apple's Senior Vice President of Services](https://www.theverge.com/22611236/epic-v-apple-emails-project-liberty-app-store-schiller-sweeney-cook-jobs)</cite>
+
+> Apple's Safari **lags considerably** behind its peers in supporting web features
+> <cite>[Scott Gilbertson - The Register](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/?td=keepreading-top)</cite>
+
+> Apple’s web engine **consistently trails** others in both **compatibility** and **features**, resulting in a large and persistent gap with Apple’s native platform.
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/04/progress-delayed/#:~:text=The%20data%20agree%3A%20Apple%27s%20web%20engine%20consistently%20trails%20others%20in%20both%20compatibility%20and%20features%2C%20resulting%20in%20a%20large%20and%20persistent%20gap%20with%20Apple%27s%20native%20platform.)</cite>
+
+> Safari just doesn’t support key features — **and Safari’s the only option**
+> <cite>[Dieter Bohn and Tom Warren - The Verge](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)</cite>
+
+> It’s not just the lack of choice in browser engines on iOS, it’s that **WebKit itself is deficient as a browser engine**.
+> <cite>[Richard MacManus - The New Stack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)</cite>
+
+
+
+#### 5.4.1 Web Platform Tests
+
+The [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned) shows this numerically by showing **every failure** that **only fails in just one browser**.
+
+{% image
+  "/images/walled-gardens/00_web-platform-results.png",
+  "Web platform tests result line chart showing higher Safari failure"
+%}
+
+As can be seen as at 10/11/2021, for each of the experimental builds of these browsers:
+
+- **4180 Failures - Safari**{.stressed}
+- 1346 Failures - Firefox
+- 494 Failures - Chrome
+
+Safari is objectively lagging the competition, and this is likely because Apple has no browser competition on the operating system most important to their business, iOS.
+
+The [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned) is a comprehensive test suite built by the developers of browsers themselves, including Mozilla, Google, Apple, Opera, and others. Not every browser supports every feature, and tests may vary in quality, but this is the closest to **"ground truth"** regarding the fine-grained detail of interoperability for all browsers. The failures listed above are **only** features that fail in just one browser.
+
+
+
+#### 5.4.2 Progressive Web App Feature Detector
+
+The [Progressive Web App Feature Detector](https://tomayac.github.io/pwa-feature-detector/) is a high-level test that can provide directional understanding for developers attempting to assess the suitability of Web Apps for addressing their needs. It contains a short but important list of features that are used throughout native apps. Below is a comparison showing Chrome 95 running on a Samsung Galaxy S20 on the left, and Safari running on an iPhone X with iOS 15.1 on the right.
+
+<div class="gallery screens">
+  <figure>
+    {% image
+      "/images/walled-gardens/01_pwa-features-chrome.jpg",
+      "Chrome (Android) progressive web app feature detector results showing 18/18 feature support",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>Chrome (Android)</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/02_pwa-features-safari.png",
+      "Safari (iOS) progressive web app feature detector results showing 6/18 feature support",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>Safari (iOS)</figcaption>
+  </figure>
+</div>
+
+
+
+#### 5.4.3 Missing Functionality
+
+Safari – or more specifically the WebKit engine that powers it – is well behind the competition.
+
+OWA identified the most important functionality specifically for Web Apps that are available on native or other browsers but missing in Safari.
+
+{% image
+  "/images/walled-gardens/40_missing-functionality.png",
+  "An overview of functionality available to both native and the web - except in Safari"
+%}
+
+This table exposes many anti-competitive issues, namely:
+
+1. Competing Browser’s on iOS are unable to implement functionality that they can on Android
+2. Apple has stagnated development and are many years behind the competition
+3. All of the functionality listed above is available for iOS Native Apps
+4. Google’s refusal to provide competitors a method of minting WebAPK’s prevents competing browsers from producing viable Web Apps.
+
+
+
+##### 5.4.3.1. Install Prompts (7+ Years Behind)
+
+The ability to install Web Apps with at least the same level as ease as a native app. See [5.4.5. iOS Web App Installation - A well hidden Safari exclusive](#ios-web-app-installation---a-well-hidden-safari-exclusive) for more details.
+
+This enables the developer to prompt to install a Web App when a user visits a website. For any implementation to be fair, it needs to match any requirements for native install prompts.
+
+Success Criteria Include:
+
+1. The prompt needs to appear **on the first** load of the website OR by developer request. Since Apple acts as a gatekeeper they should not provide any preference to installing their own apps.
+2. The language used by the Install Prompts should not convey the idea that Web Apps are inferior to Native apps. I.e. they should use the same language as native apps. "Install" instead of "Add to Homescreen"
+3. The UI should be at a minimum equal in encouraging a user to install an app as the UIs provided on websites for installing native apps.
+
+
+
+##### 5.4.3.2. Notifications (7+ Years behind other browsers, 13+ years behind native)
+
+Notifications are essential for a wide range of applications. Without notifications many apps can not function (i.e. Messaging Apps, Social Media apps etc). In general notification functionality should be equivalent to native.
+
+Success criteria for notifications include:
+
+1. The initial Enabling/Disable notifications prompt for an installed Web App should be equivalent to enabling notifications for a native app in terms of user experience and ease-of-use.
+
+2. Delivery of notifications is equivalent to native applications including as it applies to reliability, speed (i.e. the time it takes the notification to reach the device) and whether or not the notification wakes the device when it is in "sleep mode".
+
+3. Users should be able to enable / disable notifications in system settings in the same manner and ease that they enable / disable native apps.
+
+
+
+##### 5.4.3.3. First Class Web Apps (5+ Years behind)
+
+"First Class Web Apps" is a general term that is used to describe a Web App that has equivalent integration into the operating system as a native app.
+
+This includes:
+
+1. Settings
+2. Quick Launch Menus
+3. Integration with Voice Assistants
+4. Storage
+
+Without full integration, this becomes a **significant barrier** to adoption. Businesses (especially large ones) will not take the risk of building Web Apps if they have any significant issues). The overarching principle to ensure Web Apps are able to compete is equality with native apps. That is, installing and managing a Web App should not be worse than installing and managing a native app.
+
+There should be no suggestion to the user that a Web App is inferior or different from a native app.
+
+**Double Prompts and the Permission Problem**
+
+Currently on iOS Web Apps are not considered as "real" apps by the operating system. They don’t show up on the settings menu, they don’t show up on App shortcuts, and they don’t appear on any of the privacy menus.
+
+With the current architecture, for a Web-App to have permission to perform an action, Safari must have that permission. This is unobvious to all but experts. Therefore our recommendation is that permissions should be attached to the Web App itself and not to the browser.
+
+For Example:
+
+| Safari | Web App | Actual |
+| ------ | ------ | ------ |
+| Permission OFF | Permission ON | Permission ON |
+| Permission ON | Permission ON | Permission ON |
+| Permission OFF | Permission OFF | Permission OFF |
+
+i.e. If Safari has notifications OFF and AmazingWebApp has notification ON, AmazingWebApp can still send notifications.
+
+As the functionality of Web Apps in Safari improves, it will become critically important to enable users to have explicit control over what those Apps can and can’t do in a way **that a normal user can understand**.
+
+User’s need to be able to **easily grant and revoke permissions from web apps**. This is essential for the success of Web Apps. As an example if users can not easily and individually disable and enable notifications per app, then user’s might be more inclined to preemptively block them thus providing a significant advantage to native ecosystems.
+
+We recommend that all Web Apps should appear on the settings page and privacy pages identically to Native Apps.
+
+This should include:
+
+1. Settings (Appearing on the settings page and in search)
+2. Privacy (Location Services / Bluetooth / Camera / Microphone etc)
+3. General > iPhone Storage
+4. General > Background App Refresh
+5. Siri Suggestions (With no order preference to native apps)
+6. Singleton Installations (i.e. the ability to only install a Web App once) is likely to be a prerequisite.
+
+
+
+##### 5.4.3.4. App Store Support (3+ Years behind)
+
+Many companies will still want to list their Web Apps in the Apple AppStore. Android already provides this functionality with [Trusted Web Activities](https://developer.chrome.com/docs/android/trusted-web-activity/).
+
+Apple should provide a method where developers who have signed up to the Apple Developer Program can use an API to submit Web Apps to the Apple AppStore.
+
+This should not require users to purchase an Apple Mac or require xcode (i.e. developers should be free to use Windows or Linux). It’s our belief that this will help drive Web App adoption.
+
+
+
+##### 5.4.3.5. Fullscreen API (11+ years behind)
+
+Specific types of apps such as games require fullscreen to work properly. Apple currently only allows fullscreen for video and not for "canvas" which is required for games and other graphics intensive apps.
+
+
+
+##### 5.4.3.6. Badging (5+ years behind)
+
+[Badging](https://web.dev/badging-api/) which is outlined in more detail in section [5.4.4. Short Example](#short-example) allows the app to show a number to indicate the user that something has happened.
+
+Users need the ability to disable badging and this should be managed in the same way badging is managed for native apps.
+
+Success criteria include:
+
+1. Badges update at the same speed as native apps (including in the background)
+2. Badges can be enabled/disabled in the same manner as native apps.
+
+
+
+##### 5.4.3.7. Deep Links (7+ years behind)
+
+Deep links also known as [URL Protocol Handlers](https://web.dev/url-protocol-handler/) provide the ability to link into a Web App from another Web App or Native App via links.
+
+Note that the equivalent has been available for a [very long time](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content) in native apps.
+
+
+
+##### 5.4.3.8. Screen Orientation Lock (10+ Years Behind)
+
+Screen Orientation Lock allows a user to lock the screen to either horizontal or vertical. This is essential to many types of apps, but especially games.
+
+
+
+##### 5.4.3.9. Bluetooth (5+ Years Behind)
+
+Bluetooth allows apps to connect to printers / scanners / internet of things / toys. There are entire categories of apps that can’t be built without Web Bluetooth.
+
+Discussed at length in [5.5.1. Fingerprinting and Web Device APIs](#fingerprinting-and-web-device-apis)
+
+
+
+##### 5.4.3.10. NFC (1+ Year Behind)
+
+Apple has mentioned in regulatory filings issues with NFC and what is called Card Emulation Mode, but they have also refused to implement the entire Web NFC specification in Safari even though it doesn’t include Card Emulation Mode. Since they have effectively banned all other third-party browsers no other browser can provide NFC functionality.
+
+So far Apple has not provided any detailed reasoning as to why they are blocking this functionality besides the following:
+
+> I'm not sure what specifics you're looking for but the issue is that we don't believe permission prompt is sufficient mitigation. Ordinary people don't understand the full security & privacy implications of granting NFC access when asked.
+> <cite>[Ryosuke Niwa - Apple](https://lists.webkit.org/pipermail/webkit-dev/2020-January/031034.html)</cite>
+
+The Web NFC specification contains an [extensive security and privacy section](https://w3c.github.io/web-nfc/#security), but Apple has made little effort to productively convey or solve any perceived security issues. By only providing NFC functionality via [its native ecosystem](https://developer.apple.com/documentation/corenfc) Apple effectively forces any developer that wishes to produce a mobile app with NFC to create a Native App where they can take a 30% cut.
+
+As part of our submission we would argue that Apple should not be able to block NFC access to third-party browsers except where Apple applies on a **demonstrably** consistent basis to Apple's own Apps and Apps from the iOS App Store (**including by rules with analogous intent**).
+
+Additionally any blocks should be narrowly tailored to solve particular security issues and Apple should be compelled to publicly answer and publicly provide technical documentation to any reasonable questions related to these rules or the evidence for them.
+
+NFC has a huge range of current and future applications:
+
+* Cashless payments
+* Asset Tracking
+* Time / Attendance / Check-In
+    * Businesses
+    * Universities
+    * Schools
+* Opening Doors
+    * Hotels
+    * Houses
+    * Guest Access
+    * Corporate
+* Ticketing
+    * Major Events
+    * Cinemas, Sporting Events, Concerts
+* Transport (Public and Private)
+* Pharmaceuticals
+* Pairing Devices via Bluetooths
+* WIFI without passwords, Guest Wifi
+* Smart Posters
+* Smart Cards
+* Business Cards
+* Passports / IDs
+* Smart Home Integration
+* Anti-Counterfeiting of real products
+* App Shortcuts
+* Multi-Factor Authentication
+
+The door to innovation needs to be left open without Apple acting as the gatekeeper except to provide very **narrow scope, heavily justified** security, privacy or digital safety protections.
+
+Our current recommendation is that Apple be forced to provide hardware access to NFC to other third-party browsers for the purposes of implementing the NFC specification (which currently only covers [NDEF](https://w3c.github.io/web-nfc/#ndef-compatible-tag-types) which is already provided to iOS native apps) and should be forced to expand that access as the Web NFC specification expands to cover other parts of NFC. In the case where Apple believes a security risk is too great to users, Apple should prove the harm to users is greater than the loss of utility.
+
+
+
+##### 5.4.3.11. Other Important Functionality
+
+* General
+    * **Push Notifications**
+    * **SQL (WebSQL or equivalent replacement)**
+    * AV1/AVIF and VP8/VP9/WebP (open Media Codecs)
+    * Compression Streams
+    * **Keyboard Lock and Keyboard Layout APIs**
+    * Declarative Shadow DOM
+    * Reporting API
+    * Permissions API
+    * Screen Wakelock
+    * Intersection Observer V2
+    * Shared Workers and Broadcast Channels
+    * **Background Sync**
+    * Background Fetch API
+* Essential Media APIs
+    * Background Audio in Third-Party Browsers and Web Apps. See [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=198277), fix took 3 years.
+    * Features and functionality in [PushKit](https://developer.apple.com/documentation/pushkit)
+    * Features and functionality in [CallKit](https://developer.apple.com/documentation/callkit)
+* Essential Web App APIs
+    * **Web App Install Prompts**
+    * PWA App Shortcuts
+    * getInstalledRelatedApps()
+    * Periodic Background Sync
+    * **Web Share Target**
+    * Content Indexing
+    * **Badging**
+* Device APIs
+    * **Web Bluetooth**
+    * **Web NFC**
+    * Web USB
+    * Web MIDI
+    * Web Serial
+    * Web HID
+    * Shape Detection
+    * Generic Sensors API
+* Gaming and 3D-related APIs
+    * **Fullscreen API** for `<canvas>` and other non-`<video>` elements
+    * **WASM Threads**
+    * Shared Array Buffers
+    * SIMD
+    * WebXR
+    * Offscreen Canvas
+
+The article [Progress Delayed is Progress Denied](https://infrequently.org/2021/04/progress-delayed/) is a detailed look at how far Safari has fallen behind in features.
+
+Not every developer needs every feature listed above but some are the critical missing piece required to build a Web App instead of a Native App. For competition between Web Apps and Native Apps it’s important to compare the functionality of Web Apps with Native Apps and not simply between browsers
+
+
+
+#### 5.4.4. Short Example
+
+To expand on each of these to explain why these missing features are important to developers would be a lengthy undertaking so instead we will highlight just a few and explain why they are essential to allow Web Apps to compete with the App Store. Please note that most of these capabilities or something analogous are possible in Native Applications.
+
+Imagine you were building a social networking App and decided to build it as a Web App instead of as a Native App.
+
+The two key pieces of functionality you would need to compete with the App Store would be being able to notify a user when they have received a new message (**Push Notifications**) and being able to add unread message count badges to the App Icon (**App Badging**). Both of these features are missing on iOS for Web Apps despite coming out for Native Apps more than 10 years ago. Multiple browsers support these features across many operating systems, both desktop and mobile whereas iOS Safari does not.
+
+[Twitter](https://twitter.com/) has built a high-quality Web App for Twitter that you can install on iOS but they still recommend you use the iOS Twitter App, likely due to these critical missing features.
+
+An App Badge showing a count of 29 on iOS in 2011:
+
+{% image
+  "/images/walled-gardens/03_ios-app-badge.png",
+  "iOS app badge example screenshot",
+  "screenshot rounded", null, null,
+  "121px"
+%}
+
+Because of these missing features entire categories of apps can either not be built using the web or which ensure that the native app is significantly better.
+
+
+
+#### 5.4.5. iOS Web App Installation - A well hidden Safari exclusive
+
+Apple heavily preferences Native Apps while placing **strong limitations** on Web Apps.
+
+On Android devices, Web Apps are easy to find and install. Firefox / Chrome & Edge all provide functionality that allow developers to make installing Web Apps on Android simple, intuitive and easy.
+
+By comparison it can be very difficult to explain to a user how to install a web-app on iOS through Safari, as it is **hidden away** and requires multiple steps to find. It could be argued that Apple benefits from this as it will drive companies to use native apps. Apple makes it easy to install native apps with [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) while making it very difficult to install Web Apps.
+
+For the other reskinned/rebranded Safari WebView browsers (Chrome/Edge/Firefox) Apple has **blocked them from installing Web Apps**. This functionality is exclusive to Safari.
+
+
+
+##### 5.4.5.1. Android
+
+On Android devices, the process for installing a Web App on either Firefox or Chrome is very straightforward and there are many options as shown by the following examples taken from [web.dev](https://web.dev/promote-install/).
+
+Developers have a huge freedom of choice and can add installers in headers, footers, menu bars, and temporary pop-ups backed [by an open API](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent). This ensures that there is minimal difficulty installing a Web App on Android.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/04_install-banner-top.png",
+    "Mockup view of web app install banner at top of window",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/05_install-banner-bottom.png",
+    "Mockup view of web app install banner across webpage",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/06_install-banner-sidebar.png",
+    "Mockup view of web app install banner in sidebar",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/07_install-banner-inline.png",
+    "Mockup view of web app install banner within page content",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/08_install-via-menu.png",
+    "Mockup view of web app install banner in app menu",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/09_install-toast.png",
+    "Mockup view of web app install banner bottom popup toast",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+Finally there is a clearly marked "**Install App**" on the main menu. As demonstrated there is **no barrier** to installing Web Apps on Android systems and is made easy for developers to add and users to use.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/15_proxx-install-a.jpg",
+    "proxx.app web app install banner example",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/16_proxx-install-b.jpg",
+    "proxx.app web app install banner expanded",
+    "screenshot", null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+As a real life example, the game [PROXX](https://proxx.app) displays a pop-up bottom banner when you first play, sliding that up displays more information about the app. Tapping install can directly install the app although the exact experience differs between different manufacturers devices.
+
+
+
+##### 5.4.5.2. iOS Safari
+
+The process on iOS Safari is considerably more difficult and [quite a bit more hidden and awkward](https://brucelawson.co.uk/2021/briefing-to-the-uk-competition-and-markets-authority-on-apples-ios-browser-monopoly-and-progressive-web-apps/). The majority of users we have asked **do not know the functionality exists** and have never used it. Apple has [refused](https://bugs.webkit.org/show_bug.cgi?id=193959) to implement this feature without any good justification providing App Store apps a significant advantage over Web Apps.
+
+On iOS, Apple makes installing native apps very easy with [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) while making installing open Web Apps **as obscure as possible**. Even when on phone support with users it can be difficult to explain how to add a Web App. This is not a problem on Android.
+
+{% image
+  "/images/walled-gardens/17_ios-app-install-banner.png",
+  "oceanjournalweb.com webpage showing an app store install banner",
+  "screenshot", null,
+  [150, 200, 300],
+  "150px"
+%}
+
+You can see in the example taken from Apple’s documentation that a **link to the native app is prominently displayed at the top of the screen.**
+
+To install a Web App on iOS the current process is as follows:
+
+<div class="gallery screens">
+  <figure>
+    {% image
+      "/images/walled-gardens/18_ios-web-install-step-1.png",
+      "A circled example of the share button in iOS Safari",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>1. The user must know to hit this "share" button. Even this share button can be obscured if the user has scrolled, because the bottom bar is hidden away.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/19_ios-web-install-step-2.png",
+      "An example of the iOS share panel open at the bottom of the screen with various share options",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>2. This causes a bottom panel to be displayed on screen. Then the user <em>must know</em> to scroll down that panel. At this point it is obvious that installing Web Apps is deeply obscured.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/20_ios-web-install-step-3.png",
+      "A circled example of the Add to Home Screen action in the iOS Safari share drawer",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>3. Then the user must hit the "Add to Home Screen" button.</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/21_ios-web-install-step-4.png",
+      "An Add to Home Screen view with details of a web page in addition to Cancel and Add buttons",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>4. Then the user must hit "Add".</figcaption>
+  </figure>
+  <figure>
+    {% image
+      "/images/walled-gardens/22_ios-web-install-step-5.png",
+      "A view of the iOS home screen with an icon for the added web page",
+      null, null,
+      [150, 200, 300],
+      "150px"
+    %}
+    <figcaption>5. Finally the Web App appears on the user's home screen.</figcaption>
+  </figure>
+</div>
+
+Other "browsers" on iOS **do not have the ability to install Web Apps**.
+
+This means that despite simply being thin user interface shells around Safari’s WebKit, every "browser" on iOS including Firefox, Chrome, Edge, Opera, Brave can not add Web Apps. Users visiting a Web App capable site in these browsers on iOS would not even find the install button unless they would know to switch to Safari, then go through the steps as described here. This is clearly evidence of Apple preferencing their browser and native apps.
+
+
+
+##### 5.4.5.3. App Clips
+
+An [App Clip](https://developer.apple.com/app-clips/) is a micro-version of native iOS application which allows consumers to load and use part of the application without installing the full application.
+
+{% image
+  "/images/walled-gardens/23_ios-app-clips.png",
+  "A series of 5 iPhones each showing an App Clip panel with a prominent open action",
+  null, ["webp", "png"]
+%}
+
+<cite>App Clips as shown on [Apple.com](https://developer.apple.com/app-clips/)</cite>
+
+This is good for native application developers who want to decrease friction by allowing users to nearly instantly preview or use a subsection of functionality. An App Clip does not require a user to have to go through the App Store, removing a key barrier.
+
+As seen in the previous section, Apple has not implemented any way to inform users that they can install a Web App, and makes the whole installation process very cumbersome. In the meantime, Apple has added the ability for developers to display these native App Clip panels on top of web pages often to **incite users to use a native app instead of the web page they are currently viewing**.
+
+Apple’s addition of this feature while at the same time ensuring that Web Apps are hidden away, difficult to install and have other barriers to adoption which increase user friction, is a clear demonstration of anti-competitive behaviour.
+
+
+
+##### 5.4.5.4. Smart App Banners
+
+Apple has a technology called [Smart App Banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners). These are little banners that appear in Safari when visiting a url that matches the universal link patterns set for an App or by including a special meta tag.
+
+<div class="gallery screens">
+  {% image
+    "/images/walled-gardens/25_ios-smart-banner-open.png",
+    "iOS Safari shown an Ocean Journal website with a banner at the top to open in the Ocean Journal app",
+    null, null,
+    [150, 200, 300],
+    "150px"
+  %}
+  {% image
+    "/images/walled-gardens/26_ios-smart-banner-view.png",
+    "iOS Safari shown an Ocean Journal website with a banner at the top to view in the Ocean Journal app",
+    null, null,
+    [150, 200, 300],
+    "150px"
+  %}
+</div>
+
+If the App is not installed it displays a deep link to the iOS App Store. If the App is installed it provides a link to open the App on iOS.
+
+According to [this complaint](https://developer.apple.com/forums/thread/105129?answerId=639849022#639849022) there is no way for the developer to stop the Smart App Banner from appearing even if they do not add the meta-tag. Provided the universal link patterns set for an App match it will display the banner.
+
+There is no meta-tag to disable this behavior, forcing all developers to include a banner on their Website even if they wish to disable it is a clear attempt to direct traffic off the Web and into Apple’s ecosystem. Smart App Banners should likely be opt-in and respect the developers wishes. At the very least developers should be able to opt-out.
+
+
+
+##### 5.4.5.5. Dark Patterns
+
+> Dark patterns are design elements that deliberately **obscure**, mislead, coerce and/or deceive website visitors into making unintended and possibly harmful choices.
+> <cite>[Misha Ketchell - The Conversation](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362)</cite>
+
+The friction added to installing Web Apps by hiding away installation options, preventing the installation from other "browsers" and the clear preference shown to native apps through Smart Banners and App Clips are arguably [dark patterns](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362) and can completely hobble developers' attempts to provide apps to their users through the open web.
+
+Despite Apple’s [claims to regulators](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf) that "PWA’s eliminate the need to download a developer’s app through the App Store (or other means)" the reality is that Apple has limited the user experience for Web Apps to the point where developers are forced to develop native apps.
+
+
+
+### 5.5. Apple Uses Flawed Privacy Arguments
+
+> The most dangerous feature that browsers have are not the device API’s; it is the ability to **link to and download native apps**.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)</cite>
+
+
+
+#### 5.5.1. Fingerprinting and Web Device APIs
+
+The goal of fingerprinting is to re-identify users uniquely (without their permission), this is typically for advertising purposes. This is done by collecting many different data points about the device (ip address, screen size, operating system version, existence of certain fonts). Each of those data points cannot identify an individual, but it could be possible to track users if you have enough of these data points and combine them.
+
+Apple has [rejected certain web standard device APIs](https://webkit.org/tracking-prevention/#anti-fingerprinting) that would provide Web Apps equivalent capabilities to Native Apps (the web standard versions are actually arguably much more strict and secure than their native counterparts, see Section 4.14 below).
+
+> Finally, if we find that features and web APIs increase fingerprintability and offer no safe way to protect our users, we will not implement them until we or others have found a good way to reduce that fingerprintability.
+> <cite>[Apple](https://webkit.org/tracking-prevention/#anti-fingerprinting)</cite>
+
+This was the stated reason Apple used to reject WebBluetooth from Safari (Webkit). This doesn’t make a great deal of sense.
+
+Bluetooth is a short-range, standardized wireless technology standard that is used for exchanging data between fixed and mobile devices over short distances. [Web Bluetooth](https://web.dev/bluetooth/) is an API that provides the ability to connect and interact with Bluetooth Low Energy peripherals (but not classic Bluetooth devices, for security reasons). For example printers, toys, scanners, lights, home automation, washing machines, dryers, scanners, payment devices and a huge list of other "Internet of Things" (IoT) devices.
+
+With Web Bluetooth, a Web App **can not get a list of bluetooth devices**. Instead, **only with user interaction** (e.g., clicking on a button), can a site request the browser open a permission prompt to connect to a bluetooth device and the site can provide filters to potentially reduce the list to devices it can understand, but cannot skip the user’s consent. The list is **made available to the user, not to the Website/Web App**. The user can give access to a single device or deny access altogether.
+
+This is a very unreliable method of fingerprinting and requires a scary permission prompt to the user on each Web App.
+
+Similar arguments can be extended to each of the other hardware APIs, they are all difficult to use for fingerprinting as it's impossible to do so without alerting the users and requiring their permission.
+
+> Device API’s are simply bad for fingerprinting. It is unreliable and really obvious when it is used.
+> <cite>[Niels Leenheer - HTML5test](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)</cite>
+
+We are not saying that iOS Safari must implement every feature implemented by the other browsers, in fact it is healthy for browser makers to pursue their own vision for the web. What is a problem is that Apple has banned all other browsers, so on iOS users have no option to use a different browser that does support these APIs.
+
+It should be expected that **privacy** and **security** standards that apply to the web **should also apply to native apps where Apple derives their profit**.
+
+Apple by both not supporting these APIs in iOS Safari and banning all competing browsers, is making it impossible for Web Apps to compete with native apps in cases where these device APIs are a core or important part of the application.
+
+It is important to note here that Apple in their rejection of Web Bluetooth and other Device APIs have focused on fingerprinting (as opposed to firmware hacks) despite doing a far poorer job in mitigating these risks in native. Possibly this is in a effort to frame the rejection of these features through the lens that both Apple is pro-privacy as opposed to a general belief that the web should not be an application platform on iOS, and as a slight on other browsers vendors/developers by implying they want these features in order to spy on users.
+
+
+
+#### 5.5.2. Native vs Web Privacy/Security
+
+The web’s paranoid security model was not developed in a vacuum. Browsers have evolved to place a high value on security and privacy, and the same is true of the [Web Bluetooth Security Model](https://medium.com/@jyasskin/the-web-bluetooth-security-model-666b4e7eed2).
+
+Behind each expansion of browser capabilities is a simple idea: if browsers do not provide important features, users will feel the need to install applications to meet their computing needs. It is also important to note that there is **no discussion** of entirely removing for example bluetooth from iOS (web and native).
+
+Therefore, privacy and security risks must be viewed in terms of mitigation and in comparison with native apps. As such bluetooth is a useful example to compare web and native in utility/privacy and security. From this vantage point, we can compare the level of care taken by browsers in exposing bluetooth devices versus native apps.
+
+
+
+##### 5.5.2.1. Potential security/privacy concerns
+
+A number of potential security and privacy issues have been raised by participants in the Working Group developing the [Web Bluetooth standard](https://webbluetoothcg.github.io/web-bluetooth/):
+
+These include:
+
+* Malicious messages sent to poorly designed, or older, bluetooth devices. <br /><br />
+A Website/Web App could connect to poorly designed older bluetooth devices and then hack them to launch further attacks on the user. <br /><br />
+Note for this attack to work:
+    1. The device needs to be poorly designed without functionality that prevents an attacker from doing harmful actions. Note that most devices that offer a harmful actions have security protections in place (i.e. they required updates in place)
+    2. The attacker needs to have specific code that targets that device, the user has to own that device and then ask to connect to that device and then the user has to give the website permission.
+    3. The Web Bluetooth specification maintains a block-list of known-vulnerable devices which browsers are expected to block from connections.
+    4. Browsers include the ability to strip permissions, including blocking the loading of, websites that act maliciously in this way (e.g. [Google’s SafeBrowsing](https://safebrowsing.google.com/), used by Chrome and Firefox, and [Microsoft SmartScreen](https://support.microsoft.com/en-us/microsoft-edge/what-is-smartscreen-and-how-can-it-help-protect-me-1c9a874a-6826-be5e-45b1-67fa445a74c8))
+* Collecting lists of nearby devices (for location tracking)<br /><br />
+Shops could place bluetooth devices on their premises and a Website/Web App with completely unfettered access to bluetooth could connect to them thus revealing the users location without permission.<br /><br />
+Thankfully, the Web Bluetooth specification prevents this ambient attack by creating the opportunity for a user to select the devices they wish to connect to before any data is sent.
+* Fingerprinting <br /><br />
+The goal of fingerprinting is to reidentify users uniquely (without their permission), this is typically for advertising purposes. Typical fingerprinting is done by silently collecting many different data points on the website (ip address, screen size, operating system, existence of certain fonts). Each data point is unlikely to uniquely identify an individual, but it is possible to track users if you have enough of them. A user connecting to the same device on two different websites could uniquely identify the user. <br /><br />
+Web Bluetooth adds a strong deterrent to ambient fingerprinting through the addition of a user-visible permission prompt. Permission-based APIs are not frequently used for fingerprinting today due to the low acceptance rates by users of these grants, making them **nearly useless for pervasive, low-friction fingerprinting**. <br /><br />
+Risks endure for users who have elevated threats and clear their caches, but thanks to the permission model of Web Bluetooth, browsers can also inform users of the risks of re-identification at the time of use. By managing these capabilities more tightly than native OS APIs (which expose blanket grants to bluetooth stacks), browsers mitigate these risks more directly.
+
+
+
+##### 5.5.2.2. Process for connecting to a device on web and iOS native
+
+###### 5.5.2.2.1. Web
+
+The process in the web specification is as follows:
+
+1. Upon a user gesture (click, touching a button etc) the Website/Web App may request to connect to a specific bluetooth device OR they may provide a specific category of device to be used as a filter.
+2. The browser displays a prompt to the user indicating that the Website / Web App would like to connect to a bluetooth enabled device and displays a list of devices. <br />
+The Website/Web App **never gets to see this list of bluetooth devices, it may not connect to any device without specific consent**.
+3. If the user choices to connect to a device, the Website/Web App may now communicate with that specific device
+4. This permission can be revoked at any time via the browser but it is important to note it is only for this specific Website/Web App and only the specifically chosen device
+
+{% image
+  "/images/walled-gardens/27_pair-process-web.png",
+  "An Android screenshot showing device options to pair with, for a webpage, with a 'PAIR' primary action",
+  "screenshot", null,
+  [200, 300, 400],
+  "200px"
+%}
+
+
+
+###### 5.5.2.2.2. iOS Native
+
+The process for iOS native applications using Swift CoreBluetooth is:
+
+1. Declare that the application needs to use bluetooth along with a description in the info.plist *
+2. On first boot of the application, it will ask the user permission (via a prompt) to use bluetooth *
+3. If the user agrees the application now has access to bluetooth <sup>2</sup>
+4. This permission can be revoked at any time via user settings
+5. The application **can now get lists of any nearby bluetooth devices and connect/communicate with them indefinitely without user interaction**.
+
+{% image
+  "/images/walled-gardens/28_pair-process-ios-a.jpg",
+  "iOS screenshot showing a prompt asking if the application can use Bluetooth",
+  "screenshot"
+%}
+
+<sup>2</sup> Until 2019, steps 1 - 3 were not required. **This means before 2019 that the very large number of apps with bluetooth permissions track all users and connect to any device**.
+
+
+
+##### 5.5.2.3. How does iOS bluetooth for native apps mitigate these concerns?
+
+The permission system on iOS is a bit more of a **[blank check](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)**. Once given initial Bluetooth permission, applications are essentially given free reign to do whatever they want with regards to Bluetooth. They can list all nearby devices (without user interaction) and they can communicate with any nearby Bluetooth device (without user interaction).
+
+Prior to iOS 13 (late 2019) the situation was even worse. Applications did not even need to ask for bluetooth permission at all.
+
+Many companies were using this to [track users' locations without their consent](https://www.fastcompany.com/90386781/ios-13s-new-bluetooth-privacy-feature-is-important-but-confusing). Shops were placing bluetooth beacons in their stores and then tracking users' physical location without consent. This was only possibly due to the weak security/privacy implementation on iOS Native CoreBluetooth. **Note this still has not been fixed** and this sort of abuse is still possible today, provided an application can convince a user that it has a plausible reason to provide access to bluetooth (a simple yes/no prompt).
+
+{% image
+  "/images/walled-gardens/29_pair-process-ios-b.jpg",
+  "iOS screenshot showing a prompt asking if the application can use Bluetooth",
+  "screenshot"
+%}
+
+All three of the above listed privacy/security concerns are currently essentially unmitigated except by:
+
+1. App Store Review ([a dubious defense](https://habr.com/en/post/580272/))
+2. The user giving permission to access bluetooth once
+
+It's odd that Apple **is not implementing** Web-Bluetooth over security/privacy concerns and, in effect, forcing users to download a native app with far broader powers when they don't appear to have adopted equivalently strong protections within their native app ecosystem. Rejecting WebBluetooth on these grounds is nonsensical.
+
+These issues still have not been fixed with native iOS Apps bluetooth permissions. Their APIs were not designed to enable a more respectful prompt the way the Web Bluetooth specification was, and shifting all existing applications to a less invasive model may break many unmaintained programs. In these tradeoffs Apple could choose user privacy and security and against invasive developers, but they have not, and yet they hold up the less problematic web API as an unacceptable risk.
+
+When comparing risk in allowing a Web App feature, the comparison is not between the risk the feature brings and nothing (i.e not allowing the feature). The comparison is between the feature and getting the user to download a native application with an analogous feature.
+
+As shown in the previous sections, with regards to bluetooth the web is far more restricted, secure and private than what is allowed in native. It could be argued that not allowing Web Bluetooth is actually worsening the user's risk profile, in addition to denying them convenient functionality. If the only alternative is to download a native app with far greater permissions then this arguably puts the user at greater risk.
+
+Web Bluetooth is largely analogous to the other Device APIs.
+
+Device APIs and File System Access are probably the most complex in terms of security privacy. There are legitimate security concerns (as there are with equivalent APIs for native applications). The web specifications have in our opinion largely mitigated these concerns (certainly far better than native apps on iOS have).
+
+Apple has done an extremely poor job communicating what their concerns are (in sufficient technical detail, including why they think the mitigations are insufficient) to developers and other browser vendors.
+
+
+
+##### 5.5.2.4. Safari WebBluetooth Extension
+
+> Can't we solve this using browser extensions?
+> <cite>[Daniel Bates - Apple Webkit Team - 8th November 2017](https://www.w3.org/2017/11/08-device-api-minutes.html#:~:text=can%27t%20we%20solve%20this%20using%20browser%20extensions%3F)</cite>
+
+In the last public discussion about Web Bluetooth Standard between Apple and the other browser vendors it was suggested that browser extensions could offer a potential solution.
+
+The idea is that users who need Web Bluetooth could install a browser extension via the iOS App Store that provides this functionality to Safari. A [prototype](https://vimeo.com/642462265) of this has been produced for iOS.
+
+While developers producing these types of extensions are almost certainly just trying to help users, this solution is problematic for several reasons:
+
+1. Security/Privacy is hard, Device APIs are powerful and while they provide great utility this seems more a job for the dedicated teams at the browser vendors to handle.
+2. iOS Native has poor privacy protection relative to Web Bluetooth and the developer of these extensions would need to attempt to replicate all the mitigations in the extension itself.
+3. It is arguably a [dark pattern](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362) to discourage usage of Web Apps vs Native Apps to add extra hoops for users wanting to use Bluetooth on the web. This style of solution would presumably be unacceptable for Native Apps.
+
+
+
+##### 5.5.2.5. Apple's Identifier for Advertisers (IDFA)
+
+> Apple has a tactical commitment to your privacy, not a moral one. When it comes down to guarding your privacy or losing access to Chinese markets and manufacturing, **your privacy is jettisoned without a second thought.**
+> <cite>[Cory Doctorow - Former European director of the Electronic Frontier Foundation](https://twitter.com/doctorow/status/1459914164152016905)</cite>
+
+Given Apple’s strong stance on user privacy on the web, to the point of rejecting extremely useful functionality on the mere possibility that a user could be assigned a unique identifier it may surprise readers to learn that **Apple offers a method to uniquely fingerprint users** in native apps called [Apple's Identifier for Advertisers (IDFA)](https://en.wikipedia.org/wiki/Identifier_for_Advertisers).
+
+Up until iOS 10 there was no way for users to disable this, starting in iOS 14 users are asked via this slightly ambiguous prompt if they consent (about 20% of users have turned this operating system provided fingerprint off).
+
+Even when users do turn this functionality off, due to Natives' very permissive privacy and security model (relative to the Web) Apps can continue to fingerprint users.
+
+> Our investigation found the iPhone’s tracking protections are nowhere nearly as comprehensive as Apple’s advertising might suggest. We found at least three popular iPhone games share a substantial amount of identifying information with ad companies, even after being asked not to track. <br />
+When we flagged our findings to Apple, it said it was reaching out to these companies to understand what information they are collecting and how they are sharing it. After several weeks, nothing appears to have changed.
+> <cite>[Geoffrey Fowler And Tatum Hunter - Washington Post](https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/)</cite>
+
+The only consistent privacy policy with Apple’s concern for uniquely fingerprinting users on the web and with users being tricked via prompt) would **be to remove this functionality from iOS altogether**.
+
+{% image
+  "/images/walled-gardens/30_allow-tracking-prompt.png",
+  "iOS prompt asking if an application can track the user across apps and websites",
+  "screenshot"
+%}
+
+Apple has not announced any plans to entirely remove this functionality from iOS. Apple’s privacy stance needs to be consistent to believe that they are doing it for the benefit of the user. If they apply strict conditions that limit functionality on the web but allow pervasive tracking in native it can be argued they are providing pervasive tracking in the area which generates revenue while applying heavy restrictions beyond what is needed to prevent tracking on the other side.
+
+
+
+### 5.6. iOS Safari is Buggy
+
+In the [Mozilla Developer Network Web Developer Needs Assessment 2020 Survey](https://insights.developer.mozilla.org/reports/mdn-web-developer-needs-assessment-2020.html) developers listed browser compatibility issues as the largest issue as defined by:
+
+* Having to support specific browsers (e.g IE 11)
+* Avoiding or removing a feature that doesn’t work across browsers
+* Making a design look/work the same across browsers
+* Testing across browsers
+
+{% image
+  "/images/walled-gardens/31_mdn-needs-survey.png",
+  "A chart showing the popularity of issues faced by web developers"
+%}
+
+Drilling down further it was specific browsers that were causing the issues.
+
+Internet Explorer is at End of Life in June 2022, and has not been in serious development since 2015. This means that **Safari causes at least 5 times more issues** than the next active browser on the list.
+
+Note that Edge (based on the EdgeHTML engine) has been discontinued and now accounts for much less than 1% of global use. The Edge browser has been rebuilt on Chromium.
+
+This suggests that once Internet Explorer ceases to be used (its usage is already [below 1%](https://gs.statcounter.com/browser-market-share)) than the **primary browser causing serious issues for developers will be Safari**.
+
+{% image
+  "/images/walled-gardens/32_mdn-survey-browser-developer-issues.png",
+  "A chart shown what browsers developers have ranked as causing issues"
+%}
+
+Safari on iOS has had countless, severe application breaking bugs that make it impossible to use as a foundation for a stable application. Furthermore, the mechanism by which updates for Safari on iOS are pushed to users, **requiring a full OS update** instead of just updating the browser, means it can take multiple weeks, if not months, for a severe bug to be fixed. All this time, Web Apps and sites may be broken or even unusable. This means many companies are forced to develop native applications simply for the stability they provide.
+
+It is important to note that we believe these bugs are likely a result of reverse incentives in relation to the App Store and a lack of competition which has led to a [systemic underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/#:~:text=We%20asked%20Apple%20about%20the%20IndexedDB%20bug%20and%20whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition.%20We%20would%20be%20stunned%20if%20it%20chose%20to%20reply.) of the Safari/webkit team for many years. It’s likely that the Safari/Webkit team is working as hard as they can to make a stable browser but just can’t keep up because Apple has not provided enough resources for them to be able to do it.
+
+
+
+#### 5.6.1. State of CSS Survey
+
+[CSS](https://en.wikipedia.org/wiki/CSS) stands for Cascading Style Sheets which is used for formatting and layout for websites and Web Apps. It is one of the four languages used to develop websites and Web Apps, along with [HTML](https://en.wikipedia.org/wiki/HTML), [JavaScript](https://en.wikipedia.org/wiki/JavaScript) and [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly). It is used in nearly every web page, and is definitionally an uncontroversial core web standard.
+
+The [State of CSS](https://stateofcss.com) survey of web developers recently had a question about "pain points" and "browser incompatibilities". In the [raw text](https://gist.github.com/SachaG/cd7cf12623a95d8162ac2b8e340c4724) of the answers, the yellow lines are the ones that contain the word Safari:
+
+{% image
+  "/images/walled-gardens/32_mdn-survey-browser-developer-issues.png",
+  "Text file view showing a large amount of matches for the term 'Safari'"
+%}
+
+Extracting some of the quotes from the survey, it’s obvious that the opinion among developers that Safari is both buggy and lagging behind features is commonly shared amongst developers. Safari/iOS/webkit/iPhone/ipad was mentioned 369 times several times. By comparison Firefox only had 12 negative mentions in the entire survey.
+
+Here are some extracts from the survey:
+
+> I hate Safari with a passion of a thousand burning suns.
+
+> **Why is Safari so crap?** Why on earth do I still have discussions about IE11?
+
+> The Safari team should put their head out of their arse - Safari, Especially iOS Safari, are such a pain to work with as a webdeveloper, they lag years behind on too many features for both CSS & JS.
+
+> Safari feels pretty behind the times most of the time
+
+> **Safari is always years behind** Edge/Chrome and has many many many bugs related to viewheight/scroll.
+
+> iOS Safari is the biggest limiting factor in all web development.
+
+> mostly things that safari is catching up on
+
+> safari is evil
+
+> Flex gap :( it's so good but Safari is the new IE.
+
+> Safari is the main problem
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> Full screen height is a pain to work with in Safari
+
+> Still have been held back by IE11, but that ends soon. (Safari though...)
+
+> **Anything Safari doesn't want to implement**
+
+> Safari is just weird a lot
+
+> Too many to list for Safari on iOS/ipadOS
+
+> Only **lacking/lagging** support in Safari
+
+> Safari in general has issues with standards implementation
+
+> All of CSS with Safari. Notch specially
+
+> All the new stuff **being held back by Safari**
+
+> Anything iOS Safari doesn't support is a blocker, **because its rendering engine is mandatory in iOS**.
+
+> Anything new when using a WebKit browser -.-
+
+> Anything related to Apple company, **most of the new features are not available over there** ;)
+
+> Anything **safari does not support**
+
+> Anything Safari doesn't want to implement
+
+> **Anything that Firefox and Chrome support but Safari doesn't. It's a pain having to account for Apple's low bar**.
+
+> Anything that’s implemented differently in Safari & iOS Safari
+
+> Better Safari update cycle, detached from OS updates
+
+> Bugs in Safari related to shadow DOM.
+
+> Everything Safari doesn't support but Chromium & Firefox do
+
+> Flex gap, damn you Safari!
+
+> focus-visible is not yet supported by Safari
+
+> For whatever reasons, I wish Safari was quicker at implementing things.
+
+> Full screen height is a pain to work with in Safari
+
+> height being inconsistent on IOS safari
+
+> I hate Safari.
+
+> I have more and more instances where **stuff works everywhere but not in Safari**.
+
+> **I just treat safari as a hellhole** where css goes to die
+
+> I often find myself with layout issues that only happen in Safari
+
+> I'm not sure exactly what it is, but **Safari is now my problem child across all metrics**. It seems to be a little different each time, but overall Safari is always the browser with CSS related bugs.
+
+> Incompatibilities, poor CSS support in Safari
+
+> It is difficult for me to treat Safari as an important testing target or to pretend I care about its compatibility when **Apple seems utterly determined to make it difficult to test on Safari, and to use its incompatibilities to hold back open web development on Mac and especially on iOS**. I increasingly feel that **Safari doesn't really want to be part of a creative or open web**, and that's fine I guess, but I'm not going to waste my time and money buying an iPhone to test on when Apple would just prefer I made a native app for their platform anyway.
+
+> Just all of Safari.
+
+> Just wish Safari would die already
+
+> Main CSS pain point above all: Safari (i.e. all iOS) being rigged with bugs and lagging behind in features.
+
+> Many technologies blocked by lack of Safari support
+
+> Mostly just slow adoption by Safari
+
+> mostly things that safari is catching up on
+
+> **Nearly all pain points are Safari**.
+
+> Not any specific at the top of my head, but usually Safari is the one giving me a hard time :(
+
+> Not many but it's annoying when it happens. It's usually Safari lagging behind or rendering random stuff instead of the UI specified.
+
+> Not really difficulties, but Safari is one he** of a pain in the a** and having a more precise way of targeting it instead of both him and Chrome would be great (like -moz- prefix instead of having to write a bunch of @supports)
+
+> Only lacking/lagging support in Safari
+
+> Perf issues in Safari
+
+> Pretty much anything modern, as **Safari is lagging behind**.
+
+> Pretty much **anything that Safari shipped less than 18 months ago**
+
+> REMs in media queries. Damn you Safari!!
+
+> Safari (in general)
+
+> Safari and apple in general have incompatibility because they are late
+
+> **Safari became the new Internet Explorer** fro us
+
+> Safari feels pretty behind the times most of the time
+
+> safari has been a bit of a pain
+
+> Safari imcompatibilities
+
+> Safari iOS is becoming tiresome.
+
+> Safari is a huge mess
+
+> Safari is always years behind Edge/Chrome and has many many many bugs related to viewheight/scroll. iOS Safari is the biggest limiting factor in all web development.
+
+> **Safari is constantly dragging its heels**.
+
+> safari is evil
+
+> Safari is just weird a lot
+
+> **Safari is neglected**
+
+> safari is pain in the ass for debug if you have pc
+
+> Safari is the main problem
+
+> Safari is the new IE
+
+> Safari is the new Internet Explorer...
+
+> Safari on iOS :D
+
+> Safari should die!
+
+> Safari sucks
+
+> Safari updates not frequent enough
+
+> Safari, especially mobile
+
+> Safari. Everything WebKit. Freaking Apple…
+
+> The number one web problem is browser compatibility. **Browser like Safari is slowing down the evolution of web unfortunately**
+
+> Too many to list for Safari on iOS/ipadOS
+
+> Using Flexbox to layout forms because Safari on iOS shrinks radio buttons.
+
+> we can create any new features, but if browsers (like Safari) are waiting 3 years to implement it, it's totally useless.
+
+> **WebKit is never up to date and doesn't implement features fast enough (or at all)**.
+
+> yea, loads, mostly because of safari - like gap or ::marker
+
+> Yeah **Safari is killing me, it's the new IE**!
+
+> Yep, Safari is the new IE regarding grid and flexbox issues
+
+> Yes - and Safari is nearly always the browser that gets it wrong.
+
+> Yes, **horrible Safari support**
+
+> Yes, specifically compatibility with Safari
+
+> Yes, usually it's Safari. It became new IE😂
+
+> **Yes. And we have Apple to blame for it**! Flexbox gap is a good example.
+
+> Yes. Too much new useful features not supported by fcking safari.
+
+  </div>
+</div>
+
+
+
+#### 5.6.2. WebRTC
+
+WebRTC is a standard for web video calls, access to microphones and cameras, and enables streaming video applications such as game streaming (Stadia, xCloud, Luna, GeForce NOW, etc.).
+
+> During March 2020 and the rise of the pandemic in Norway EVERYONE needed video calling. We are the number one video calling tool for healthcare here, and our use base is around 60% iOS Safari. I can tell first hand having to deal with onboarding 70% of the doctors in Norway with active bugs on iOS in simple things like media reliability, and with no real alternative (a lot of people only have one modern device, and that's their phone), **it was near catastrophe for us, and a lot of pain for doctors missing their patients due to bugs**
+> <cite>Das-Igne Aas – CTO Confrere</cite>
+
+> iOS Safari WebRTC is such a broken mess that my going suggestion to clients unfortunately is to not support it and redirect users to a native app installation. I had to manually go through all open WebRTC bugs in webkit to figure out how to explain this to my clients and help them in reaching that conclusion and even conveying that to their customers.
+>
+> There are nasty bugs in iOS Safari that have been opened since 2019 or earlier relating to media handling of WebRTC. These aren’t just edge cases, but rather things you’ll have users bump into in regular use. Some of them have finally been fixed in the latest 13.5.5 beta earlier this month.
+>
+> Oh – and if you plan on using any OTHER browser on iOS then WebRTC won’t be supported there. Why? Because Apple hasn’t made WebRTC available in its Webkit Webview on iOS and they aren’t allowing anyone to build a mobile iOS browser that doesn’t use Webkit as its rendering engine. So much for freedom and choice.
+> <cite>[Tsahi Levent-Levi](https://bloggeek.me/webrtc-browser-support/)</cite>
+
+
+
+#### 5.6.3. IndexedDB
+
+IndexedDB is a local browser database for storing data. It is essential for many apps, especially apps that require offline functionality. IndexedDB on iOS Safari has had many bugs and been broken many times since it was first introduced. Recently, both IndexedDB and LocalStorage, a similar API for storing small amounts of data, were broken, leaving developers little alternatives to store data or risk data loss or corruption. Local Storage which is also essential for many websites was broken at the same time.
+
+> Apple's WebKit team has managed to break the popular IndexedDB JavaScript API in the latest version of Safari (14.1.1) on macOS 11.4 and iOS 14.6.
+> <cite>[Thomas Claburn - The Register](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug)</cite>
+
+> Ran into a spectacularly awful Safari bug in the latest Safari (14.1.1 on macOS and iOS 14.6).
+>
+> Opening an IndexedDB database fails 100% of the time on the first try. 😩
+>
+> If you refresh, it starts working. <br />
+> Bug report: [https://bugs.webkit.org/show_bug.cgi?id=226547](https://bugs.webkit.org/show_bug.cgi?id=226547)
+>
+> It's really really hard to build reliable websites on macOS and iOS with showstopper bugs like this.
+> This should have been caught by basic unit testing.
+> <cite>[Feross Aboukhadijeh (Stanford Computer Security University Lecturer and Open-Source Developer of Socket)](https://twitter.com/feross/status/1404568122158313474)</cite>
+
+
+
+### 5.7. Default Browser Choice
+
+Until [late 2020](https://www.theverge.com/2020/10/21/21526556/ios-14-resets-default-email-browser-apps-after-updates), it was impossible for iOS users to choose an alternative browser to handle links, even if they had installed other WebKit-skin browsers from the App Store. Apple continues to prevent competitors from bringing differentiating features via their own engines.
+
+As the only company banning competing engines, **Apple is clearly the worst offender**, but they are not the only ones impeding user choice. It is our opinion that to preserve competition, users must be given the ability to easily change their default browser and that choice must be respected by the operating system
+
+> Google’s “Android Google Search App” has been ignoring browser choice on Android.
+>
+> Known as the "Android Google Search App" ("AGSA", or "AGA"), this humble text input is the source of a truly shocking amount of web traffic; traffic that all goes to Chrome, no matter the user's choice of browser.
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser.)</cite>
+
+Facebook has been abusing IAB (In App Browsers) to prevent users from opening links from within the Facebook app in either their own browser or in a view that uses the users default browser (both iOS and Android provide this, although the iOS is only iOS Safari).
+
+Using IAB (In App Browsers) to deny users choice is a very complex topic. [This article](https://infrequently.org/2021/07/hobsons-browser) does an excellent summary of the current situation and why it is bad for consumers. We have also made a separate submission covering this topic.
+
+It is our opinion that mass market operating systems and major applications should as much as possible provide users with the means of selecting a default browser (complete with its engine) and respect it. Additionally they should avoid using dark patterns or misleading interfaces to favour their own browser.
+
+
+
+### 5.8. Evidence of Long Term Neglect and Developer Discontent
+
+In addition to [5.6. iOS Safari is Buggy](#ios-safari-is-buggy), this section describes some of the long term evidence of neglect and developer discontent with Safari by providing quotes with links to external sources. This evidence is not exhaustive and is simply a subset of what’s available. The sources date from 2011 to 2022.
+
+
+
+#### 5.8.1. Push Notifications
+
+Push Notifications for iOS on Native was released on [June 17, 2009](https://en.wikipedia.org/wiki/Apple_Push_Notification_service). As of writing **almost 13 years have passed** and Apple has provided no mechanism to allow Web Apps to send notifications, a critical feature for many applications.
+
+It is undoubtedly the most requested feature but has been repeatedly ignored by Apple. It was only on September 26th 2021 (after OWA’s #AppleBrowserBan campaign and presentations to regulators) that Apple started work on Push API, although over 200 days later and there have been no indication that this feature will be ready any time soon.
+
+There are countless requests for this feature across platforms frequented by developers including twitter/stackoverflow/reddit and Apple’s own bug tracker.
+
+Developers were so frustrated in the lack of development and response from Apple they started their own change.org petition which has garnered over 7000 signatures, a substantial amount considering how poorly supported Web Apps are on mobile devices.
+
+{% image
+  "/images/walled-gardens/41_change-dot-org-petition-web-push.png",
+  "A change.org petition, asking Apple to implement Web Push notifications",
+  "screenshot"
+%}
+
+Extracted from the site are some quotes:
+
+> It's **hard enough to develop for Apple as is**. Stop making it harder for me to make something for your users to use.
+> <cite>[James Hessell-Bowman (Feb 9, 2022)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **PWAs are the future. iOS Safari isn't. Change it!**
+> <cite>[Mauricé Ricardo Bärisch (Jan 7, 2022) ](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Safari is the new IE
+> <cite>[Flavio Spezi (Nov 24, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> My goodness no push notification yet, **disgrace**
+> <cite>[Daniel Gadd (Nov 24, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> IMHO, **PWAs are a better way to reach mobile users**, compared to native mobile apps, for not-hardware-intensive apps.
+> <cite>[Saqib Shafin (Oct 3, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I'm a developer who would like to be able to sell this feature to clients without caveats or additional costs. **It would also be great to have a unified web for all platforms**.
+> <cite>[Alex Grant (Jun 26, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Please implement the W3C standards. **Don't be like IE or soon the developer community will turn on you**.
+> <cite>[Frank Ali (May 26, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **We need this** web developers
+> <cite>[Jack Smith (Apr 29, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Come on guys, we need this**... It's crucial.
+> <cite>[Morne Erasmus (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **It's the right thing to do Apple.**
+> <cite>[Shaun Bliss (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> Need it! **Soon**!!
+> <cite>[Francesco Rombecchi (Dec 1, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Desperately** needed for modern web apps
+> <cite>[Michoel Samuels (Jun 9, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I would like to write from **one codebase** and deploy on **all platforms**
+> <cite>[David Murdoch (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Shocking what they are doing. Pure monopoly**. They are **lowering the technological progress to protect their pockets**, but they are the most rich stock in the world…
+> <cite>[Federico Schiocchet (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This would **dramatically** simplify some business apps.
+> <cite>[Ben in CA (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> It's **ridiculous** they don't have it!
+> <cite>[Mohameth Seck (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **It's sad that we have to petition** for something like this. I wonder if Steve was alive if he would hold back the progress of technology like these clowns at apple.
+> <cite>[Shaquille Hinds (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Because developers don't want to have to build a whole new frontend iOS app just to send push notifications.**
+> <cite>[Miles Exner (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Seriously ? Still not implemented ??? **Apple, you're standing in the way of a better life for all humans**. Get over it and do the right thing.
+> <cite>[Edouard SILHOL (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This feature will helps developers to create a fast and eficient communication trought sites. Increases PWA experience. **It will help any business type**.
+> <cite>[Lucas Santos (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **This is SO long overdue. It needs to happen. Like... NOW.**
+> <cite>[Sean McDade (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Stop calling iphone a smartphone **when it can't even handle web push**. It's **2020 and we're still fighting for this**. Please make your dumbphone smart again.
+> <cite>[Jonelle Mancilla (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> This is an **absolutely necessary feature** to allow iOS users to have the same experience across so many apps as Android users have. Resisting adding this feature only ends in frustration and brand disdain, **not any type of monopolistic win that Apple** might want to go for as an alternative.
+> <cite>[William Lancaster (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **In 2020 it is beyond my comprehension that Apple’s support for PWAs - but more specifically the WebPush API - is non-existent**
+> <cite>[Christopher Deeming (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I want to be able to give push notifications to users of my web application **without having to build a native app**!
+> <cite>[Adam Ullman (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> Enabling Push Notifications for iOS Safari will lead to more **innovation** in the web space.
+> <cite>[Alexander Matulionis (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> PWAs are the future for smaller apps that don't want to invest in the skill required to make native or native-ish apps. **Apple you're currently the weakest link**. People will still make microtransations in games, and native apps will still be a necessity for video and audio purposes -- your app…
+> <cite>[Jacob Clarke (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> When it is a matter of standardize systems that can contribute to deliver safety or security notifications to consumers, **a vendor shouldn't have the right to lock those consumers to proprietary platforms**.
+> <cite>[Alberto Cruz (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> as a developer this is a **vital requirement for any modern application**.
+> <cite>[Luke Whitehouse (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> **Because apple is making life hard (and expensive) for everyone.**
+> <cite>[Micah Galizia (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I signed because I think it's **silly to be the only platform out there to not support web notifications**. Every other browser and os supports this feature. When iPhone came out, it was game changing because it could do everything a computer could as far as web browsing (other than flash…
+> <cite>[Joshua Shell (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> It's **very** important for web experiences!
+> <cite>[Juan David Nicholls Cardona (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> we **need** this feature to get free of apps
+> <cite>[Tamir Konor (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> our app helps restaurants notify guest when their food is ready, guest can opt to receive a notification. **but iphone users cant**. only android users can. Not everyone wants to install an app to receive mobile event based notifications.
+> <cite>[sal iozzia (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I'm a web dev, **it makes no sense that apple is behind on this**.
+> <cite>[Darren Allen (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> PWAs are here now! Empower developers to use the skills they know today (HTML, CSS, JavaScript) to create amazing products.
+> <cite>[Cesar Perez (Feb 23, 2022)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Add notifications!
+> <cite>[Wesley Pohto (Jan 24, 2022))](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> **We built a small app for the push** and have **difficulty to maintain it**. We are in a big need to have web push to run in iOS
+> <cite>[Brenda Kwok (Oct 22, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> I m facing same issue and I want to request for notification on web IOS devices
+> <cite>[Nitesh Sharma (Oct 15, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I have no idea when a client comes into my retail chat platform with me while I work on my iPad. I don't receive a chime or banner so I am unable to use my iPad as a tool for work. Please enable push notifications for ios.
+> <cite>[Blake Y (Oct 2, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> we need it
+> <cite>[呂 昶億 (Sep 15, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Our clients will benefit greatly from push notifications on iPhones
+> <cite>[Sergei Gorlovetsky (Aug 22, 2021)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> OMG!!!! PLEASE!!! WHY YOU DIDN'T IMPLEMENT THIS YET?!!!!
+> <cite>[Leandro Simões da Silva (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I think that this is a very important feature to have.
+> <cite>[David Rychlý (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> To remove the barrier requiring users to download an app just to deliver push notifications
+> <cite>[Loveth Ezeoye (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> This is need of the hour. iOS users are loosing on a great UX.
+> <cite>[adarsh madrecha (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> apple! i want to be able to use web push notification from my favorite sites and pwa apps!
+> <cite>[ChunTing Tai (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I represent a small company that creates membership administration software for dance/martial arts/yoga studios, which includes a PWA for their members for ease of communication, conveying absence, sharing calendar and events, etc. Currently approximately 40.000+ dancers …
+> <cite>[Johan van Ingen (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Apple are going to lose support from their loyal customers over this glaring omission. Thousands of great websites will work great on Android and PCs but not on Apple.
+> <cite>[Mac MacLaren (1 year ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Support open web standards
+Those kind of systems must be more agnostic.
+> <cite>[Brian Kephart (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> It's a huge feature that "the best of the best" should of thought of first and is falling behind once again.
+> <cite>[joseph simmons (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Just do it.
+> <cite>[Jazmyn Cote (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I really need this for a web app I am developing.
+> <cite>[Adrian Meyers (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Implementen push notification en safari
+> <cite>[Hector Luis Batista (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Web notifications can be useful for users that do not want to download an app just to receive notifications. Email notifications are not as effective and SMS are pricey
+> <cite>[Mo Alraddadi (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Hoy en día los usuarios tienen que tener la posibilidad de ELEGIR si recibir notificaciones web push en su celular o no... No debe ser algo restricto!
+> <cite>[Mauro Francisco Arrigoni (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Make this a reality.
+> <cite>[Devonte Valentine (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> Apple initially unveiled Safari as the means by which developers could develop applications for iPhone. An idea ahead of its time. But that was followed by the first iOS SDK and app store. I believe there is room for both. PWA's are not meant to wipe out app stores, but to open a new pathway to…
+> <cite>[Michael Bunchball (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> I develop PWA and I want to send web push notifications to users
+> <cite>[Erick Daniel Miranda Varas (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> **Ios should lead this technology, not slack behind!**
+> <cite>[Anton Albèrt Karlström (2 years ago) ](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> NEED THIS BIG TIME!
+> <cite>[Nevaan Perera (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices)</cite>
+
+> to deliver a consistent and smooth user experience on iOS and Android devices - **to remove the barrier requiring users to download an app just to deliver push notifications**
+> <cite>[Lukas Schmyrczyk (2 years ago)](https://www.change.org/p/tim-cook-apple-inc-implement-web-push-notifications-on-ios-devices) <br />(emphasis added)</cite>
+
+> really hoping in new **iOS 12** they added web push notifications in Safari
+#PWA
+> <cite>[Irsyad Ilham (Jun 5, 2018)](https://twitter.com/_irsyadilham_/status/1003837872850362368?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> When is iOS Safari gonna get Web Push?
+> <cite>[@chendo (Jul 31, 2018)](https://twitter.com/chendo/status/1024165614577840129?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Hi! I've watched a Google IO keynote about the PWA and they've shown this table. Are Web Push & Notifications coming to Safari, even on iOS? Thanks for the answer!
+> <cite>[Thibault (May 9, 2018)](https://twitter.com/ThibB/status/994214627570569216?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Dear @Apple,
+>
+> Can you **please please please** enable push notifications for safari ios ?
+>
+> Sincerely yours, <br />
+> Alan, a #PWA developer.
+> <cite>[@AlanCrevon (Jun 28, 2018)](https://twitter.com/AlanCrevon/status/1011984630738759681?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> So sad that push notifications **are still not possible** in Safari for iOS 10.
+> <cite>[Boris Smus (Oct 9, 2016)](https://twitter.com/borismus/status/784917901945872384?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Hey @jonathandavis, Any plans to bring Web Push Notifications to iOS Safari?
+> <cite>[Diogo Cunha (Jun 26, 2018)](https://twitter.com/diffcunha/status/1011582721737383936?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> iOS Safari DOES NOT support push notifications. With macOS Safari will it support push notifications for WEB APPS?
+> <cite>[eon V Baravykas (Jun 16, 2016)](https://twitter.com/AussieVilkas/status/743239015143399425?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Apple should bring Safari push notifications to iOS.
+>
+> A much-needed bridge.
+> <cite>[George Papadakis (Jan 12, 2014)](https://twitter.com/phaistonian/status/422242877461106688?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Why **doesn't iOS allow push notifications** from Safari? #firstworldproblems
+> <cite>[Josh Manders (Nov 20, 2011)](https://twitter.com/joshmanders/status/137976204702658560?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I **guess still no Push Notifications** on iOS Safari, even proprietary ones
+> <cite>[Arthur Stolyar (Jun 6, 2017)](https://twitter.com/nekrtemplar/status/871825566999212033?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Anyone else find it odd that OS X is getting push notifications for Safari before iOS is?
+> <cite>[Dan Ryan (Jun 12, 2013)](https://twitter.com/dryan/status/344591918749069312?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> One more thing…noticed how Push notifications for safari was listed under iOS/OSX. Maybe well get push notifcations for mobilesafari at wwdc
+> <cite>[Constantin Jacob (Apr 27, 2014)](https://twitter.com/tzeejay/status/460303135022780418?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> Safari for iOS should support push notification…
+> <cite>[K̾a̾x̾i̾n̾g̾🛸 (May 21, 2011)](https://twitter.com/kaxing/status/71823217274261505?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A)</cite>
+
+> **Seeing a Web App I worked on used by *Apple* to justify that the Web is a viable platform on iOS is bullshit**
+>
+> The Web can be an ideal place to build apps but Apple is consistently dragging their heals on implementing the Web APIs that would allow them to compete with native apps
+> <cite>[Ada Rose Cannon (May, 2021)](https://twitter.com/AdaRoseCannon/status/1389642353472851970) <br />(emphasis added)</cite>
+
+  </div>
+</div>
+
+#### 5.8.2. Safari has been buggy for a long time
+
+> I'm always **amazed at the irriparable bugs Safari** on iOS yields due to its cutting corners whereever it can. **Thank you for being our new IE!**
+> <cite>[Christian Schaefer (Oct 10, 2017)](https://twitter.com/derSchepp/status/917668189592588288?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Severe two year old iOS Safari bug** with position:fixed that started in iOS 8, finally closed…
+> <cite>[Jeff Atwood (Jun 15, 2017)](https://twitter.com/codinghorror/status/875127338190503937?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> iOS safari bugs have **added 80 hours of work** to my current project - now I'm kinda fed up with it! But seems to have everything fixed now :-)
+> <cite>[Michael Vestergaard (Nov 5, 2016)](https://twitter.com/iltp/status/794535136645750789?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Can we all pause and reflect on the disgusting fact that Safari desktop still does not support HTML input type date? Every other modern browser does. **Safari iOS support is half baked with bugs** such as the default date being today even if the max attribute is set with a past date.
+> <cite>[Jayden Seric (Dec 12, 2018)](https://twitter.com/jaydenseric/status/1072649315397615616?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I 💓 bugs in Safari/iOS that **do not appear in any other browser incl. Safari/Desktop** and Safari/iOS Simulator. Great way to spend one's time.
+> <cite>[Manuel Strehl (Apr 26, 2017)](https://twitter.com/m_strehl/status/857186402261512192?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Safari for iOS sucks. 5 bugs on website only because of Safari**. It’s getting out of control. Still no good service worker implementation. Becoming new Internet Explorer in some time. 😭
+> <cite>[Dariusz Lorek (Oct 11, 2018)](https://twitter.com/dariuszlorek/status/1050176807272624130?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> But you will find lots of **iOS Safari-only bugs**, so… swings and roundabouts 😉
+> <cite>[Matt Stow (Sep 26, 2017)](https://twitter.com/stowball/status/912611092018323456?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Oh and we fixed those **crazy iOS layout bugs** (since Safari on iOS does not really respect viewport height. I mean, it does, but come on..)
+> <cite>[Clean Email (May 9, 2017)](https://twitter.com/clean_email/status/861767744919814144?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> iOS 12 introduced some nasty Safari bugs. **Safari is the new IE for developers**.
+> <cite>[Grant McCall (Sep 20, 2018)](https://twitter.com/grantmccall/status/1042542145612075008?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **I can't believe iOS Safari has such major bugs**. Showing cached pages unexpectedly all the time, like when opening a homescreen link
+> <cite>[Tom Bielecki (May 1, 2016)](https://twitter.com/tombielecki/status/726560977823526912?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+<div class="collapser">
+  <button class="action-button">Show more comments</button>
+  <div class="collapsed">
+
+> A number of issues C3 has in "Add to home screen" mode on iOS are Safari bugs. We report them **but Apple are very slow and opaque in dealing with them**. For example switching between Safari and web app loses all storage: [https://bugs.webkit.org/show_bug.cgi?id=181849](https://bugs.webkit.org/show_bug.cgi?id=181849)
+> <cite>[Ashley Gullen (Nov 3, 2018)](https://twitter.com/AshleyGullen/status/1058373005120860161?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Safari on iOS tends to ship with tons of bugs** (think of fixed position handling) that need version-specific workarounds. Don't take away our last straw for building something somewhat useable in Safari.
+> <cite>[Matthias Keller (Dec 21, 2017)](https://twitter.com/kellermatth/status/943812107358924800?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Calypso is so advanced it can’t even see into its own bewildered state. This is manifest in **the plague of interaction bugs on iOS Safari**.
+> <cite>[Ryan Boren (Aug 19, 2018)](https://twitter.com/rboren/status/1030832012469395456?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Alright, it should work now as far as I could test. **There are a lot of Safari & iOS bugs in WebGL**; I'm still grappling with some (and that on a Friday night!) :)
+> <cite>[David Lenaerts (Oct 6, 2018)](https://twitter.com/DerSchmale/status/1048291855589421057?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **We have to spend way too much time on Flexbox related iOS Safari bugs** each sprint, but I'm not sure what Safari version that is so you could be right about the "right now" part 😅
+> <cite>[Dillon de Voor (Apr 13, 2018)](https://twitter.com/CrocoDillon/status/984706727898644481?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I may or may not have **just spent 2hrs fixing a bug caused by iOS Safari being a piece of shit** and I may or may not have an entirely different opinion on this tomorrow okay thx bye.
+> <cite>[Scott (Dec 5, 2018)](https://twitter.com/scott_riley/status/1070051423860203520?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Thinking Webkit (Safari and Chrome for iOS) is on verge of becoming the new IE for developers: Brittle, cumbersome, and falling behind**.
+> <cite>[CK MacLeod (Jul 6, 2018)](https://twitter.com/CK_MacLeod/status/1014957101179797504?s=20&t=Pjt8d3GlAJzYPgdlQPbp5) <br />(emphasis added)</cite>
+
+> There was article about Chrome being the new IE and it makes a lot of valid points, but **to me, it's Safari on iOS**. It's such horseshit. <br />
+> #webdev <br />
+> [https://medium.com/@bdc/chrome-is-the-new-ie-1a21c1efc133](https://medium.com/@bdc/chrome-is-the-new-ie-1a21c1efc133)
+> <cite>[Longzero (Feb 16, 2018)](https://twitter.com/Longzero/status/964166488482631684?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Two major complains to @Apple. Safari is slow on adopting new JS/CSS APIs & iOS11 is too buggy. **Safari is new IE**, iOS is new Android.
+> <cite>[Ilya (Sep 23, 2017)](https://twitter.com/darasus_/status/911593652635488256?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Unfortunately, since Steve Jobs died, **we have the buggiest Safari starting from iOS 7**, completely denying the perfection which was set initially. <br />
+> [https://dzone.com/articles/safari-ios-7-and-html5](https://dzone.com/articles/safari-ios-7-and-html5)
+> <cite>[Brian Cannard (Nov 18, 2018)](https://twitter.com/briancannard/status/1063879561606098954?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Hey Apple, **please take some of your $180 billion cash reserves and fix Safari and iOS**. They are easily the buggiest modern OS and browser.
+> <cite>[Creative Logic (Apr 15, 2015)](https://twitter.com/creative_logic/status/588002875239899136?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> I think **Safari might be the buggiest app I currently run in OS X. Debugging an iOS device is almost unbearable**.
+> <cite>[George Crawford (Jun 27, 2014)](https://twitter.com/georgeocrawford/status/482515603211968513?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> "Bad news! **Apple iOS 7 is plagued with HTML5 bugs**" -InfoWorld (2013), "**This is the buggiest Safari version since**..." <br />
+> [http://fb.me/37BcJBuaK](http://fb.me/37BcJBuaK)
+> <cite>[Occupy HTML5 (Jan 5, 2014)](https://twitter.com/occupy_html5/status/419650316632850432?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> Apple has published just 10% of the necessary information for web developers, and I can say without fear of mistake that **this is the buggiest Safari version since 1.0**
+> <cite>[Maximiliano Firtman](https://firt.dev/ios-7) <br />(emphasis added)</cite>
+
+> Yo, @Apple, **Your new iOS is trash, especially safari. So many bugs**.
+>
+> Honestly, Apple has been going down hill since Jobs died.
+> <cite>[Sarah (Nov 30, 2020)](https://twitter.com/HvrdTimes/status/1333052218963062785?s=20&t=Pjt8d3GlAJzYPgdlQPbp5A) <br />(emphasis added)</cite>
+
+> **Everyone in my mentions saying Safari is the worst, it’s the new IE**… Can you point to specific bugs & missing support that frustrate you, inhibit you making websites/apps. Bonus points for links to tickets.
+>
+> Specifics we can fix. Vague hate is honestly super counterproductive.
+> <cite>[Jen Simmons (Apple Developer Relations) - Feb 9, 2022](https://twitter.com/jensimmons/status/1491064075987873792) <br />(emphasis added)</cite>
+
+> Hi @jensimmons - I'm a big fan of yours and your work (specifically CSS articles), but **I've been super-frustrated with Safari for the past few years** - thank you for asking for input. It is like the new IE, but not quite as bad. (cont'd)
+>
+> Part of the issue is that **it seems like the webkit bugzilla is a dead-end** - it seems like any info posted there just sits there, and may be sucked into another system, so the public view is radio silent. Here's one that I posted (still a bug):<br />
+> [https://t.co/048O9KTnBJ](https://t.co/048O9KTnBJ) <br />
+> … <br />
+> It also seems like **webkit (and webkit iOS) has just been understaffed**/not a priority for Apple. We're investing heavily in PWAs so our apps run on all platforms, **but PWA support on webkit has well-documented gaps**. For a small startup, we'll necessarily deprioritize iOS.
+> <cite>[John Crim (Feb 11, 2022)](https://twitter.com/johnwcrim/status/1491828595433836545?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> I can't point to specific bugs on this, **but I've all but given up on iOS support for my 3D engine** because out of every browser and OS I support, iOS Safari is the most trigger-happy when it comes to killing tabs for using "too much" memory. How much is too much?🤷‍♂️ wish I knew!
+> <cite>[James Baicoianu (Feb 9, 2022)](https://twitter.com/bai0/status/1491147591555645440?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> You want the truth? Okay
+>
+> Plugin support on Safari is trash since **you’re at the mercy of the awful App Store**, which is a nightmare to search and is lacking in support compared to Firefox and Chrome
+>
+> Webkit is also restricted for third parties so they can’t make any good web apps
+> <cite>[Dri Scaphandre (Feb 10, 2022)](https://twitter.com/Dr_Scaphandre/status/1491437615241109505?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> [https://bugs.webkit.org/show_bug.cgi?id=218012](https://bugs.webkit.org/show_bug.cgi?id=218012)
+>
+> including analysis and specific suggestion in comment 12. This is a hard problem for a web app obviously but 1.5+ years without traction... (**but a sleuth of other audio bugs, it is hard to keep them apart even at this point**)
+> <cite>[Philipp Hancke (Feb 9, 2022)](https://twitter.com/HCornflower/status/1491154421048573952?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> A lot of the hate comes from product decisions / forcing people to use Safari (on iOS), which you probably have no control over, so the hate shouldn’t be directed at you. **But it’s a browser that lags in features and fixes, gets updated less often, and is forced on users**.
+> <cite>[Matthew Dean (Feb 9, 2022)](https://twitter.com/MatthewDeaners/status/1491230548702142466?s=20&t=BJ4-YBnU8vDTCOGhQlpC0A) <br />(emphasis added)</cite>
+
+> Safari is quickly turning into the new IE.
+>
+> **20% of my time is spent writing hacky code apologizing for Safari's failures as a browser**
+>
+> In our project, we've just started the E2E testing phase on Safari
+>
+> I'm just trying my best to survive the imminent bug avalanche on Jira 🤮🤮
+> <cite>[Aurelian Lucius (Apr 13, 2022)](https://twitter.com/aurelian_lucius/status/1514174112314318849) <br />(emphasis added)</cite>
+
+  </div>
+</div>
+
+
+
+#### 5.8.3. News and Blog Articles
+
+Many have written about the issues surrounding Safari, Web Apps and iOS. This section goes through just a small number of articles.
+
+> First, it means that Dieter and I drink a lot of bourbon and talk about the sad, **slow death of the open web a lot**. (It was a good run, open web! So sorry that **Apple killed you** by turning Safari into the new IE and **forbidding alternative browsers to innovate on iOS**.)
+> <cite>[Nilay Patel - Editor-in-Chief - The Verge (Oct 6, 2016))](https://www.theverge.com/2016/10/6/13188306/refreshing-the-verge-facebook-video-google-amp-future-of-the-web) <br />(emphasis added)</cite>
+
+> Devices using iOS and the future Windows RT **hobble third-party browsers**. Despite some good reasons for doing so, the change could **undermine browser competition**. <br />
+> … <br />
+> On iOS devices, **Apple permits only its own version of the WebKit browser engine**. Technically other browsers besides Safari are allowed, but they must use Apple's technology for actually rendering Web pages. <br />
+> … <br />
+> Apple, though, gives its Safari browser privileges using Apple's WebKit browser engine that third-party apps from the App Store don't get.
+> <cite>[CNET Browser Choice - A thing of the Past? (May 23, 2012)](https://www.cnet.com/tech/services-and-software/browser-choice-a-thing-of-the-past/) <br />(emphasis added)</cite>
+
+> Firefox won't land on Apple's iOS until the fruity company relaxes its rules about third-party browsers, according to Jay Sullivan, vice president of product at Mozilla.
+>
+> Sullivan spoke on a panel at the SXSW music-and-tech-fest in Austin, Texas, over the weekend, and told the crowd **Apple's refusal to allow the installation of Mozilla's preferred Gecko rendering engine is an immovable obstacle to development of an iOS version of Firefox**.
+> <cite>[The Register (Mar 10, 2013)](https://www.theregister.com/2013/03/10/no_firefox_for_ios/) <br />(emphasis added)</cite>
+
+> I think there is a **general feeling among web developers that Safari is lagging behind the other browsers**, but when you go to a conference like EdgeConf, it really strikes you **just how wide the gap is**. All of the APIs I mentioned above are not implemented in Safari, and Apple has shown no public interest in them. <br />
+> … <br />
+> **Even when Apple does implement newer APIs, they often do it halfheartedly**. To take an example close to my heart, IndexedDB was proposed more than 5 years ago and has been available in IE, Firefox, and Chrome since 2012. Apple, on the other hand, didn’t release IndexedDB until mid-2014, and **when they did, they unveiled a bafflingly incompetent implementation that was so bad, it’s been universally derided as unusable**. <br />
+> … <br />
+> Now, after one year, Apple has fixed a whopping two bugs in IndexedDB (out of several), and they’ve publicly stated that they don’t find much value in working on it, because they don’t see “a huge use.” Well duh, nobody’s going to use IndexedDB if the browser support is completely broken. (Microsoft, I’m looking at you too.) <br />
+>
+> It’s **hard to get insight into why Apple is behaving this way. They never send anyone to web conferences**, their Surfin’ Safari blog is a shadow of its former self, and nobody knows what the next version of Safari will contain until that year’s WWDC. In a sense, **Apple is like Santa Claus, descending yearly to give us some much-anticipated presents, with no forewarning about which of our wishes he’ll grant this year. And frankly, the presents have been getting smaller and smaller lately**. <br />
+> … <br />
+> In recent years, Apple’s strategy towards the web can **most charitably be described as “benevolent neglect.”** Although performance has been improving significantly with JSCore and the new WKWebView, the emerging features of the web platform – offline storage, push notifications, and “installable” webapps – **have been notably absent on Safari**. <br />
+> … <br />
+> The tragedy here is that Apple hasn’t always been a web skeptic. As recently as 2010, back when Steve Jobs famously skewered Flash while declaring that HTML5 is the future, Apple was a fierce web partisan. <br />
+… <br />
+> Around that same time, when WebSQL was deprecated in favor of IndexedDB, you’ll even find mailing list arguments where **Apple employees vigorously defended WebSQL as a must for performant web applications**. Reading the debates, I sense a lot of bitterness from Apple after IndexedDB won out.
+> <cite>[Nolan Lawson - Safari is the New IE (Jan 2015)](https://nolanlawson.com/2015/06/30/safari-is-the-new-ie/) <br />(emphasis added)</cite>
+
+> **The real problem is Apple’s lack of browser-choice in iOS**, and that’s a problem for several reasons: <br />
+> … <br />
+> **It's limiting the browser-vendor competition on Apple’s iOS platfrom, as Apple are the only one allowed to innovate within the browser engine**. This for example means Google are limited to only compete on the UI-front in Chrome, and can’t bring new platform features, that already are available on other platforms, to iOS. <br />
+> <br />
+> As a vendor of dominant mobile operating system, Apple, should make a real browser choice possible in iOS in order to ensure fair competition and innovation. **Any other major operating system (Android, Windows, OSX, Linux) has a free browser choice, and iOS should be no different**. <br />
+> <br />
+> To me this this draws many parallels to the antitrust case against Microsoft back in the golden-era of Windows, as Safari is deeply integrated into iOS. It can't be removed or replaced. It's forcefully distributed by Apple, and is embedded inside native applications as WebViews. Since I’m not a lawyer, I don’t know if there exists similar legal reasoning as in the Microsoft case, but I do see the similarities when comparing the two.
+> <cite>[Safari isn’t the problem, but the lack of browser choice in iOS is - Kenneth Auchenberg (July 2015)](https://kenneth.io/post/safari-isnt-the-problem-but-the-lack-of-browser-choice-in-ios-is) <br />(emphasis added)</cite>
+
+> Bad PC software created the opportunity for the web to exist in the first place, **just as bad mobile web performance created the market for mobile apps**. <br />
+> … <br />
+> **But we can't fix the performance of Mobile Safari. Apple totally forbids other companies from developing alternative web rendering engines for the iPhone, so there's no competition** for better performance, **and no incentive for Apple to invest heavily in Safari development**. In many ways, Safari is the new Internet Explorer. <br />
+> … <br />
+> **That's a recipe for stagnation, and stagnation is what we have**. It's leading powerful players like Apple and Facebook to create ersatz copies of the web inside their walled gardens, when what we really need is a more powerful, more robust web.
+> <cite>[The mobile web sucks - Nilay Patel - Editor in Chief - The Verge ](https://www.theverge.com/2015/7/20/9002721/the-mobile-web-sucks) <br />(emphasis added)</cite>
+
+> But **Apple has a reason not to like this recycling of web technology**. It wants its **Mac App Store to be filled with apps that you can’t find anywhere else, not apps that are available on every platform**. <br />
+> … <br />
+> In a discussion on the programming community Github, several developers say rejections for apps that they built using Electron — which would were approved in the past. <br />
+> … <br />
+> **Apple has a history of stunting the web’s progress on its platforms**. On iOS, **Apple doesn’t allow fully independent third-party browsers**, requiring all apps to leverage its Safari browser when rendering web-based content. While browsers like Chrome and Opera are available in the App Store, they must use Apple’s Safari browser behind the scenes to render web pages, rather than their own. That means Apple has a monopoly on how iPhone and iPad users access the web. **To push developers toward building native apps on iOS rather than using web technologies, Apple ignores popular parts of the open web specification that other browsers implement, to its own benefit**.
+>
+> **Apple’s subtle, anti-competitive practices don’t look terrible in isolation, but together they form a clear strategy**.
+>
+> A technology called WebRTC, for example, allows video calling in a web browser without additional software. It powers tools like Google Meet. **But Apple was incredibly slow to implement the specification, leaving out key pieces of functionality, and the technology didn’t work when embedded inside apps**.
+>
+> **Apple also handicapped an emerging standard called Progressive Web Apps (PWAs)** — which, like Electron, allows developers to build native-like apps for both desktop and mobile — **by partially implementing it in a way that makes it too inconsistent to rely on. PWA doesn’t have the same problem if users open apps in Chrome or Firefox**, but iPhone and iPad users can’t install third-party browsers, which makes PWA-based technology a non-starter.
+>
+> **Developers use technologies like Electron and PWA because they allow for faster updates across platforms without an array of different codebases**. <br />
+> … <br />
+> **Apple’s subtle, anti-competitive practices don’t look terrible in isolation, but together they form a clear strategy: Make it so painful to build with web-based technology on Apple platforms that developers won’t bother**. <br />
+> … <br />
+> These types of changes may be made in the name of privacy or security, but the reality is that the argument looks weak when both users and developers simply don’t have a choice because Apple controls the platform, browser engine, and the distribution method. Regardless of your opinion of Electron app quality, choice is important. <br />
+> **Apple’s control over its app ecosystem is a new type of monopoly that’s hard to understand for lawmakers, and difficult for us to fight back against — because there simply isn’t a way out of these restrictions when the company controls both the distribution method and the platform itself**.
+> <cite>[Apple is Trying to Kill Web Technology - Owen Williams (November 2019) ](https://onezero.medium.com/apple-is-trying-to-kill-web-technology-a274237c174d) <br />(emphasis added)</cite>
+
+> **It's seemingly deliberate and about protecting App Store revenue**. <br />
+> … <br />
+> With IE now out of the way, the **distinction of ‘most-hated browser’ goes to Apple’s Safari** – which all along had been a close second to IE. <br />
+> … <br />
+> In a similar vein, **Safari has consistently lagged behind competing browsers in supporting modern web APIs and features**, presenting considerable challenges for developers wanting to create products that work consistently across all the major browsers (Chrome, Edge, Firefox, and Safari). <br />
+> … <br />
+> **Apple dragged their feet in adding support for PWAs in Safari**, and when they finally did, **limited the capabilities of a PWA so that native-like app functionality wouldn’t be possible, like notifications or a home screen icon shortcut – to name just a few of the many restrictions imposed by Apple**.
+>
+> But it goes beyond that. On **iOS, the only web rendering engine allowed is Apple’s own WebKit, which runs Safari**. Third-party iOS browsers such as Chrome can only use WebKit, not their own engines (as would be permitted in Windows, Android, or macOS). And it’s WebKit that governs PWA capabilities. <br />
+> … <br />
+> The reason for Apple’s self-imposed limitations on PWA-related web APIs? They’ll tell you they’re for user privacy reasons, which may be valid in certain cases. <br />
+> … <br />
+> **But most of us know the dominant reason is because fully-capable PWAs would compete against the iOS App Store – robbing Apple of 30% cut in revenue it rakes in when an app is purchased, or an in-app purchase is executed**. <br />
+> … <br />
+> **Web developers and engineers have long lamented about slow or lack of support of key web APIs and CSS features** that are commonly available with other browsers. <br />
+> … <br />
+> > Apple don’t give a f\*\*k about any modern APIs. PWA, streams, who the f\*\*k needs that? **Well, dear Apple, a f\*\*king lot of web devs need that nowadays**.
+> > <cite>Reddit User</cite>
+>
+> … <br />
+> Take WebRTC, for example. WebRTC is prominently used in video and audio communications over the web. It’s also used to send files, and share screen content.
+>
+> **Apple took years to finally add WebRTC support to Safari**, far enough behind Chrome and Firefox that it **practically became a running joke among developers** and even industry observers.
+>
+> Despite the support now available, **WebRTC is known to be buggier on Safari desktop compared to other browsers**. Developers have found it a mess to support in iOS that it’s practically not even worth the effort.<br />
+> … <br />
+> I often read about developers frustrated with the many bugs in Safari’s implementation of web APIs and CSS features, and in particular, the slowness of seeing them addressed.
+>
+> > **How are we supposed to keep up with this? Isn’t Apple one of the richest company in the world? Invest in your f\*\*king browser**.
+> > <cite>Reddit user</cite>
+>
+> … <br />
+> But not exactly surprising either, given that **Apple has staked its future on service-based revenue that includes sales generated from the App Store**.
+> <cite>[For developers, Apple’s Safari is crap and outdated - Perry Sun (July 2021)](https://blog.perrysun.com/2021/07/15/for-developers-safari-is-crap-and-outdated/) <br />(emphasis added)</cite>
+
+
+
+## 6. Negative Consequences for Consumers and Businesses
+
+It’s worth taking a moment to discuss why holding back the Web as an application platform, banning the rival browsers and having the iOS App Store be the only viable development platform on iOS is causing real harm to both consumers and businesses.
+
+
+
+### 6.1. Blocks the web from being an interoperable applications platform
+
+The Web could be an **interoperable platform** for applications on mobile devices but due to the lack of competition and key features being withheld it is incredibly hard (if not impossible) for them to compete with the App Stores. Safari has no competition from rival browsers on iOS. All the third-party browsers on iOS are essentially Safari (a specific Apple provided and mandated version of WebKit) under the hood. iOS Safari has a significant mobile web market share around the world (around 50% in the UK and the US, up to 75% in Japan). This is important as bugs and missing features in Safari can not be avoided (as all the browsers on iOS are Safari). Safari has many bugs and seriously lags behind its competitors' feature set.
+
+It's **hard for businesses to justify supporting features that 30-75% of their customers can't use**. This means if Safari doesn't support it then businesses don't want to use it. Additionally iPhone/iPad owners tend to be wealthier and spend more on software, businesses tend to follow revenue so Apple users have an outsized influence. This means that Apple's Browser Ban is not only holding web-apps back on iOS but also on Android.
+
+As a result many businesses feel obligated to reproduce their Web Apps as iOS Native Applications.
+
+
+
+### 6.2. Maintenance/Development Cost for Multi-Platform Applications
+
+Native iOS Apps have to be written in Apple created languages (Swift/Objective C) and system APIs that are specific to iOS. You can not run an iOS Application on an Android device (typically written in Java). Web Apps however only have to be written once, in one language and then can run on any device.
+
+In order to support multiple platforms for their application (without using Web Apps) a business will need to produce separate applications for iOS, Android and Windows. This typically involves expanding the team and having multiple code bases effectively multiplying the workload. Keeping multiple code bases in sync is also difficult and time consumer even for large businesses.
+
+This can increase by 2-5 times the development and maintenance cost. These costs must be passed onto consumers. For some smaller businesses it can cause the product not to be produced at all. Users also suffer lower quality applications because companies have to split their resources for developing and maintaining applications between two or three platforms, while they could have focused them on only one application.
+
+
+
+### 6.3. Small teams might be forced in iOS Exclusives
+
+Due to the cost mentioned in the previous section some small teams may decide to produce an iOS exclusive. This entrenches Apple’s lock-in and makes it harder for developers to reach a wider audience. Apple has a lot of leverage since iOS captures a significantly high amount of user time and attention, iOS users are wealthy and for businesses they represent an audience that cannot afford to under-serve. iOS is not an ecosystem that any developer is likely to be able to ignore.
+
+
+
+### 6.4. Gatekeeper Tax
+
+Additionally the business must then pay 15-30% of their revenue to Apple (further increasing costs by up-to another 44% for users).
+
+For example, imagine you require $10 per user to cover the costs of developing, publishing and maintaining an Application. The Application Store that you are selling your App in decides to add a 30% fee. In order to still receive $10, you now need to charge $14.2, which is a 42% price increase for the end user. However the actual price increase will be higher as when you increase the price by 42% you will lose a percentage of users as you move to a higher position on the demand curve, causing the equilibrium price to be even higher.
+
+
+
+### 6.5. Applications Banned on Apple’s whim
+
+> there’s no safety, security or privacy issue - Apple just doesn’t like those apps.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> It should not surprise you to know that Apple’s interpretation of its text often seems capricious at best and at worst seems like it’s motivated by self-dealing.
+> <cite>[Dieter Bohn - The Verge](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)</cite>
+
+Apple effectively [ban certain categories](https://www.theverge.com/2020/9/18/20912689/apple-cloud-gaming-streaming-xcloud-stadia-app-store-guidelines-rules) of Applications they don't like or that potentially [compete with their own offerings](https://www.theverge.com/2021/9/16/22676706/apple-watch-swipe-keyboard-flicktype-lawsuit-kosta-eleftheriou).
+
+
+
+### 6.6. App Store Review Process
+
+> there are endless horror stories around curation of the store. Apps are rejected in arbitrary, capricious, irrational and inconsistent ways, often for breaking completely unwritten rules.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> There's a lot of talk about the 30% tax that Apple takes from every app on the App Store. The time tax on their developers to deal with this unfriendly behemoth of a system is just as bad if not worse
+> <cite>[Samantha John - CEO Hopscotch](https://twitter.com/samj0hn/status/1431001795904561160)</cite>
+
+The App Store review process can be an extremely stressful and chaotic experience for businesses and developers despite problems with **actually [stopping malware](https://habr.com/en/post/580272/)**.
+
+
+### 6.7. Lawsuits and Criticisms
+
+Apple may choose to boot developers who sue or publicly criticize them. This can make publicly disagreeing with Apple scary, when they can snuff out your access to half your mobile users with little recourse.
+
+> Apple has blacklisted Epic Games from returning to its App Store ecosystem indefinitely despite the games developer saying it would disable its own payments system, according to a series of emails published on Twitter and a blog post by Epic CEO Tim Sweeney. <br />
+> … <br />
+> One of the published emails allegedly sent by Apple's legal representatives -- dated September 21 -- said the games developer's apps, such as its flagship game Fortnite, would not be allowed to return to the App Store until the US lawsuit was finalised.
+> <cite>[Campbell Kwan - ZDNet](https://www.zdnet.com/article/apple-bans-epic-games-from-app-store-until-all-litigation-is-finalised/)</cite>
+
+> In Sweatshop HD’s case, what is in fact a tasteful commentary aiming to raise awareness of modern-day manufacturing commissions through bright, addictive gameplay mechanics — in other words, an artistic statement — is being banned because Apple seemingly doesn’t want that awareness being raised.
+> <cite>[John Brownlee - Cult of Mac](https://www.cultofmac.com/220790/why-apples-reason-for-kicking-a-sweatshop-game-out-of-the-app-store-is-total-hypocrisy/)</cite>
+
+
+
+## 7. Apple's Incentives
+
+### 7.1. Advantages of the status quo for Apple
+
+> Apple gains a lot by slow-walking progressive web apps on the iPhone
+> <cite>[Russell Brandom - The Verge](https://www.theverge.com/2021/5/27/22454959/epic-apple-trial-recap-video-tim-cook-xbox-playstation-business#:~:text=APPLE%20GAINS%20A%20LOT%20BY%20SLOW-WALKING%20PROGRESSIVE%20WEB%20APPS%20ON%20THE%20IPHONE)</cite>
+
+Businesses that want to have applications on Apple mobile devices are forced to develop Apple native applications, which provides the following advantages to Apple:
+
+* **Business Lock-In** <br />
+Businesses have to go through the AppStore and provide Apple 15-30% of their revenue, which represents a significant share of Apple's revenue (estimated at [$64 billion in 2020](https://www.theverge.com/2021/1/8/22220873/apple-2020-app-store-revenue-60-billion-dollars)). Preventing Web Apps from being a viable alternative to native apps also allows Apple to maintain a high commission rate, as it is acknowledged in internal Apple emails that they are [unable to charge such an amount on other systems which have competition](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email) for their App Store. <br />
+Not only is iOS too large of a percentage of the mobile market to ignore, iOS users are typically more valuable because they spend more money. Combined with the high cost of developing a native app for iOS, development companies will often target iOS first and then only optionally build apps for other platforms **if they have the budget, expertise and staffing to do it**. <br />
+This gives Apple an advantage over competing mobile ecosystems by enriching its exclusive application ecosystem which it can then use to push sales of its mobile devices. Web Apps do not offer this lock-in because they work on all devices regardless of manufacturer and operating system.
+* **Consumer Lock-In** <br />
+They prevent Apple devices owners from switching to competitor mobile devices and operating systems as iOS Apps must be written for iOS. Many iOS apps never get rewritten for Android, so they are not available (It's very expensive to write the same App 2-3 times in different languages).
+* **Control** <br />
+Apple can **ban** categories of applications for no reason other than they don’t like them (game streaming for example). <sup>3</sup>
+* **Barriers to Entry** <br />
+They prevent the emergence of competing mobile operating systems, because many applications are only available on iOS and since they are not interoperable, emergent competitors have an insurmountable disadvantage since they don’t have access to a library of useful apps. This is arguably one of the biggest reasons **why Microsoft’s Windows Phone operating system failed** - Microsoft never managed to convince companies to invest in building and maintaining apps for yet another mobile operating system. Even a juggernaut like Microsoft was not able to break into the mobile operating systems market.
+* **Google Search Engine Revenue** <br />
+Apple have a $15B annual deal with Google to set Google as the default search engine on iOS Safari (9% of Apples Annual Gross Profit)
+* **Cost Cutting to boost margins on hardware** <br />
+By only allowing Safari to mint subprocesses Apple can save money on RAM <sup>4</sup>
+
+> <sup>3</sup> But some seem to be just personal preference, or taste - most obviously, the decision in the last few weeks to block streaming games services from Microsoft and Google. This may partly be about revenue, but the real issue seems to be that Apple thinks that games on iOS ’should’ use native APIs, and, perhaps, that they ‘should’ work without you needing to buy a separate games controller. But whatever it is, there’s no safety, security or privacy issue - Apple just doesn’t like those apps.
+>
+> One indication of Apple's control over developers is the fact they stay despite their many complaints.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)</cite>
+
+> <sup>4</sup> Re-using the WebKit binary maximizes the sharing of "code pages" across processes. Practically speaking, this allows more programs to run simultaneously without the need for Apple to add more RAM to their devices. This, in turn, pads Apple's (considerable) margins in the construction of phones
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2021/08/webkit-ios-deep-dive/#:~:text=re-using%20the%20webkit%20binary%20maximizes%20the%20sharing%20of%20%22code%20pages%22%20across%20processes.%20practically%20speaking%2C%20this%20allows%20more%20programs%20to%20run%20simultaneously%20without%20the%20need%20for%20apple%20to%20add%20more%20ram%20to%20their%20devices.%20this%2C%20in%20turn%2C%20pads%20apple%27s%20(considerable)%20margins%20in%20the%20construction%20of%20phones)</cite>
+
+
+
+### 7.2. Microtransactions and “Whales”
+
+Many have speculated that Safari's lack of funding and functionality is to protect App Store revenue. Apple’s marketing and legal teams push the ideas that it’s their thriving App Store marketplace and curation that brings income to developers as a justification for the 30% tax that is applied but then use privacy and security as reasons they need to block third-party App Stores.
+
+Despite Apple’s marketing claiming a thriving App Store marketplace it recently came to light in the Epic vs Apple trial that **72% of all App Store revenue** comes from **free to play games**.
+
+> 80% of that was from games, mostly in the US and north-east Asia, and mostly on iPhone. There’s no clear reason to think the proportions have changed much since then, except that China is probably bigger (Apple had only just added support for Alipay in 2016).
+>
+So, this is mostly games, and, from other disclosures, over 90% free-to-play.
+> <cite>[Benedict Evans - Technology Writer](https://www.ben-evans.com/benedictevans/2021/7/8/app-store)</cite>
+
+This would indicate that the majority of revenue comes from mobile gaming whales, which has **parallels with problematic gambling**.
+
+> A mobile gaming whale is someone who spends a lot of microtransactions. So-called “whales” are the main target for microtransactions in free-to-play games, for example; they're the ones who buy booster packs, cosmetics, etc. Tons of them.
+> <cite>[Mihovil Grguric - CEO of Udonis Inc (A mobile apps marketing agency)](https://www.blog.udonis.co/mobile-marketing/mobile-games/mobile-games-whales)</cite>
+
+Whether or not the motivation is to protect this revenue source, the browser ban and the current state of Safari is having profound negative effects. Apple hides behind security and privacy but [Apple does not even develop features which have no possible security or privacy concerns](https://httptoolkit.tech/blog/safari-is-killing-the-web/).
+
+All of this comes back to competition. Because Apple has effectively banned the competition, they are under no pressure to produce a competitive browser that might threaten the App Store monopoly. Despite Apple’s claim that the App Store provides security and privacy [others](https://www.theverge.com/2021/4/21/22385859/apple-app-store-scams-fraud-review-enforcement-top-grossing-kosta-eleftheriou) have found the review process to be [ineffective](https://www.forbes.com/sites/gordonkelly/2021/04/07/apple-iphone-ipad-app-store-scam-warning-new-iphone-problem/?sh=7231e8a960aa). Web Apps can often provide more security and privacy than their native counterparts.
+
+
+
+### 7.3. Apple’s Pattern of iOS App Store Favoritism
+
+Looking through Apple's actions in iOS and Safari/Webkit a clear pattern of iOS App Store favoritism vs the Open Web emerges. Specifically:
+
+* They [don't develop key features](https://infrequently.org/2021/04/progress-delayed/) Web Apps need to compete with the App Store
+* They have [banned the other browsers](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.), thus blocking any other company from providing these features
+* They have [hidden the installation process](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.9e2hl5xfy1mf) for Web Apps and [refused](https://bugs.webkit.org/show_bug.cgi?id=193959) to improve it
+* They have made [linking](https://9to5mac.com/2021/07/08/developers-will-be-able-to-integrate-app-clips-into-websites-as-a-full-screen-card-with-ios-15/) to and installing native apps from the web much more [fluid and easy](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners)
+* They have astonishingly been [secretly buying advertising](https://www.forbes.com/sites/johnkoetsier/2021/11/12/apple-quietly-buying-ads-via-google-for-high-value-subscription-apps-to-capture-app-publisher-revenue/?sh=67998df71b52) for other companies without permission, deep linking to these companies iOS App Store Offerings and redirecting millions of dollars from these companies to Apple
+
+Far from being an unbiased party, as the gatekeeper of iOS, Apple has a lot to lose if the Web becomes a viable platform vs the iOS App Store. Apple's iOS App Store generated [$41.5 billion](https://www.macrumors.com/2021/06/29/app-store-revenue-h1-2021-42-billion/) revenue globally in the first half of 2021, representing 22.1% growth compared to the same period last year. Currently Apple can extract a [15-30% tax](https://www.bloomberg.com/news/newsletters/2021-05-03/apple-s-30-fee-an-industry-standard-is-showing-cracks) on all App Store purchases and have complete control over what is offered on the App Store. They can ban [both categories of Applications](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores) they don't like and ones that potentially [compete with their own offerings](https://www.businessinsider.com.au/apple-arcade-xbox-stadia-blocked-gaming-services-iphone-app-store-2020-10?r=US&IR=T).
+
+Given all this you might wonder why they bother supporting Web Apps at all. First removing support for Web Apps would look really bad and immediately attract the attention of regulators worldwide, second while it is awkward/impossible for Web Apps to compete with Native they are not a significant threat and finally it has proven to be a useful regulatory/legal shield as shown [here](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf), [here](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) and [here](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple).
+
+It could be argued this is an overly conspiratorial view of how Apple's management team thinks but recently uncovered emails show Apple's line of thinking on another topic, iMessage:
+
+> The #1 most difficult [reason] to leave the Apple universe app is iMessage … iMessage amounts to serious lock-in
+> <cite>[Unnamed Apple Employee](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)</cite>
+
+> iMessage on Android would simply serve to remove [an] obstacle to iPhone families giving their kids Android phones … moving iMessage to Android will hurt us more than help us, this email illustrates why.
+> <cite>[Craig Federighi - Apple's Senior Vice President of Software Engineering](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)</cite>
+
+
+
+## 8. Arguments Against Third-Party Browsers
+
+To our knowledge Apple has never published a detailed defense on why they feel justified in banning all rival third-party browsers from iOS. That said, the following three sections contain arguments that others have made on Apple's behalf.
+
+
+
+### 8.1. The Chromium Argument
+
+There is an idea being advocated that allowing Apple to ban all other rival browsers from iOS is desirable as it stops Google from dictating the future of the web via decisions made in Chromium.
+
+> One proposed solution is to prevent operating systems from banning particular browser engines and/or browsers. However, since the majority of non-iOS browsers are based on Google’s Blink browser engine, the current chair of the HTTP Working Group Mark Nottingham submits that any requirement for Apple to allow third-party browser engines on iOS is likely to result in even greater usage of Google’s Blink and therefore ‘a further concentration of market power by Google'.
+> <cite>[ACCC – Digital Platform Services Enquiry (September 2021)](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20March%202021%20interim%20report.pdf)</cite>
+
+This needs to be broken down to identify whether that is true or not and that depends on:
+
+1. Does Google allow for good governance of the project?
+2. Is Google's governance of the project inclusive?
+3. Does it allow for dissenting opinions?
+4. Can Google leverage its control over governance to introduce features that further it’s own goals?
+5. Can Google slip in features against the wishes of the other browsers which they can’t remove?
+
+This particular defense of Apple's Browser Ban has three issues.
+
+First, this argument implicitly acknowledges that iOS Safari is sufficiently underpowered and buggy that given the choice users would immediately jump ship to a rival browser. It also assumes that with the advent of competition on iOS that Apple wouldn’t invest deeply to make up for the ground they have lost in Safari.
+
+Second, other browsers are allowed on MacOS and Safari still maintains a healthy share of 60.4%, calculated by using StatCounter’s 2021 Oct data by dividing [Safari's market share on desktop](https://gs.statcounter.com/browser-market-share/desktop/worldwide/#monthly-202010-202110) by [macOS' desktop share](https://gs.statcounter.com/os-market-share/desktop/worldwide/#monthly-202010-202110).
+
+Third, the counter argument is that Samsung, Edge, Brave, Opera etc all maintain soft forks of Chromium and can **disable features** they don't like with flags and **add any feature** they want directly on top. They can continue to pull in changes and updates from Chromium they do like. Should governance of the Chromium project become unhealthy, all of these participants retain the credible ability to hard-fork Chromium and Blink the way the Chrome team forked from WebKit, and how Apple forked WebKit from KHTML.
+
+This is **very different** to the iOS Webkit situation where a **very specific version of Webkit** is **forced** on third-party browser vendors. Browser makers have **no recourse to change** the engine feature set, not even to enable or disable features that are available in the source code from which WebKit on the device was built. The **inability to differentiate** effectively, even via soft fork, is a major step down in competition for iOS browsers. Beyond soft and hard forks, in a market with functioning browser choice, there is nothing stopping a third-party from creating their own browser from scratch (beyond development cost).
+
+There is already **direct competition** between the Chromium browsers and they are diverging in what they offer consumers.
+
+Any argument that Apple makes suggesting that the situation with Webkit is equivalent to the situation with Blink / Chromium because Webkit is also open source **is false**. When Browser Vendors use Chromium in their Browser on Android, they decide what features are included. On iOS, only Apple decides. It’s the software that runs on real users' devices that’s important.
+
+Edge, Opera, Brave and other browser makers **freely choose** Chromium as their engine, and have invested in integrating their differentiated features with it, and into its shared development via open-source contributions.
+
+Although Google by accounts does pay Igalia to contribute to Webkit to improve compatibility issues, in general browsers should not be seriously expected to contribute to another rival browser engine and ecosystem that is being forced onto them while having no control over how they can use it and which features, whether adding or removing or modifying, make it onto iOS.
+
+To imply that browsers can simply contribute to WebKit negates the fact that Apple has exclusive control over the Safari WebView on iOS. For browsers on iOS what makes it into WebKit is irrelevant, it’s what functionality that is available within the Safari Webview that's important.
+
+
+
+#### 8.1.1. Microsoft Differentiates Edge from Chrome
+
+For example this is a list of all the features that Microsoft have [removed or replaced](https://9to5google.com/2019/04/09/chromium-edge-browser-disables-google-services/) from Chromium in Edge:
+
+{% image
+  "/images/walled-gardens/34_microsoft-chrome-edge-differences.png",
+  "List of many browser features under the title 'Services we replaced or turned off'"
+%}
+
+Additionally **Brave** has **added many privacy features** into their browser. A [research study](https://www.zdnet.com/article/brave-deemed-most-private-browser-in-terms-of-phoning-home/) analyzing browser privacy by Professor Douglas J. Leith of the University of Dublin reported that **Brave had the highest level of privacy of the browsers tested**.
+
+There is even code being added to the Chromium project that Chrome will not use but other browsers using Chromium want. For example Edge ships the requestStorageAccess API that Safari defined for ITP. Chrome has no intention to ever ship it. Yet code for it [has landed](https://groups.google.com/a/chromium.org/g/blink-dev/c/e5fu5Q06ntA/m/UUqPuA8hEQAJ) in Chromium.
+
+If anything the situation is analogous to Linux on the server where many different versions of Linux compete with each other for market share based on their differing feature sets while still being based and soft-forked from the same underlying entirely free and open-source software.
+
+The [API owners](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/API_OWNERS) of Blink are the ones that can make decisions about what new features are included in the Browser’s main engine. 6 of these owners’s work for Google, but the other 3 work for separate companies (Igalia, Microsoft and Opera). This means that Google has shared the governance of their project with external parties with a fairly [transparent process](https://www.chromium.org/blink/guidelines/api-owners).
+
+Webkit by comparison has an opaque governance structure and it is not clear if anyone outside of Apple has decision making capability when it comes to the project.
+
+
+
+#### 8.1.2. Blink and Webkit - Two Sides of the same Coin?
+
+A second variation of this argument is that, as many browsers on Android are Chromium based (and thus use the Blink layout engine), the situation with Blink on Android and Webkit on iOS is similar. In other words: “Most browsers on Android are Chromium, so why is it a problem that all browsers on iOS are Safari/Webkit?”
+
+For now let's mostly ignore that completely different browser engines (i.e Gecko) are allowed on Android.
+
+The reality could not be more different.
+
+On iOS, third-party browsers:
+
+* Can't pick their own browser engine
+* Can't pick which version of Webkit they wish to us
+* Can't turn browser engine features on or off using flags
+* Can't add entirely new browser engine features
+* Can't edit browser engine features
+* Can't entirely remove browser engine features
+* Don't even get all the features of Webkit that iOS provides Safari
+* Get a more restricted version of Webkit than the one iOS provides Safari (Safari and the WebView that browsers use do not get the same level of access)
+* Use a version of Webkit provided that is tied to iOS system updates as opposed to packaged with the third-party browser
+
+On Android, third-party browsers:
+
+* Can use their own browser engine
+* Can pick which version of Blink they wish to use (if they are using Blink at all)
+* Can turn browser engine features on/off using flags
+* Can add entirely new features to Blink
+* Can edit existing features in Blink
+* Can completely remove features from Blink
+* Don’t have to use Blink at all
+
+On iOS, only Apple has final say on what the web can and can not do, Not users, third-party browsers or developers.
+
+{% image
+  "/images/walled-gardens/35_chrome-non-google-commit-chart.png",
+  "A line chart showing non-google contributions to chrome from 2016 to 2021, averaging around 20%"
+%}
+
+Percentage and Number of non-Google commits in Chromium over the past 5 years
+
+
+
+### 8.2. Security
+
+Apple argues that allowing third-party browsers will worsen security on iOS. The general pitch is that additional browser engines expand the iOS attack surface. If they bring even one security flaw with them, that is one more way for iOS users to be attacked. <sup>5</sup>
+
+Browsers are incredibly complex, and all browsers have bugs and security vulnerabilities. Not all security vulnerabilities are equal, and many discovered by developers and security researchers are patched before they are abused in the wild. Browsers can be thought of as mini-operating systems that sit atop traditional OSes. They are application platforms as well as tools for browsing the web. They are exceptionally powerful and need low-level system access that other apps do not (or should not). Browser bugs can be leveraged to gain access to the device by exploiting security flaws. It is likely that all browsers have and will continue to have security vulnerabilities.
+
+Browser Vendors must be committed to high levels of security investment, reasonable response times for fixing security holes, and should actively maintain their browsers. Google, Mozilla, Microsoft, Opera, Samsung, and others have good track records on security. They promptly patch security flaws and transparently publish what they have done. This give us confidence that they can be trusted with the same sort of low-level API access they enjoy on every other major OS.
+
+**We are not suggesting a free for all**. Indeed, we do not necessarily support expanded API access for non-browsers. What we suggest is that well-staffed and secure rival browsers with proven track records be allowed to compete on a level playing field. Competition on security has driven security innovation in browsers for 20+ years, and responsible vendors are heavily incentivised to fix security issues or lose market share.
+
+When thinking about browser security vulnerabilities it is important to note it's typically very difficult to use a browser exploit against a user **who does not use that browser**. This means that when thinking about security of a system, it needs to be viewed through the lens of what is the weighted average of the severity of vulnerabilities in all the browsers offered, not the sum. Adding a new browser to the system can only make the security worse if its security is worse than the average, even if it increases the total number of vulnerabilities of any given severity. This is important because if you have an operating system with only one browser and then you allow an additional 5 browsers (complete with their engines) the number of vulnerabilities that the "average user" is affected by doesn't change, provided each browser vendor does not have dramatically worse security.
+
+Security is a nuanced and difficult topic. Not all vulnerabilities have equal impact, and in modern browsers, vulnerabilities must often be chained to put users at risk. Simple counts of vulnerabilities are not particularly helpful when comparing browser vendors.
+
+Apple has justified their Webkit restriction by stating they can roll out security patches faster than other browser vendors and that their browser is more secure than rival browsers. In order to persuasively argue a need to ban all rivals, Apple would **need to prove** that iOS Safari **rolls out security patches faster**, has **significantly better security**, and that the harm to users from allowing rival browsers is **significantly worse** than the **harm caused by lack of competition**. Apple must further demonstrate that the risks inherent to a browser monoculture are not material. Users who fear they may be under attack have no alternatives available today, and Apple must show this is net beneficial.
+
+There is reason to believe Safari security is not better than the competition, nor does Safari roll out patches faster.
+
+<sup>5</sup> For now let's exclude intentional [jail-breaking](https://en.wikipedia.org/wiki/IOS_jailbreaking), as that is more of a problem for Apple than it is for their users.
+
+
+
+#### 8.2.1. Safari Users are Exposed for Longer
+
+Safari updates are tied to the operating system ([an antiquated practice](https://en.wikipedia.org/wiki/Internet_Explorer_9)). This means to update the browser, users have to update the entire operating system.
+
+According to the [metrics regarding bugs filed by Google’s Project Zero team](https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html), Safari is the slowest major engine to fix issues and is significantly slower than others as delivering fixes through software updates.
+
+{% image
+  "/images/walled-gardens/42_histogram-of-days-from-fix-landed-to-shipped.png",
+  "A histogram showing how many days it takes Chrome, Firefox and Safari to ship security fixes to users"
+%}
+
+iOS users remain vulnerable to known bugs in Safari longer than users of alternative browsers on every other OS. This picture is made even darker by OS update rates. Since Safari requires a full operating system update, further hassle (and attendant delay) is introduced in getting patches into user’s hands than if the browser updated like a “normal app” (the standard on all other modern OSes). Safari requires the user to update their entire operating system, a process that makes the **device unusable for up-to 20 minutes**.
+
+
+
+#### 8.2.2. Apple does not patch older versions of iOS
+
+Users perform operating system updates less often than application updates (which can happen silently). Additionally users may choose not to update to the next major operating system release ([i.e iOS 14 to iOS 15](https://www.intego.com/mac-security-blog/why-doesnt-apple-want-people-to-upgrade-to-ios-15/)) meaning they can miss out on vital security patches. Because Apple does not always back-port patches to older OS versions, users that fail to endure heavyweight OS updates can fall behind on browser security updates on iOS.
+Of vital importance to security is shortening the length of time between a vulnerability being discovered and being patched for the end user. This is referred to as patch gap.
+
+> Ideally, the window of time between a public patch and a stable release is as small as possible.
+> <cite>[Tim Becker - Security Researcher](https://blog.theori.io/research/webkit-type-confusion/)</cite>
+
+Older versions of iOS do not always get the security patches provided to the latest version. For example [this chart](https://twitter.com/theJoshMeister/status/1454023794578706433) (reproduced below) shows a list of patches (many of them for Webkit) available in iOS 15 and *if* they are available in iOS 14. It is important to note that Apple **has not communicated this information to users**. As users are unable to choose alternative browsers, they are left insecure without warning, even though their browser may be “up to date”.
+
+The article titled "Apple’s Poor Patching Policies Potentially Make Users’ Security and Privacy Precarious” goes [into more detail](https://www.intego.com/mac-security-blog/apples-poor-patching-policies-potentially-make-users-security-and-privacy-precarious/).
+
+Apple says it never intended iOS 14 security updates to last forever, whereas Firefox and Chrome support far older devices. Since Edge, Vivaldi and Brave are built on the same platform as Chrome, they are likely to be identical or very similar in terms of security.
+
+{% image
+  "/images/walled-gardens/36_safari-cve-list.png",
+  "A spreadsheet view of reported vulnerabilities in iOS",
+  "centered"
+%}
+
+
+
+#### 8.2.3. Browser Code Execution Vulnerabilities
+
+{% image
+  "/images/walled-gardens/43_browser-code-execution-vulnerabilities.png",
+  "A histogram showing the number of browser code execution vulnerabilities in Chrome. Firefox and Safari since 2014"
+%}
+
+Code execution vulnerabilities range in severity, and as previously noted, often require “exploit chains” of multiple bugs to use, meaning that raw numbers are not the full story. Regardless, they can help inform a fuller picture.
+
+We look at the publically available data regarding code execution bugs since [the Blink/Webkit fork](https://blog.chromium.org/2013/04/blink-rendering-engine-for-chromium.html). Examining the trends for [Safari](https://www.cvedetails.com/product/2935/Apple-Safari.html?vendor_id=49), [Chrome](https://www.cvedetails.com/product/15031/Google-Chrome.html?vendor_id=1224) and [Firefox](https://www.cvedetails.com/product/3264/Mozilla-Firefox.html?vendor_id=452), we see that **Safari suffered the most reported vulnerabilities** in every year save 2016. The graph above focuses on code execution vulnerabilities because these are the most serious category.
+
+While not a conclusive picture about relative security, this data brings into doubt Apple’s claims that it is significantly better than the competition:
+
+> Chrome/Brave/Firefox are required to use the default WebKit/JS [to run on iOS, making them merely skinned versions of Safari]. If Apple isn't going to put in the work necessary to protect users then they should let others do so.
+> <cite>[Paul Wagenseil - Tom’s Guide](https://www.tomsguide.com/opinion/your-iphone-is-less-safe-than-it-was-yesterday-and-thats-good)</cite>
+
+{% image
+  "/images/walled-gardens/44_browser-code-execution-vulnerabilities.png",
+  "A pie chart showing the ratio of browser code execution vulnerabilities between Chrome. Firefox and Safari since 2014"
+%}
+
+There are many caveats. First, the [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) database only includes vulnerabilities that are reported or named. Vendors may choose not to assign a CVE number to every vulnerability and there have been reports of security engineers who have complained that Apple hasn’t in the past.
+
+It is also possible that Apple’s platform may be under more scrutiny since Apple promotes itself as being security and privacy focused. Apple users also tend to be wealthier, adding to the potential value of an exploit to bad actors, incentivizing more investment by researchers.
+
+The more scrutiny a system recipes, the more likely vulnerabilities are to be found, so looking at bug counts is unreliable. Apple, however, is making extraordinary claims regarding browser security and so **the onus is on Apple to prove it**.
+
+
+
+#### 8.2.4. Apple has a Poor Relationship with External Security Experts
+
+The security of iPhones is one of Apple’s key marketing claims. According to [two dozen security researchers](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/) who spoke on the condition of anonymity, Facebook, Microsoft and Google publicize their programs and highlight security researchers who receive bounties in blog posts and leaderboards. They hold conferences and provide resources to encourage a broad international audience to participate. In contrast, Apple, already known for being tight-lipped, limits communication and feedback on why it chooses to pay or not pay for a bug, according to security researchers who have submitted bugs to the bounty program.
+
+Apple reportedly has a considerable bug backlog:
+
+> You have to have a healthy internal bug fixing mechanism before you can attempt to have a healthy bug vulnerability disclosure program. What do you expect is going to happen if they report a bug that you already knew about but haven’t fixed? Or if they report something that takes you 500 days to fix it?
+> <cite>[Moussouris - Helped create Microsoft's Bug Bounty Program](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> It seems like Apple thinks people reporting bugs are annoying and they want to discourage people from doing so
+> <cite>[Tian Zhang - an iOS software engineer](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> Apple’s closed-off approach hinders its security efforts
+> <cite>[Dave Aitel - co-author of “The Hacker’s Handbook](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> To me, the bigger takeaway is that Apple is shipping iOS with known bugs, And that security researchers are so frustrated by the Apple Bug Bounty program they are literally giving up on it, turning down (potential) money, to post free bugs online. It's not that Apple doesn't have resources or money to fix this, Clearly it's just not a priority to them.
+> <cite>[Patrick Wardle - Security Expert](https://www.theregister.com/2020/07/01/apple_macos_privacy_bypass/)</cite>
+
+> Apple is slow to fix reported bugs and does not always pay hackers what they believe they’re owed. Ultimately, they say, Apple’s insular culture has hurt the program and created a blind spot on security.
+> <cite>[Reed Albergotti - Washington Post](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)</cite>
+
+> I want to share my frustrating experience participating in Apple Security Bounty program. I've reported four 0-day vulnerabilities this year between March 10 and May 4, as of now three of them are still present in the latest iOS version (15.0) and one was fixed in 14.7, but Apple decided to cover it up and not list it on the security content page. When I confronted them, they apologized, assured me it happened due to a processing issue and promised to list it on the security content page of the next update. There were three releases since then and they broke their promise each time.
+> <cite>[Denis Tokarev](https://habr.com/en/post/579714/)</cite>
+
+
+
+#### 8.2.5. Every other OS can manage to allow competing browser Engines
+
+Finally, **every other OS** in wide use – including Windows, ChromeOS, Android, Linux, and Apple’s own macOS, – **allow competing browser engines** while remaining secure. Surely Apple can find alternative measures to remain secure without banning the competition.
+
+
+
+#### 8.2.6. Summary
+
+Based on the information above Apple:
+
+1. Has the longest delay in patching vulnerabilities
+2. Experiences the largest number of code execution vulnerabilities
+3. Doesn’t patch vulnerabilities in their browser for older versions of iOS
+4. Has a poor relationship with external security experts
+
+It is hard to argue that iOS Safari **even matches the security of other major rival browser vendors**. It is impossible in our view for Apple to argue that iOS Safari's security advantage over other vendors is so extreme that it justifies the clear anti-competitive practice of simply banning the competition, considering the negative externalities that it imposes on consumers.
+
+
+
+### 8.3. Privacy
+
+Apple could argue that it can not allow third-party browsers (complete with their own engines) because they will [provide users with functionality](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.u5ygilw20uu2) that Apple believes only Native Apps should have.
+
+Apple's public position on denying these APIs is that they could be used to fingerprint the user. As is extensively argued in <!-- TODO --> [this section](#), Apple's position is wildly inconsistent between Web and Native. There is a strong case that the current protections in other browsers for these features are far stronger than the ones Apple provides for analogous Native features.
+
+Additionally Apple astonishingly holds this position while providing its own [opt-in fingerprinting solution to Native Apps](https://docs.google.com/document/d/1SoamKhuJD6wKgwFUJcyr6nJCeIislqsIM-f0Ytikepo/edit#heading=h.zhli1xk46625) and poorly policing when users who reject being tracked are ignored.
+
+
+
+#### 8.3.1. Native vs the Web
+
+Apple is not doing enough to protect user’s privacy in native apps while at the same time stifling Browsers and Web Apps.
+
+Tracking is far more pervasive and allowed in native than it is on the web. Privacy is incredibly important for users and more needs to be done especially on the native ecosystems however it should not be used as a tool to defend against competition.
+
+> By now you probably know that your apps ask for permission to tap into loads of data. They **request device information, like advertiser IDs**, which companies use to build marketing profiles.
+>
+> **you’re also exposing your sensitive information to dozens** of other technology companies, ad networks, data brokers and aggregators
+>
+> And **every app is potentially leaking data to five or 10 other apps**. Every S.D.K. is taking your data and doing something different — combining it with other data to learn more about you. It’s happening even if the company says we don’t share data. Because they’re not technically sharing it; the S.D.K. is just pulling it out. Nobody has any privacy.
+> <cite>[Charlie Warzel - New York Times](https://www.nytimes.com/2019/09/24/opinion/facebook-google-apps-data.html) <br />(emphasis added)</cite>
+
+> The simple fact is, the data you give to apps powers a massive economy worth hundreds of billions of dollars, which is hundreds of billions of reasons for it not to change — until and unless it’s forced to.
+> <cite>[Sara Morrison - VOX](https://www.vox.com/platform/amp/recode/22587248/grindr-app-location-data-outed-priest-jeffrey-burrill-pillar-data-harvesting) <br />(emphasis added)</cite>
+
+> But this is only the tip of the iceberg. Now the app stores should take the next step: ban SDKs from any data brokers that collect and sell our location information.
+>
+> There is no good reason for apps to collect and sell location data, especially when users have no way of knowing how that data will be used. We implore Apple and Google to end this seedy industry, and make it clear that location data brokers are not welcome on their app stores
+> <cite>[Bennett Cyphers - Electronic Freedom Foundation](https://www.eff.org/deeplinks/2020/06/apples-response-hey-showcases-whats-most-broken-about-apple-app-store)</cite>
+
+Apple is wildly inconsistent in how it approaches privacy on Native and on the Web. Apple is very happy to take measures that break functionality for the Web that they would never even consider for Native Apps (i.e completely removing bluetooth). Additionally Native Apps have comparably weak permissioning compared to that provided by browsers. Finally Apple provides its own opt-in fingerprinting solution for Native Apps for the purpose of advertising.
+
+Apple's commitment to privacy on the web is admirable but the uneven enforcement between the iOS App Store where they command a 15-30% tax and the Web where they have none **implies that it is simply a tactical tool to block competition**.
+
+
+
+## 9. The Web Can Be Capable
+
+> The fact that web apps aren’t able to fully compete with iOS apps **is an Apple problem, not a web problem**
+> <cite>[Richard MacManus - NewsStack](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation/) <br />(emphasis added)</cite>
+
+
+
+### 9.1. Photoshop
+
+Using various new standardized web technologies, Adobe has now brought a public beta of [Photoshop to the web](https://web.dev/ps-on-the-web/).
+
+It’s important to note that Adobe did not rebuild Photoshop from scratch. This is real photoshop using their 31 year old code-base along with its decades of investment.
+
+{% image
+  "/images/walled-gardens/37_photoshop-on-web.png",
+  "A screenshot of Photoshop running in a web-browser, featuring a happy looking elephant"
+%}
+
+> The simple power of a URL is that anyone can click it and instantly access it. All you need is a browser. There is no need to install an application or worry about what operating system you are running on. For web applications, that means users can have access to the application and their documents and comments. This makes the web the ideal collaboration platform, something that is becoming more and more essential to creative and marketing teams.
+> <cite>[web.dev](https://web.dev/ps-on-the-web/#:~:text=The%20simple%20power%20of%20a%20URL%20is%20that%20anyone%20can%20click%20it%20and%20instantly%20access%20it.%20All%20you%20need%20is%20a%20browser.)</cite>
+
+This was made possible by a few web standards:
+
+
+
+#### 9.1.1. WebAssembly
+
+[WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is a new type of code that can be run in modern web browsers — it is a low-level assembly-like language with a compact binary format that runs with near-native performance and provides languages such as C/C++, C# and Rust with a compilation target so that they can run on the web. It is also designed to run alongside JavaScript, allowing both to work together.
+
+Using this Photoshop was able to get their decades of C++ code and port it into a sandboxed environment for their Web App.
+
+
+
+#### 9.1.2. WebGL and WebGL2
+
+[WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API) is a JavaScript API for rendering high-performance interactive 3D and 2D graphics. Photoshop needed this to deliver competitive performance for its image compositing system.
+
+
+
+#### 9.1.3. SIMD Instructions
+
+This is a [specialized instruction set](https://developer.mozilla.org/en-US/docs/Glossary/SIMD) that can improve performance for certain types of parallel code. For Photoshop SIMD provides a 3–4× speedup on average and in some cases a 80–160× speedup.
+
+
+
+#### 9.1.4. File System Access API - Private File System
+
+Given how large Photoshop documents can be, Photoshop needs the ability to dynamically move data from on-disk to memory as a user pans around. This new [origin trial](https://web.dev/file-system-access/#accessing-files-optimized-for-performance-from-the-origin-private-file-system) allowed Photoshop to have a high performant private file system that it could access via the API. This allows competitive performance on a wide range of devices.
+
+Photoshop’s reputation as a demanding application demonstrates that nearly any sort of program can be delivered today as a Web App on a capable browser. Given the speed of progress in the best browsers, it’s hard to imagine that the gap between Native and Web in terms of performance/capability will not continue to shrink.
+
+## 10. The Future of the Web
+
+If effective competition was restored to the mobile web then the advantages to users are:
+
+**Considerably lower development and maintenance costs**
+
+Being able to develop a single interoperable application and deploy it to 5 operating systems simultaneously reduces costs by potentially 2-5 times, perhaps more when the costs of waiting for each app store to approve updates are factored in. Maintaining multiple code bases in different languages and navigating the rules of multiple app stores is expensive and time consuming.
+In a well functioning market, these savings should be passed on to users.
+
+**Higher quality**
+
+Less time wasted on duplicated code and keeping different versions of the code base in sync means more time can be focused on quality. This is doubly true for important concerns like accessibility and security reviews which tend to require specialist attention. Concentrating the attention of development teams on a single codebase has a positive effect on these attributes.
+
+**Interoperability**
+
+The same applications, running from the same codebase, deployed the same way can become the norm for mobile application development the way it has been on the desktop for nearly a decade, powered by the web.
+
+**Reduced Lock-In**
+
+If more applications are cross platform then users have less tying them to a particular OS or hardware vendor. Application portability reduces friction between moving OSs and improves competition in that space too.
+
+**More private and secure**
+
+Browsers are heavily sandboxed and historically place less trust in Web Apps than native platforms grant to apps by default. Web APIs, unlike their Native App counterparts, have a long track record of giving as little access as necessary, requiring direct user permission for access to powerful or dangerous capabilities, and deploying anti-abuse mitigations faster than the pace of OS patch uptake.
+
+**Lower platform taxes for commodity capabilities**
+
+If Web Apps were allowed to compete effectively, enormous pressure would be placed on platform taxes for the large majority of applications that do not require truly proprietary or exclusive functionality not available on other devices.
+
+With effective competition App Stores would only be able to charge a tax proportional to the value (in terms of review, cataloging, payment processing, and access to unique hardware) that users perceive they provide. It is unlikely that in this future Apple would have enough market power to maintain a 30% tax, something akin to VISA or Mastercards 2-3% is more likely.
+
+**A level playing field for small developers**
+
+Developing for multiple platforms in different languages almost immediately necessitates larger teams making life difficult if not impossible for smaller developers to provide cross platform support. This reduces the number of firms that can produce and market software effectively.
+
+**More innovation**
+
+Lowering the cost of development allows more market participants and experimentation, leading to increased innovation.
+
+
+
+### 10.1. Multiple Competing Browsers
+
+If Apple allowed multiple rival browsers (complete with their engines) then iOS could actually have browser competition. Having multiple browsers competing on a platform is desirable. Competition is what drives improvements in utility, performance, privacy and security. iOS Safari currently faces almost no competitive pressure.
+
+Apple will likely make arguments that their Safari browser is more privacy focused than other browsers but competition will make the web more private, not less. Browsers, like for example Brave and Firefox could compete on which is the most private. Users not Apple can make decisions on the trade offs between utility, performance, privacy and security. Browsers are by default considerably more private, sandboxed and secure than Native Apps.
+
+Chrome, Edge, Opera, Brave and Samsung Browser are not the same despite being all based on Chromium. They are competing to differentiate themselves in utility, performance, privacy and security on top of a shared underlying open source and free codebase.
+
+Competitive pressure will force iOS Safari to improve or if it doesn't, offer users recourse to switch to alternate browsers. This would provide Apple the incentive to keep pace with the other browsers and give consumers a means of voting with their feet by moving to a competing browser if they fail to do so.
+
+Competition is what drivers innovation and delivers the most value to consumers.
+
+
+
+### 10.2. Competing App Stores without Sacrificing User Safety
+
+There is a [proposed specification](https://m.youtube.com/watch?v=FtVhbLya49w) called the [Web Install API](https://github.com/PEConn/web-install-explainer/blob/main/explainer.md) to allow Web Apps to install other Web Apps (via browser prompts and user interaction). No capability beyond the APIs needed for competing browsers to install PWAs to an OS (currently a private API that Apple does not expose to competing browsers on iOS) are needed.
+
+This is important for two reasons. First, it allows developers to produce installable App Stores that are themselves Web Apps, and therefore safe and secure by default. Also, it would allow companies to offer collections (“suites”) of Web Apps that are seperate products on separate domains; for example, Adobe’s Creative Cloud Suite (Photoshop, Illustrator, Lightroom, Spark, Fonts, etc.).
+
+This specification is at a very early stage, but we believe that in the long term this feature will greatly enhance Web Apps ability to compete with NativeApps. This adds vital functionality to Web Apps in terms of an alternate system to the gatekeepers App Store of user reviews, trust, cataloging and potentially payment.
+
+Ensuring that APIs are made available to competing browsers to facilitate this open, interoperable future should be a goal of regulatory oversight because, unlike sideloading of native apps, it charts a safe and secure middle-way for true competition, low developer taxes, and improved interoperability for users.
+
+{% image
+  "/images/walled-gardens/38_proxx-install-example.png",
+  "A screenshot of the prox.app website on an Android device, with an install banner at the top of the view",
+  "centered"
+%}
+
+
+
+### 10.3. Web App / Native App Feature Parity
+
+For the web to truly provide effective competition to native App Stores the browsers need access to various system APIs to be able to provide feature parity.
+
+For chat and social applications:
+
+* Screen Wakelock
+* Push Notifications and Unread Count badging
+* Stable (non buggy) webRTC
+
+For applications that need to communicate with users devices:
+
+* Web Bluetooth
+* Web USB
+* Web MIDI
+* Web Serial
+
+For gaming and other graphic intensive applications:
+
+* Fullscreen API for `<canvas>` and other non-`<video>` elements
+* WASM Threads, Shared Array Buffers, and SIMD
+* WebXR
+* Offscreen Canvas
+* WebGPU (arriving in other engines this year)
+
+
+
+#### 10.3.1. Integrated Web App Permissions
+
+Finally to make the experience truly equivalent and to enable users to sensibly manage security and permissions, users need per an installed Web App permissioning built into the operating system. Permissions that are exclusive to browsers (i.e. don’t have an Native App equivalent) can be handled by a webview to the browser that installed the application, alternatively each browser could provide an implementation of this page to the OS.
+
+Example of iOS permission settings screen:
+
+{% image
+  "/images/walled-gardens/39_ios-permission-settings.png",
+  "A view of the iOS permission settings screen for WeChat showing toggles for many iOS features",
+  "screenshot", null,
+  [150, 200, 300],
+  "150px"
+%}
+
+
+
+## 11. Potential Regulatory Solutions
+
+To bring effective competition to both browsers on iOS and to allow Web Apps to effectively compete with the App Store (as Apple has suggested they can), regulation should mandate opening up iOS to true third-party browsers, complete with their own engines.
+
+Further, Apple should be prohibited from enforcing restrictions that would prevent competing engines from delivering Web Apps at feature parity with Native Apps. Regulation should provide for prudent privacy and security considerations to be handled in arbitration should parties not be able to come to speedy agreement.
+
+
+
+### 11.1. Mandating iOS Safari support specific standards is the wrong approach
+
+Web Standards evolve quickly, spurred on by competing browser makers working with developers. This involves collaboration in standards bodies to improve compatibility, however if each Browser vendor had to wait until there was complete agreement between every vendor for each of the various standards (and each standards body operates differently), it would be possible for a vendor (e.g. Apple) to game these processes especially in areas where they have an outsized influence to prevent the progression of these standards.
+
+Typically, cutting edge features are deployed by browser makers in their **own engines first**, then, using real world feedback over several years, eventual standards are created. No feature starts out as a web standard.
+
+> Web Standards are voluntary. The force that most powerfully compels their adoption is competition, rather than regulation. This is an inherent property of modern browsers. Vendors participate in standards processes not because they need anyone else to tell them what to do, and not because they are somehow subject to the dictates of standards bodies, but rather to learn from developers and find agreement with competitors in a problem space where compatibility returns outsized gains
+> <cite>[Alex Russell - Program Manager on Microsoft Edge](https://infrequently.org/2020/07/why-ui-isnt-specified/)</cite>
+
+No one can predict what web technologies will be important in the future, and disagreements between browser makers on the exact path forward are reasonable and expected. It is very difficult, if not impossible for regulators to predict which standards will be the most important and what their exact definition will end up being. It's a subtle and complex topic.
+
+So rather than (as a regulator) mandating that a gatekeeper must support a particular web standard, a better approach is regulating to enable effective competition on the gatekeepers operating systems **both between rival browsers** and **between Web Apps and Native Apps**. Then allow market forces to push forward the changes (new web standards) most beneficial to end users.
+
+
+
+### 11.2. Predicted Response from Apple
+
+Apple on their iOS platform, has a strong incentive to not allow Third-Party Browsers or capable Web Apps on iOS as this would:
+
+1. Allow open competition with the App Store where Apple currently receives between 15% - 30% of the all revenue.
+2. It would endanger their [15 billion USD](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/) dollar search deal with Google Search (9% of Apple’s 2020 Gross Profit).
+3. Reduce developer lock-in to Apple’s ecosystem as Web Apps are interoperable with other manufacturers devices and reduce the number of developers that are only exclusively targeting iOS as a platform.
+4. Reduce user lock-in to their ecosystem as users could migrate with their apps and data to other devices which also supported the apps they use.
+
+This is covered in more detail in [this section](#apple's-incentives).
+
+Apple is incentivized to use security and privacy as roadblocks to competition including to block Third-Party Browsers, Web Apps and their capabilities. These roadblocks could be spurious and either offer no or exceptionally limited privacy or security benefits to users while depriving them of useful functionality.
+
+When there are privacy or security issues, there could also be mitigations that would allow use of the feature while minimizing any privacy or security issues. Unfortunately due to the highly technical nature of the platform it is possible to present convincing but spurious arguments as a shield to protect against competition, especially if you have a high budget to spend on lobbying. ​​There is a joke doing the rounds of the developer community that Apple has more lobbyists working to prevent competition for the iOS App Store than they have developers working on Safari/Webkit.
+
+> “Apple has been able to intimidate and use a lot of money” to kill legislation
+> <cite>[Arizona Rep. Regina Cobb](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299)</cite>
+
+It is expected that Apple [will fight hard](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299) against these changes as they are likely to dramatically increase competition, affect their Search Engine revenue and curtail their control of the iOS app market, so it is important to break down any argument and separate Apple’s concerns into individual components and address them individually.
+
+
+
+### 11.3. Legitimate Issues
+
+There are legitimate privacy, security, spam, and app quality concerns that gatekeepers will have and these need to be addressed.
+
+The gatekeeper should be able to enforce proportional policies that address these concerns while still enabling open competition between browsers and between proprietary Native Apps and open Web Apps.
+
+
+
+#### 11.3.1. Security
+
+Browsers are complex applications, and all browsers have bugs and security vulnerabilities. Not all security vulnerabilities are equal, and many are discovered and patched before they are abused in the wild.
+
+Browsers can be thought of as mini-operating systems, an application platform as well as a tool for browsing the web. They are very powerful and as such need low-level system access and privileges that no other app on iOS currently receives.
+
+It is important to recognize that browsers can be leveraged to gain access to the device by using security flaws. It is likely that all browsers have and will continue to have security vulnerabilities.
+
+Browser Vendors should be committed to maintaining high security in their browsers, reasonable response times for fixing security holes and should continue active maintenance of their browser. If it can be shown that a Browser Vendor is not providing reasonable efforts to keep their browser secure then the gatekeeper should be allowed to either remove privileges from that browser or remove the browser from their platform.
+
+The gatekeeper should either have to apply to the regulator to have a browser removed OR a browser should be able to appeal removal to the regulator.
+
+
+
+#### 11.3.2. Privacy
+
+User’s should be able to make decisions and choices which include tradeoffs between security, privacy and utility.
+
+Apple, despite their marketing, arguably does not have the “most” private browser and other browsers could offer more privacy than Safari if they had access to the technology to make that possible. Brave is one example, which is built on top of chromium (blink, the same engine Chrome and Edge use), has extensive privacy features and ad-blocking built in.
+
+Enabling particular functionality may in some cases lead to potentially less privacy but more utility, and it’s important that users are allowed to make these judgements and trade-offs by switching their browser.
+
+
+
+#### 11.3.3. Ignoring User Settings / Preferences
+
+The third-party browser might ignore user settings such as parental controls or block lists. It is our opinion that browsers should as much as reasonably possible respect the wishes of the user as expressed through Operating System settings, and that Operating System setting should be available to those browsers through reliable, stable, public APIs.
+
+
+
+#### 11.3.4. Ignore certain privacy and security policies
+
+A user may have applied specific privacy and security policies that they would like enforced. A third-party browser could choose to ignore these preferences or enact stricter preferences as set via their own settings surfaces.
+
+
+
+#### 11.3.5. Abandoned Browsers
+
+A third-party browser may be abandoned by its developer and no longer updated. This means that the browser would no longer get timely security updates. Operating Systems should be within their rights to disable or remove such browsers from wide circulation to protect users.
+
+Regulators should provide enforcement oversight of these mechanisms to ensure they are not abused by Gatekeepers.
+
+
+
+#### 11.3.6. Low Effort Spam Browser
+
+A company could simply package up another browser engine, add functionality to spam users or collect private data.
+
+**Note:** Windows, macOS, Android and Linux already allow Third-Party Browsers and Web Apps. Note that Android has yet to make it easy for third-party browsers to deploy Web Apps properly (specifically because the interface to [mint WebAPKs](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583) are private APIs and are not exposed to competitors).
+
+
+
+### 11.4. Balancing the need for competition with Security/Privacy
+
+The way to address each of these issues is for the Gatekeeper to mandate browser engine choice, open access to private APIs, and require publicly publish extensive documentation for the responsibilities of the Third-Party Browsers with regards to security and privacy.
+
+All rules must be narrow in scope and based on the expectations set by the Gatekeeper’s own Browser or Applications.
+
+Third-Party Browsers that do not abide by these rules can be removed, with appeals to regulatory oversight mechanisms set forth publicly by competent authorities.
+
+*Please note that the authors are software experts not lawyers. We simply want to convey the intent, structure and content of potential regulation.*
+
+
+
+### 11.5. REGULATION
+
+In all aspects of regulatory oversight, we envision that regulators continue to be involved deeply in the enforcement of rules that accompany findings of fact from these enquiries. Such oversight might create mechanisms of appeal for competitors, hands-on regulatory intervention in day-to-day rule-change proposals by Gatekeepers, or mechanisms for statutory relief. We don’t presume to know the correct mix of these remedies, but the goals of enforcement are more clear.
+
+**Gatekeepers should:**
+
+1. Not block the **installation** of **Third-Party Browsers**
+2. Not prevent or restrict Third-Party Browsers from their choice of a Javascript Engine (for example Nitro, V8) or Layout Engine (for example Blink, Gecko, Webkit) <sup>6</sup>
+3. Not block **updates** to **Third-Party Browsers**
+4. Allow Third-Party Browsers to **install** and **manage Web Apps**
+5. **Not limit the capabilities** of Third-Party Browsers and Web Apps and should provide access to relevant device and operating system APIs. Browsers and Web Apps should not be restricted by the operating system from accessing any feature that is provided to the gatekeeper's own browser, native apps or system apps.
+6. Provide users with equivalent ability to manage Web Apps through **system settings** provided for Native Apps, regardless of which Browser installed them.
+7. Provide an easy to use mechanism for users to set their desired **default browser** and should respect this choice in the operating system and their own applications
+
+**Limitations on Third-Party Browsers:**
+
+1. The Gatekeeper can mandate and publish **narrow scope** and **proportional** security/privacy policies for Third-Party Browsers and Web Apps with regulator approval.
+2. All restrictions relating to Third-Party Browsers and Web Apps including those for security and privacy must be individually approved by the regulator.
+3. All restrictions placed on Third-Party Browsers must be publicly documented. Confidential or Secret restrictions should be prohibited.
+4. Proposed changes to these policies must be published and approved by the regulator.
+5. These policies must be in the interest of the **end user**.
+6. These policies can not **inhibit capabilities** of the Third-Party Browser or Web App from the perspective of the end user.
+7. The Gatekeeper must produce documentation for these policies which:
+    1. are thorough;
+    2. contain a high level of technical detail explaining both the need for these policies and exactly what they mean.
+8. These policies and their associated documentation must be made public. Confidential or secret restrictions should be prohibited.
+9. The Gatekeeper must answer all questions and hypotheticals about these policies in a timely fashion. These questions and answers must be made public.
+
+Providing that the Third-Party Browser or Web App latest version is in compliance with the current privacy/security policies the Gatekeeper should not block installation/capabilities or update of it, including if arbitration or litigation is currently in process. The Gatekeeper may apply to the regulator to permanently ban a particular company from providing Third-Party Browser or Web Apps if they can prove the Third-Party Browser is maliciously acting against the interests of end users (i.e it is actually malware/spam).
+
+The desired outcome with these regulations is that browsers and web-apps are delivered unrestricted by the operating system.
+
+These proposed regulations should be subject to an open comment period to allow all stakeholders to provide feedback, however it should be expected that Apple and other special interest groups are heavily incentivized to maintain the status quo.
+
+<sup>6</sup> A browser engine (also known as a layout engine or rendering engine) is a core software component of every major web browser. The primary job of a browser engine is to transform HTML documents and other resources of a web page into an interactive visual representation on a user's device.</sup>
+
+
+
+## 12. Bright Future for Competition
+
+If third-party browsers were allowed, with full access to all the APIs that Apple gives Safari, this would provide Apple the incentive to keep pace with the other browsers and give consumers a means of voting with their feet by moving to a competing browser if they fail to do so.
+
+It would provide a source of competition with the App Store as Tim Cook and others at Apple have suggested. It would place downward pressure on the tax Apple charges companies and by extension users on all purchases made in the App Store.
+
+If Apple was compelled to provide Web Apps an equal footing to Native Apps, companies would be able to develop a wide range of apps for a single standards based platform that would then be interoperable between iOS, macOS, Android, Windows and Linux. This would result in as much as a 2-5 fold drop in development and maintenance cost and result in higher quality Apps for end users.
+
+A ban on third-party browsers benefits Apple and harms users, developers and businesses.
+
+**Competition, not walled gardens, leads to the best outcomes**.
+
+
+
+## 13. Further Reading
+
+### 13.1. Alex Russell - Browser Choice Must Matter
+
+Alex Russell (Former W3C TAG / Google Chrome, Now on the Microsoft Edge team) has written a series of articles labeled “Browser Choice Must Matter” which go into deep technical detail in relation to “Browser Choice”.
+
+**[Progress Delayed is Progress Denied](https://infrequently.org/2021/04/progress-delayed/)** <br />
+A detailed look into Safari on iOS and how it has slipped behind
+
+**[Hobson’s Browser](https://infrequently.org/2021/07/hobsons-browser/)** <br />
+How Apple, Facebook and Google are undermining user choice in browsers
+
+**[iOS Engine Choice in Depth](https://infrequently.org/2021/08/webkit-ios-deep-dive/)** <br />
+A deep dive into browser choice on iOS with technical details
+
+### 13.2. Bruce Lawson
+
+**[Progressive Web Apps and iOS](https://www.youtube.com/watch?v=EOyfMzWqHiY)** <br />
+Bruce Lawson presentation to the UK’s Competition and Markets Authority about issues with Web Apps on iOS
+
+### 13.3. Stuart Langridge
+
+**[Browser choice on Apple's iOS: privacy and security aspects](https://kryogenix.org/code/cma-apple/)** <br />
+Stuart Langridge’s presentation to the UK’s Competition and Markets Authority about various privacy and security aspects on iOS.
+
+
+
+## 14. References
+
+* [Thomas Claburn - The Register - On Safari Underfunding](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug/)
+
+* [The Ultimate How-to: Build a Bluetooth Swift App With Hardware in 20 Minutes](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)
+
+* [Apple’s iOS App Store is littered with malicious apps](https://www.techradar.com/au/news/apple-app-store-is-apparently-still-littered-with-malicious-apps)
+
+* [Security Researcher on iOS App Store Malware](https://habr.com/en/post/580272/)
+
+* [Matthew Ball - On Apple inhibiting the future Internet](https://www.matthewball.vc/all/applemetaverse)
+
+* [Ben Thompson on why Apple wants to make the web less useful](https://stratechery.com/2020/apple-and-facebook/)
+
+* [Mozilla Documentation on Web Apps (PWAs)](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)
+
+* [Apple claiming PWAs represent a viable distribution alternative to the App Store](https://www.accc.gov.au/system/files/Apple%20Pty%20Limited%20%2810%20February%202021%29.pdf)
+
+* [Tim Cook making the same claim](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s)
+
+* [Apple lawyers making a similar claim in court vs Uber](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple)
+
+* [Apple rule effectively banning third-party browsers](https://developer.apple.com/app-store/review/guidelines/#2.5.6)
+
+* [Scott Gilbertson - On Safari being the new IE](https://www.theregister.com/2021/10/22/safari_risks_becoming_the_new_ie/)
+
+* [Dieter Bohn and Tom Warren - The Verge - Talking about Apples Browser Ban](https://www.theverge.com/2021/5/6/22421912/iphone-web-app-pwa-cloud-gaming-epic-v-apple-safari)
+
+* [Niels Leenheer - HTML5test - On iOS Safari holding back the web](https://nielsleenheer.com/articles/2021/chrome-is-the-new-safari-and-so-are-edge-and-firefox/)
+
+* [Chris Coyier - CSS-TRICKS - On the Apple Browser Ban](https://css-tricks.com/ios-browser-choice)
+
+* [Richard MacManus - The New Stack - On the Apple Browser Ban holding back the web](https://thenewstack.io/apples-browser-engine-ban-is-holding-back-web-app-innovation)
+
+* [The Verge - Emails from the Epic vs Apple trial](https://www.theverge.com/22611236/epic-v-apple-emails-project-liberty-app-store-schiller-sweeney-cook-jobs)
+
+* [Steve Jobs - Original Announcement of iOS Web Apps](https://www.youtube.com/watch?v=p1nwLilQy64)
+
+* [iOS “Smart App Banners”](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners)
+
+* [Patterns for promoting PWA installation](https://web.dev/promote-install/)
+
+* [MDN - BeforeInstallPromptEvent documentation](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent)
+
+* [Minesweeper like PWA/Web App](https://proxx.app)
+
+* [Bruce Lawson - Talk to the CMA about Web Apps](https://brucelawson.co.uk/2021/briefing-to-the-uk-competition-and-markets-authority-on-apples-ios-browser-monopoly-and-progressive-web-apps/)
+
+* [Apple/Webkit - rejecting request to add BeforeInstallPromptEvent](https://bugs.webkit.org/show_bug.cgi?id=193959)
+
+* [Chromium Ticket on Open WebAPK minting server for third-party browsers](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583)
+
+* [Misha Ketchell - The Conversation - On Dark Pattens](https://theconversation.com/what-are-dark-patterns-an-online-media-expert-explains-165362)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On Safari Webkit lagging behind](https://infrequently.org/2021/04/progress-delayed/#:~:text=The%20data%20agree%3A%20Apple%27s%20web%20engine%20consistently%20trails%20others%20in%20both%20compatibility%20and%20features%2C%20resulting%20in%20a%20large%20and%20persistent%20gap%20with%20Apple%27s%20native%20platform)
+
+* [Web Platform Tests Dashboard](https://wpt.fyi/results/?label=experimental&label=master&aligned)
+
+* [Can I Use - Website with data comparing features of different browsers](https://caniuse.com)
+
+* [Mozilla Developer Network Web Developer Needs Assessment 2020 Survey](https://insights.developer.mozilla.org/reports/mdn-web-developer-needs-assessment-2020.html)
+
+* [CSS](https://en.wikipedia.org/wiki/CSS)
+
+* [HTML](https://en.wikipedia.org/wiki/HTML)
+
+* [Javascript](https://en.wikipedia.org/wiki/JavaScript)
+
+* [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly)
+
+* [State of CSS survey](https://stateofcss.com)
+
+* [State of CSS survey - Raw Answers Text](https://gist.github.com/SachaG/cd7cf12623a95d8162ac2b8e340c4724)
+
+* [The Register - On Safari breaking indexedDB](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug)
+
+* [Russell Brandom - The Verge - On Apple holding PWAs back](https://www.theverge.com/2021/5/27/22454959/epic-apple-trial-recap-video-tim-cook-xbox-playstation-business#:~:text=APPLE%20GAINS%20A%20LOT%20BY%20SLOW-WALKING%20PROGRESSIVE%20WEB%20APPS%20ON%20THE%20IPHONE)
+
+* [Benedict Evans - Technology Writer - On Apples arbitrary application of App Store rules](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On Apple saving ram by banning other browsers](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser)
+
+* [Benedict Evans - Technology Writer - On iOS Free to Play Games](https://www.ben-evans.com/benedictevans/2021/7/8/app-store)
+
+* [Mihovil Grguric - CEO of Udonis Inc (A mobile apps marketing agency) - On free-to-play Whales](https://www.blog.udonis.co/mobile-marketing/mobile-games/mobile-games-whales)
+
+* [Tim Perry - Httptoolkit - On Safari not implementing features with no potential security/privacy issues](https://httptoolkit.tech/blog/safari-is-killing-the-web/)
+
+* [Sean Hollister - On Apple inability to spot obvious scams in the iOS App Store](https://www.theverge.com/2021/4/21/22385859/apple-app-store-scams-fraud-review-enforcement-top-grossing-kosta-eleftheriou)
+
+* [Gordon Kelly - On scams and clones on the iOS App Store](https://www.forbes.com/sites/gordonkelly/2021/04/07/apple-iphone-ipad-app-store-scam-warning-new-iphone-problem/?sh=7231e8a960aa)
+
+* [Dr Michael Grenfell - On Effective Competition](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+* [Entrepreneurship Life - Apple users spend more than Android users](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+
+* [Times on India - Apple users spend more than Android users](https://timesofindia.indiatimes.com/gadgets-news/iphone-users-spend-more-money-on-apps-than-android-users-report/articleshow/83947757.cms)
+
+* [Professor Douglas J. Leith - On Brave Privacy](https://www.zdnet.com/article/brave-deemed-most-private-browser-in-terms-of-phoning-home/)
+
+* [A Feature added to Chromium that Edge and other browsers use but Chrome does not](https://groups.google.com/a/chromium.org/g/blink-dev/c/e5fu5Q06ntA/m/UUqPuA8hEQAJ)
+
+* [Benedict Evans - Technology Writer - On iOS App Store](https://www.ben-evans.com/benedictevans/2020/8/18/app-stores)
+
+* [Dieter Bohn - The Verge - On Apples Capricious App Store policies](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)
+
+* [Sean Hollister - Verge - On Apples effective ban on streamed games](https://www.theverge.com/2020/9/18/20912689/apple-cloud-gaming-streaming-xcloud-stadia-app-store-guidelines-rules)
+
+* [Sean Hollister - Verge - On Apple copying then banning a keyboard App](https://www.theverge.com/2021/9/16/22676706/apple-watch-swipe-keyboard-flicktype-lawsuit-kosta-eleftheriou)
+
+* [Samantha John - CEO Hopscotch - On iOS App Store Review Policies](https://twitter.com/samj0hn/status/1431001795904561160)
+
+* [Kosta Eleftheriou - On iOS Malware](https://www.xanjero.com/news/developer-kosta-eleftheriou-claims-apples-app-store-is-littered-with-malicious-apps/)
+
+* [Slipping Past the Review - Malware in iOS Native Apps](https://habr.com/en/post/580272/)
+
+* [Campbell Kwan - ZDNet - On Apples indefinite ban of Epic](https://www.zdnet.com/article/apple-bans-epic-games-from-app-store-until-all-litigation-is-finalised/)
+
+* [John Brownlee - Cult of Mac - On Apple banning Sweatshop Labour Rights Game](https://www.cultofmac.com/220790/why-apples-reason-for-kicking-a-sweatshop-game-out-of-the-app-store-is-total-hypocrisy/)
+
+* [Niels Leenheer - HTML5test - On Apple Webkits banning of web device APIs on privacy grounds](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)
+
+* [Apple has rejected certain web standard device APIs](https://webkit.org/tracking-prevention/#anti-fingerprinting)
+
+* [Niels Leenheer - HTML5test - on why web device APIs are really bad at fingerprinting](https://nielsleenheer.com/articles/2021/hardware-and-the-web-the-balance-between-usefulness-security-and-privacy/)
+
+* [Web Bluetooth Documentation](https://webbluetoothcg.github.io/web-bluetooth/)
+
+* [Microsoft Smartscreen](https://support.microsoft.com/en-us/microsoft-edge/what-is-smartscreen-and-how-can-it-help-protect-me-1c9a874a-6826-be5e-45b1-67fa445a74c8)
+
+* [Google SafeBrowsing](https://safebrowsing.google.com/)
+
+* [iOS Native Bluetooth Guide](https://www.freecodecamp.org/news/ultimate-how-to-bluetooth-swift-with-hardware-in-20-minutes/)
+
+* [On malicious tracking of users using iOS Native Apps bluetooth](https://www.fastcompany.com/90386781/ios-13s-new-bluetooth-privacy-feature-is-important-but-confusing)
+
+* [Cory Doctorow - Former European director of the Electronic Frontier Foundation - On Apple's stance on privacy](https://twitter.com/doctorow/status/1459914164152016905)
+
+* [Apple's Advertising Identifier](https://en.wikipedia.org/wiki/Identifier_for_Advertisers)
+
+* [Geoffrey Fowler And Tatum Hunter - Washington Post](https://www.washingtonpost.com/technology/2021/09/23/iphone-tracking/)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On IAB and Browser Choice](https://infrequently.org/2021/07/hobsons-browser/#:~:text=Known%20as%20the%20%22Android%20Google%20Search%20App%22%20(%22AGSA%22%2C%20or%20%22AGA%22)%2C%20this%20humble%20text%20input%20is%20the%20source%20of%20a%20truly%20shocking%20amount%20of%20web%20traffic%3B%20traffic%20that%20all%20goes%20to%20Chrome%2C%20no%20matter%20the%20user%27s%20choice%20of%20browser)
+
+* [John Koetsier - Forbes - On Apple secretly buying advertising for other companies](https://www.forbes.com/sites/johnkoetsier/2021/11/12/apple-quietly-buying-ads-via-google-for-high-value-subscription-apps-to-capture-app-publisher-revenue/?sh=67998df71b52)
+
+* [Mac Rumors - On Apple’ 2021 1st half profit](https://www.macrumors.com/2021/06/29/app-store-revenue-h1-2021-42-billion/)
+
+* [Austin Carr - Bloomberg - On Apples 30% Gatekeeper fee](https://www.bloomberg.com/news/newsletters/2021-05-03/apple-s-30-fee-an-industry-standard-is-showing-cracks)
+
+* [Russell Brandom - The Verge - On Apple iMessage](https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute)
+
+* [Apple Scoop - On why the Mac App Store is not successful](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+* [Photoshop on the web](https://web.dev/ps-on-the-web/)
+
+* [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)
+
+* [SIMD](https://developer.mozilla.org/en-US/docs/Glossary/SIMD)
+
+* [Private File System Origin Trial](https://web.dev/file-system-access/#accessing-files-optimized-for-performance-from-the-origin-private-file-)
+
+* [Alex Russell - Program Manager on Microsoft Edge - On WebStandards](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+* [Apple received 9% of Gross Profit from Google Search Engine deal](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/)
+
+* [Rep. Regina Cobb - A Republican state lawmaker in Arizona - On Apple’s aggressive lobbying](https://www.politico.com/news/2021/08/20/apple-takes-on-state-legislatures-georgia-506299)
+
+* [Joshua Long - Apple’s Poor Patching Policies Potentially Make Users’ Security and Privacy Precarious](https://www.intego.com/mac-security-blog/apples-poor-patching-policies-potentially-make-users-security-and-privacy-precarious)
+
+* [Charlie Warzel - New York Times on privacy and native apps tracking](https://www.nytimes.com/2019/09/24/opinion/facebook-google-apps-data.html)
+
+* [Sara Morrison - VOX on harvesting data via native apps](https://www.vox.com/platform/amp/recode/22587248/grindr-app-location-data-outed-priest-jeffrey-burrill-pillar-data-harvesting)
+
+* [Bennett Cyphers - Electronic Freedom Foundation - On harvesting data via native apps](https://www.eff.org/deeplinks/2020/06/apples-response-hey-showcases-whats-most-broken-about-apple-app-store)
+
+* [Google - Announcing the Webkit/Blink Engine Split](https://blog.chromium.org/2013/04/blink-rendering-engine-for-chromium.html)
+
+* [CVEDetails -All Vulnerabilities in Safari](https://www.cvedetails.com/product/2935/Apple-Safari.html?vendor_id=49)
+
+* [CVEDetails - All Vulnerabilities in Chrome](https://www.cvedetails.com/product/15031/Google-Chrome.html?vendor_id=1224)
+
+* [CVEDetails - All Vulnerabilities in Firefox](https://www.cvedetails.com/product/3264/Mozilla-Firefox.html?vendor_id=452)
+
+* [Paul Wagenseil - Tom’s Guide - On hacking the iPhone via Safari/Webkit](https://www.tomsguide.com/opinion/your-iphone-is-less-safe-than-it-was-yesterday-and-thats-good)
+
+* [Wikipedia - CVE - Definition](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures)
+
+* [Google - Project Zero (Security Team) on security browser metrics](https://googleprojectzero.blogspot.com/2022/02/a-walk-through-project-zero-metrics.html)
+
+* [Reed Albergotti - Washington Post - On the poor state of Apple’s bug bounty program](https://www.washingtonpost.com/technology/2021/09/09/apple-bug-bounty/)
+
+* [Thomas Claburn - The Register - On poor treatment of Security Researchers by Apple](https://www.theregister.com/2020/07/01/apple_macos_privacy_bypass/)
+
+* [Denis Tokarev - Security Researcher - On poor state of Apple’s bug bounty program](https://habr.com/en/post/579714/)

--- a/src/ja/posts/Australia-ACCC-Nov-22.md
+++ b/src/ja/posts/Australia-ACCC-Nov-22.md
@@ -1,0 +1,54 @@
+---
+title: >-
+  Australian Government considering ACCC proposed anti-competitive conduct
+  legislation changes
+date: '2022-11-30'
+tags:
+  - Policy
+  - Updates
+author: Bruce Lawson
+permalink: /ja/blog/Australia-ACCC-Nov-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+G'day, sport! [Bruce](https://brucelawson.co.uk) here, with an update on progress we've made down under with the Australian Competition and Consumer Commission (ACCC).
+
+ACCC published a [Digital Platform Services Inquiry Discussion Paper (PDF)](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry.pdf)  which has great news for competition in browsers and web apps.
+
+They propose:
+
+1. Reversing the Apple browser ban
+2. Requiring equivalent access to hardware and software
+3. Allowing web apps to compete with single-platform "native" apps
+
+> Apple requires all browsers on iOS to be built using its WebKit browser engine. Further, Apple prevents WebKit from accessing certain APIs and iOS functionality, which restricts the functionality of web apps compared to native apps (for example, push notifications can be accessed by native apps but not web apps).
+
+> As a result, Apple iOS users do not have the option to use browsers that can offer a wider range of innovative features and functionality. Instead, they are limited to using browsers built using Apple’s WebKit browser engine. Stakeholders submit that, as a result, Safari faces very limited competitive pressure on iOS. We are also concerned that this limits the ability for web apps … to impose a competitive constraint on native apps.”
+
+> Apple, and to a lesser extent Google, have also restricted interoperability with hardware, software and functionality through their mobile OS for providers of third-party apps and services.
+
+The ACCC is recommending introducing a new regulatory regime that will be able to compel gatekeepers to stop anti-competitive conduct. They note that reforms are underway globally and it would make sense to align Australia's new regulatory regime with ones such as the [EU's Digital Markets Act, the UK's Digital Markets Unit](/blog/cma-dma-nov-22/) and the Japan's Act on Improving Transparency and Fairness of Digital Platforms.
+
+They clearly recognize the harm that the gatekeepers have on competition, businesses and consumers. The ACCC has a lovely shopping list of proposed legislated obligations, most of which will relate to browsers and web apps. The [majority of OWA’s concerns (PDF)](https://www.accc.gov.au/system/files/DPB%20-%20DPSI%20-%20September%202022%20report%20-%20Submission%20-%20Open%20Web%20Advocacy%20-%20Public%20(1).pdf) fit into these categories:
+
+- anti-competitive self-preferencing
+- anti-competitive tying
+- exclusive pre-installation and default agreements that hinder competition
+- impediments to consumer switching
+- impediments to interoperability
+- data-related barriers to entry and expansion, where privacy impacts can be managed
+- a lack of transparency
+- unfair dealings with business users
+-  exclusivity and price parity clauses in contracts with business users.
+
+The Australian Government is considering the ACCC’s recommendations and will consult publicly to seek the views of stakeholders.
+
+We would like to thank [Mozilla (PDF)](https://www.accc.gov.au/system/files/DPB%20-%20DPSI%20-%20September%202022%20report%20-%20Submission%20-%20Mozilla%20-%20Public.pdf) and all of the [individual developers and businesses](https://www.accc.gov.au/focus-areas/inquiries-ongoing/digital-platform-services-inquiry-2020-25/september-2022-interim-report) who wrote to the ACCC in support of browser competition and web apps.
+
+Stay tuned so we can let you know when the governmental consultation begins, so you can have your say if you do business in Australia.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/CMA-DMA-Nov-22.md
+++ b/src/ja/posts/CMA-DMA-Nov-22.md
@@ -1,0 +1,46 @@
+---
+title: OWA updates on progress with UK and EU digital competition regulations
+date: '2022-11-28'
+tags:
+  - Policy
+  - Updates
+  - UK
+  - EU
+author: Bruce Lawson
+permalink: /ja/blog/CMA-DMA-Nov-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Howdy, [Bruce](https://brucelawson.co.uk) here, with an update on progress we've made in both the EU and with the UK's competition regulator, the Competition and Markets Authority (CMA).
+
+## Browser engines on the agenda
+
+We've had encouraging success at putting browser engines on the regulators' agenda. While rendering engines seem a pretty esoteric subject, it's of paramount importance: Apple has done a great job concealing its anti-competitive behaviour, saying "you can have other browsers on iOS" while glossing over the fact that all other browsers are [Apple's mandated version of WebKit](https://developer.apple.com/app-store/review/guidelines/#performance:~:text=Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.) under the hood. 
+
+Many web developers don't realise this, which is why we made this meme:
+
+{% image "/images/blog/apple-browser-ban.webp", "Fred from Scooby Doo with a masked figure and text 'Firefox on iPhone'. Fred removes the mask to reveal the villain headed 'Apple's Safari'. Then the same with Edge on iPhone and Chrome on iPhone." %}
+
+So we're thrilled that, after we met with those drafting the EU rules, the final text of the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32022R1925&from=EN) (DMA), browser engines are explicitly referenced:
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users. 
+
+The DMA will be applicable as of [beginning of May 2023](https://ec.europa.eu/info/strategy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en). Non-compliance carries fines of up to 10% of the company’s total worldwide annual turnover, or up to 20% in the event of repeated infringements.
+
+The UK is no longer a member of the EU, so some of us who are citizens of Brexit Island met with the UK's Competition and Markets Authority after it announced an investigation into the Mobile Apps Ecosystem. We explained that it shouldn't be seen as a binary choice between single-platform "native" apps on iOS and Android, but should also be concerned with Progressive Web Apps and, by extension, also look at how Apple hamstrings PWAs by only allowing its WebKit on iOS and iPad.
+
+The CMA agreed, and last week announced [a new a market investigation into cloud gaming and mobile browsers](https://www.gov.uk/government/news/investigation-into-cloud-gaming-and-browsers-to-support-uk-tech-and-consumers) after receiving widespread support for its proposals first published in June:
+
+> Web developers have complained that Apple’s restrictions, combined with suggested underinvestment in its browser technology, lead to added costs and frustration as they have to deal with bugs and glitches when building web pages, and have no choice but to create bespoke mobile apps when a website might be sufficient.
+
+> Ultimately, these restrictions limit choice and may make it more difficult to bring innovative new apps to the hands of UK consumers. At the same time, Apple and Google have argued that restrictions are needed to protect users. The CMA’s market investigation will consider these concerns and consider whether new rules are needed to drive better outcomes.
+
+The [CMA Board Advisory Steer](https://assets.publishing.service.gov.uk/media/637b76478fa8f5771eb23acc/Board_Advisory_Steer_.pdf) gives a good insight into the things they will investigate.
+
+We want to say a huge thank you to all web developers who took the time and trouble to [reply to CMA's consultations](https://www.gov.uk/government/consultations/mobile-browsers-and-cloud-gaming-proposal-to-make-a-market-reference). Big Tech firms have whole departments who leap into action if regulators start sniffing, and the money to set up pseudo-associations to lobby on their behalf. We didn't; you had our backs. Thank you.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/NTIA-report-Feb-22.md
+++ b/src/ja/posts/NTIA-report-Feb-22.md
@@ -1,0 +1,33 @@
+---
+title: News from the NTIA report on mobile app ecosystems
+date: '2023-02-03'
+tags:
+  - Policy
+  - Updates
+author: Bruce Lawson
+permalink: /ja/blog/NTIA-report-Feb-22/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[Bruce](https://brucelawson.co.uk) published an [article](https://brucelawson.co.uk/2023/the-ntia-report-on-mobile-app-ecosystems/) where he gives us a summary of the NTIA (National Telecommunications and Information Administration) report on Mobile App Competition.
+
+> The question now is whether Apple will do the right thing, or seek to hurl lawyers with procedural arguments at it instead, as they're doing in the UK now.
+
+> But for every month they delay, they earn a fortune; it's estimated that Google pays Apple $20 Billion to be the default search engine in Safari, and the App Store earned Apple $72.3 Billion in 2020.
+
+Apple's App Store revenue is ~ $72.3 billion, of which they tax app developers between 15% and (likely more often) 30%. If we assume Apple always takes the full 30%, they would receive just shy of $21.7 billion. Apple would still need some of that money to pay for the operating costs of the App Store.
+
+The $20 billion from Google is likely almost all profit.
+
+That's 11% of Apple's yearly profit for doing nothing except banning their competitors from iOS 🤯
+
+**Browser ban = higher market share for safari = Google search engine revenue**
+
+<div class="prom-banner">
+  <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+  <p>If you love what we're doing and would like to support our work, please consider
+    <a href="https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG">making a donation</a>.</p>
+  <p>OWA is a registered not-for-profit fighting for the Web against heavily financed gatekeepers
+    to ensure the future of Browser competition and Web Apps</p>
+</div>

--- a/src/ja/posts/New-Digital-Competition-Laws-For-Australia.md
+++ b/src/ja/posts/New-Digital-Competition-Laws-For-Australia.md
@@ -1,0 +1,39 @@
+---
+title: New Digital Competition Laws for Australia
+date: '2023-12-08'
+tags:
+  - Policy
+  - Updates
+  - Australia
+author: Alex Moore
+permalink: /ja/blog/New-Digital-Competition-Laws-For-Australia/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/NewDigitalLawsAustralia.webp",
+  "Australia - New Laws for Digital Platforms. In-principle agreement reached. The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits. We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS. ACCC - Digital Platform Services Inquiry #5"
+%}
+
+The Australian government has agreed to [new competition laws for digital platforms](https://www.accc.gov.au/media-release/consumers-and-small-businesses-to-benefit-from-proposed-new-regulation-of-digital-platforms)!
+
+This is excellent news and will pave the way for fair and effective browser competition on all operating systems & allow Web Apps to compete on an equal footing with Native Apps.
+
+The new laws will be based on the ACCC's recommendations in their [Digital platform services inquiry - Interim report No. 5](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf) which includes:
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+
+> We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS.
+
+This is important as, Apple has effectively banned third party browsers via [their 2.5.6 rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+We believe that browsers should compete on merit and user choice, not via control of operating systems or other underhanded behaviour. Browser competition is important as it is this competition that pushes browser vendors to secure their products, fix bugs and add new features.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/apple-adopts-6-owa-choice-architecture-recommendations.md
+++ b/src/ja/posts/apple-adopts-6-owa-choice-architecture-recommendations.md
@@ -1,0 +1,118 @@
+---
+title: Apple adopts 6 of OWA's Choice Architecture Recommendations
+date: '2024-08-23'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /ja/blog/apple-adopts-6-owa-choice-architecture-recommendations/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[Today, in a step forward for user choice and browser competition](https://developer.apple.com/support/browser-choice-screen/), Apple has adopted 6 out of 11 of our recommendations to comply with the EU's Digital Markets Act in relation to browser defaults and choice screens. In addition Apple has fixed [two severe and deliberate deceptive patterns](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) that we campaigned to fix including at the DMA's workshop.
+
+[In March the EU Commission opened an investigation into Apple](https://open-web-advocacy.org/blog/eu-opens-dma-investigations/) for non-compliance with the Digital Markets Act related to user choice obligations. Since that time we have been working to ensure that all gatekeepers comply with the DMA with respect to browsers and Web Apps.
+
+## Implemented Recommendations
+
+1. [Browser vendors should be **granted the hotseat** when being selected as the default browser in the choice screen.](https://open-web-advocacy.org/apple-dma-review/#apples-dark-pattern-exacerbated-by-keeping-hotseat)
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/_m6tQtDpSbM?si=H37IuGP1F_yueGtd' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+2. [Browsers should be able to **display more information** in the choice screen](https://open-web-advocacy.org/apple-dma-review/#browser-should-be-allowed-to-show-more-information-on-choice-screen)
+
+3. [Once chosen, browsers should be **immediately set as the default and downloaded in the background.**](https://open-web-advocacy.org/apple-dma-review/#should-be-a-background-and-direct-download)
+
+4. [Browser vendors **need more data** to measure the effectiveness of the choice screen.](https://open-web-advocacy.org/apple-dma-review/#browser-vendors-need-data-on-the-choice-screen-to-measure-performance)
+
+5. [The choice screen should be shown to users **when syncing or purchasing a new device**.](https://open-web-advocacy.org/apple-dma-review/#periodic-choice-screen)
+
+6. [The option to change default browser should be moved out of the browser settings and into a centralised location.](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+
+According to [Apple’s announcement](https://developer.apple.com/support/browser-choice-screen/) the following recommendations will be implemented on iOS (including on iPads). We will need to observe the implementation for additional issues but this is a positive step forward for browser competition and Apple's compliance with the Digital Markets Act.
+
+## Unimplemented Recommendations
+
+1. [The user’s choice of default browser must be used for In-App Browsing (SFSafariViewController)](https://open-web-advocacy.org/apple-dma-review/#sfsafariviewcontroller-must-respect-browser-choice)
+<br>Currently most In-App browsing on iOS is locked to Safari which provides Apple a very significant advantage and a lot of traffic. It is critical for browser choice that if a user decides on a particular browser, that browser is then used for web browsing by default across the OS including in In-App Browsers.<br><br>
+
+2. [Browsers on the choice screen shouldn't be Locked to the Gatekeeper’s app store](https://open-web-advocacy.org/apple-dma-review/#direct-install-browsers-should-be-included-in-choice-screens)
+<br>Browser vendors should be able to choose if they want to have their browser distributed directly or via the AppStore, including if they also distribute via the AppStore. The choice-screen should not force any browser vendor to have to distribute via Apple’s designated core platform service and thus lock them into Apple’s unfair contracts and rules + 30% of any In-App payments.
+<br><br>Apple has indicated they are open to collaborating on this recommendation however we are concerned that browser vendors are in essence locked into Apple’s app store and [are not able to distribute their browser directly](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation) as they do on desktop operating systems.
+<br><br>Specifically, we believe that the [Core Technology Fee should be removed](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed) as this is a punitive fee on businesses daring to list any of their apps outside of Apple’s app store.  The EU should consider solving the issues of alternative app distribution (including core-technology fee) so that browser vendors have the option of direct distribution. If these issues are not solved before the choice screens are rolled out then a key opportunity for browser vendors to offer their browsers directly to users would have been lost.
+<br><br>Apple should also not be allowed to put up scare screens to dissuade users from directly downloading browsers.<br><br>
+
+3. [Browsers should be allowed to know if they are the current default browser.](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>It is important that browsers can detect whether or not they are the default in order to provide sensible prompts to users to set their browser as the default. Apple has argued that they do not provide this information to Safari but that is irrelevant as Safari is set as the default in factory settings.<br><br>
+
+4. [The option to change default browser should show up in settings search if the user searches for "default", "browser" or "default browser".](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>It should not be difficult for users to work out how to change the default browser. Making it appear in search is a minimum requirement.<br><br>
+
+5. [Browsers should be able to trigger a one-click prompt to be set as the default upon being installed (as is standard on most other operating systems).](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api)
+<br>To be able to easily change from one browser to another, once a user install a new browser they should be able to set it as default from a one-time operating system prompt. This should also include the hotseat.<br>
+
+We will be engaging with the DMA’s investigation into defaults and choice screens about these issues as we believe they are justified and that Apple is obligated to implement them under the text of the DMA.
+
+## Hotseat not granted to already installed browsers and browsers set as default outside the choice screen.
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser **that is not currently installed on their device** from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen
+> <cite>[Apple - On Browser Choice Screens](https://developer.apple.com/support/browser-choice-screen/)<br>
+(emphasis added)</cite>
+
+One issue with Apple's implementation is it does not apply to browsers which are already installed. Apple needs to update this to move an already installed browser onto the hotseat to replace the Safari icon when it is selected in the choice screen.
+
+We believe that browsers that are downloaded outside of the choice screen should also replace Safari in the hotseat upon being set as default browser.
+
+This is important as these are both common scenarios. Any friction that OS gatekeepers can introduce to make it harder for users to use a browser other than theirs undermines browser competition. Friction is a powerful force to block competition.
+
+## Deceptive Patterns
+
+[The two deceptive patterns outlined](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) in this article have both been fixed by Apple. 
+
+The deceptive pattern of hiding the option to change default browser in Safari settings if Safari is the default outlined in this article has also been removed by Apple globally. 
+
+Additionally, the deceptive pattern of triggering the choice screen when Safari is not the default browser (typically because it still occupies the hotseat) has been fixed. That is Apple was triggering the choice screen in the hope that users will change from a third-party browser back to Safari.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+## To Regulators outside the EU
+
+These changes are EU only. Apple's users in other countries do not gain any direct benefit from these remedies. We urge regulators in other countries to carefully examine these changes and consider compelling Apple to implement them in their own jurisdictions. It should be noted that the effort for Apple to implement the choice screen in other jurisdictions will now be minimal.
+
+#### Important Improvements
+
+While the changes the EU have made are excellent, they are limited in pursuing the optimal solution by the [very specific text of the DMA](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=the%20end%20users%E2%80%99-,first%20use%20of%20an%20online%20search%20engine%2C%20virtual%20assistant%20or%20web%20browser,-of%20the%20gatekeeper).
+
+In addition to the unimplemented recommendations above we would recommend several important improvements including:
+* The choice screen should be moved to device setup or upon device update rather than upon first use of the gatekeepers browser. 
+* The gatekeepers browser, if not selected, should be uninstalled from the device
+or virtually uninstalled, i.e. hidden from the user, if the gatekeeper can demonstrate that is not practical because of technical limitations.
+
+## Compliance Monitoring and Unanswered Questions
+
+We have not yet seen the implementation of the choice screen. For OWA, browser vendors and others to provide feedback to the EC we need to be able to see it in action (video) and be able to test it. This needs to be done well in advance of any browser choice screen rollout in the EU so there is time to make changes based on feedback.
+
+#### Outside of AppStore Workflow
+
+The outside of the Apple AppStore workflow for the choice screen is unknown. We'd like to know what the outside of the AppStore install process would look like, and a confirmation that browser developers can opt to have their "non-appstore" version installed if they would like.
+
+So far Apple has just provided the [very vague statement](https://developer.apple.com/support/browser-choice-screen/):
+> Additionally, developers who make their browsers available outside the App Store should contact their Apple representative or dma-data@apple.com to collaborate on including their browser in the choice screen.
+
+For example, can Brave/Firefox/Edge/Opera/DuckDuckGo/Chrome/Vivaldi offer from the choice screen, a version of their browser which is directly distributed from that browser vendor?
+
+#### Testing the Choice Screen
+
+For testing the choice screen, Apple should provide a way to trigger the choice screen multiple times without having to factory reset a device.  A “choice screen” button in settings somewhere would do the trick.  To test it properly we need to launch it many times. 
+
+## What does success for Choice Architecture look like?
+
+There are two forms of success in choice architecture. One is removing behaviour that is blatantly unfair or manipulative, the removal of the behaviour is a success in its own right regardless of any outcome. 
+
+The second is in allowing space for new and smaller browser vendors to thrive. Even the most perfect choice screen will not wildly change user preference over night. The biggest names in browsers are the ones that will be picked the most, the browser of the operating system will still get a significant boost. What choice screens need to do to succeed is let users know that they have a choice and create an opening for smaller browser vendors to get a foothold on mobile. 
+
+If third-party browsers managed to gain an additional 10% of the total market share on iOS or Android that would be a resounding success. As a point of context Google is paying Apple $20 billion USD per a year for being the default search engine. That means every 1% is worth $200 USD million annually. 
+
+That 10% is enough to support 8 Mozilla’s across iOS and Android. That is something worth fighting for. 

--- a/src/ja/posts/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface.md
+++ b/src/ja/posts/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface.md
@@ -1,0 +1,105 @@
+---
+title: >-
+  Apple appears to mislead UK Regulator over deceptive default browser user
+  interface
+date: '2024-09-04'
+tags:
+  - Policy
+  - CMA
+  - UK
+author:
+  - OWA
+permalink: >-
+  /ja/blog/apple-appears-to-mislead-uk-regulator-over-deceptive-default-browser-user-interface/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+TLDR: Apple seems to have tried to mislead the UK regulator that a deceptive pattern they had previously implemented for picking default browsers, in fact, never existed.
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1831247394643800481), [Mastodon](https://mastodon.social/@owa/113078330412825453
+), [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_breaking-apple-appears-to-mislead-uk-regulator-activity-7237018638518509568-Gxrc).
+
+## The Deceptive Pattern
+
+Earlier this year (2024-03-28) [we reported on a deceptive pattern](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) that Apple had coded into iOS which made it harder for users to change their default browser, if your current default browser was already Safari.
+
+<figure>
+    {% image
+        "/images/blog/cma-browser-selection-1.png",
+        "Example of changing the browser on iOS when Safari is not the default.",
+        null, null
+    %}
+    {% image
+        "/images/blog/cma-browser-selection-2.png",
+        "Example of changing the browser on iOS when Safari is the default (the dropdown disappears).",
+        null, null
+    %}
+    {% image
+        "/images/blog/cma-browser-selection-3.png",
+        "Larger example of changing the browser on iOS when Safari is the default (the dropdown disappears).",
+        null, null
+    %}
+    <figcaption>UK Regulator's Screenshots of the Issue - Working Paper 5</figcaption>
+</figure>
+
+> "Apple engineers added code to the Safari's settings page to hide the option to change the default browser if Safari was the default but then to prominently show it if another browser was the default." You can test this on an iPhone by scrolling to Safari under Settings. If Safari is not the default browser, there will be an option for "Default Browser App" where you can easily set Safari as the default. But if Safari is set as the default, this option disappears. For every other browser installed, the option remains to switch the default, whether that browser is set as the default or not.
+> <cite>[Ashley Belanger - Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/2/)</cite>
+
+This interesting design foible was picked up [by Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/2/) 2 weeks later and was subsequently fixed by Apple. We are uncertain exactly which version of iOS Apple fixed it in as they neglected to include it in the release notes. We noted that this had been fixed in [our review of Apple's compliance with the EU's Digital Markets Act](https://open-web-advocacy.org/apple-dma-review/#option-to-change-default-browser-hidden-if-gatekeepers-browser-is-the-default) on 2024-07-21.
+
+OWA thought: Amazing! One problem down! Well done Apple for fixing it without being directly compelled to and for doing so globally.
+
+However... [according to Apple](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf), none of the above ever happened and we collectively imagined the design!
+
+In [Apple's response](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf) (published 2024-08-01) to the [CMA's working paper 5](https://assets.publishing.service.gov.uk/media/669111d949b9c0597fdafbbb/WP5_-_The_role_of_choice_architecture_on_competition_in_the_supply_of_mobile_browsers.pdf), they respond directly. First, Apple accurately describes the issue both the CMA and OWA indicated:
+
+> The UK's Competition and Markets Authority (CMA) analysis also appears to rely on an OWA report concerning an alleged ‘dark pattern’ involving the use of different UIs in order to preference Safari is set as the default browser (paragraph 3.48) by not displaying the default browser setting in the Settings app’s Safari tab where the default browser is Safari.
+> <cite>[Apple - Response to Working Papers 1 to 5](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf)</cite>
+
+They then state:
+
+> This is not correct. The default browser app setting in the Safari tab is clearly visible when the user has set Safari as the default.
+> <cite>[Apple - Response to Working Papers 1 to 5](https://assets.publishing.service.gov.uk/media/66d6c524c52d5fb4c82ddd65/2024-08-01_Apple_Response_to_Working_Papers_1_to_5_-_TO_BE_PUBLISHED.pdf)</cite>
+
+What does _"This is not correct."_ mean in this context? 
+
+The only realistic interpretation is that statements made by the CMA and OWA on this topic are "not correct" or false. That is, at the time either OWA or the CMA’s statements were written, Apple was not employing a deceptive pattern to hide the option to switch default browser if Safari was the default. This is certainly a bold claim given this was independently verified by us, ArsTechnica and the CMA. This verification included screenshots, documents and [a video of the whole process](https://youtu.be/o6uwiG1nKK4). Apple presumably also retains copies of the original code that implement this "functionality" and can easily replicate the issue.
+
+What Apple could, and should have said, here is that _"This is **no longer** correct, as we fixed it in iOS 17.x"_. Instead they appear to have, bafflingly, chosen to mislead the regulator about the existence of the issue entirely.
+
+Before accusing Apple of seeking to mislead the CMA, it's worth interrogating the alternatives:
+
+**1. Apple is correct and this behaviour never took place.**<br>
+This isn't plausible as multiple parties independently checked this.
+
+**2. Apple's lawyers writing this section didn't check or the staff they asked didn't know.**<br>
+This option at least makes Apple merely incompetent, rather than actively seeking to mislead a regulator but is it really plausible that the lawyers writing this part of the response didn’t  ask the team at Apple that implement/maintain the iOS Safari settings page whether these accusations had any basis in truth and/or that that team didn’t remember that they updated the page, fixing the behaviour, a mere 2-3 months earlier.
+
+Ultimately, what makes this situation egregious is that this is not some off-the-cuff remark in a verbal setting or a carefully constructed non-statement, it is a direct denial of specifically alleged past anti-competitive behaviour presented in a formal (and presumably carefully reviewed) response by a multi-trillion dollar organisation to an ongoing investigation conducted by a regulator. This can have serious consequences.
+
+> In practice, the CMA expects, and normally receives, full co-operation from those involved in an investigation, and does not generally use the formal powers available to it. Where necessary, however, it does do so. It should also be noted that **the provision of false or misleading information to the CMA by a party or its advisers is a criminal offence, punishable by a fine and/or up to two years in prison.**
+> <cite>[Ashurst - Quick guide to competition law investigations by UK authorities](https://www.ashurst.com/en/insights/quickguide-the-use-of-market-studies-and-market-investigations-in-uk-competition-law/#:~:text=It%20should%20also%20be%20noted%20that%20the%20provision%20of%20false%20or%20misleading%20information%20to%20the%20CMA%20by%20a%20party%20or%20its%20advisers%20is%20a%20criminal%20offence%2C%20punishable%20by%20a%20fine%20and/or%20up%20to%20two%20years%20in%20prison.)</cite>
+
+If we were the CMA, we would have a number of questions for Apple, such as:
+
+1. Is Apple claiming that at no point in the past has the behaviour described taken place?
+2. How would Apple account for the various screenshots and videos (some of which were taken by the CMA)?
+3. What steps did Apple take internally to verify this quoted paragraph was neither false nor misleading?
+4. Can we be provided copies of all emails/messages/documentation related to writing the quoted paragraph?
+5. Can we be provided copies of all internal tickets/emails/documentation related to changes to the default browser setting in the iOS Safari setting panel over the last year?
+6. Can we be provided copies of the code related to the default browser setting in the iOS Safari setting panel including all versions and changelogs over the last year?
+
+There was no particular need for a direct response to this line item, so the choice to re-write history seems especially odd. They had after all already globally fixed it at the time of their submission.
+
+We believe that tech giants shouldn't be allowed to lie to or mislead regulators and that appropriate enforcement action should take place when they can be proven to have done so. We intend to continue calling out and questioning behaviour like this. 
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+
+* [Donate to help with our running costs](https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Contact your local government representatives
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/ja/posts/apple-backs-off-killing-web-apps.md
+++ b/src/ja/posts/apple-backs-off-killing-web-apps.md
@@ -1,0 +1,103 @@
+---
+title: 'Apple backs off killing web apps, but the fight continues'
+date: '2024-03-01'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /ja/blog/apple-backs-off-killing-web-apps/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+In a huge relief to developers and supporters of the open web, and under immense backlash, Apple has [cancelled its plan to sabotage Web Apps](https://9to5mac.com/2024/03/01/apple-home-screen-web-apps-ios-17-eu/)!. This ends weeks of fear and uncertainty for developers and users.
+
+We would like to say a massive thank you to the DMA team as Apple's decision is no doubt related to the [investigation they had opened](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc). But our most heartfelt thanks are to the thousands of developers who took the time to fill in our survey and sign the open letter, to show Apple that developers and businesses can't  be used as pawns. We are grateful for your help and no doubt will need it again - know that your voices were heard in Brussels and Cupertino, and have made a difference.
+
+The battle is not over, This simply returns us back to the status quo prior to Apple's plan to sabotage Web Apps for the EU. Apple’s over a decade suppression of the web in favour of the AppStore continues worldwide, and their attempt to destroy web apps in the EU is just their latest attempt. If there is to be any silver lining, it is that this has thoroughly exposed Apple’s genuine fear of a secure, open and interoperable alternative to their proprietary App Store that they can not control or tax.
+
+## How did we get here?
+
+[The Digital Markets Act (DMA)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) became law on 14 September 2022 and designated gatekeepers were given a 6 month grace period to comply with the regulations. Since Apple was certain to be designated this means they had almost one and half years to make the required changes. 
+
+However over the last 5 months, Apple took a different approach, one where it has continuously tried to undermine the DMA at every step, including:
+* [Claiming Safari is multiple browsers](https://www.theregister.com/2023/11/02/apple_safari_browser/)
+* [Separating out iPadOS from iOS](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) even though they are functionally almost identical
+* [Adding extremely onerous, unfair and likely illegal terms to their contract](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#apple%E2%80%99s-new-contract-for-browsers-that-wish-to-use-their-own-engine) for API access for third party browsers using their own engine
+* Deciding to lock any changes to only iPhone and the EU
+* Essentially [banning browsers from listing on alternative app stores on iOS](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#third-party-browsers-will-be-effectively-precluded-from-shipping-their-browsers-on-third-party-app-stores-on-ios)
+
+On 28th of January 2024, they pulled a new trick: break all Web Apps in the EU entirely. We first noticed it in the [first beta for iOS 17.4](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/).
+
+Initially they tried to keep it a secret. Extraordinarily there was no mention of this in [their DMA compliance plan](https://developer.apple.com/support/dma-and-apps-in-the-eu/#browser-alt-eu), [the iOS beta notes](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17_4-release-notes) or [the Safari beta notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#Web-Apps). Given how detailed these typically are and the magnitude of the change, it is impossible that this was an oversight. Clearly Apple was attempting to sneak this past the developers, users and regulators to provide everyone minimal time to respond.
+
+Over the next two weeks, Apple’s silence was deafening. No reply was given to [a Safari/WebKit ticket](https://bugs.webkit.org/show_bug.cgi?id=268643), [Apple developer forums](https://forums.developer.apple.com/forums/thread/745414), [twitter discussions](https://twitter.com/firt/status/1755406923485122615), and no statement was provided to the [many journalists](https://www.theregister.com/2024/02/08/apple_web_apps_eu/) [seeking](https://www.macrumors.com/2024/02/08/ios-17-4-nerfs-web-apps-in-the-eu/) [comment](https://www.theverge.com/2024/2/14/24072764/apple-progressive-web-apps-eu-ios-17-4).
+
+After 2 weeks, in the face of steadily increasing developer and media backlash, Apple was forced to rush out [this statement](https://developer.apple.com/support/dma-and-apps-in-the-eu#8) where they confirmed they were deliberately breaking Web Apps and that it had been planned. Astonishingly the iOS and Safari release notes have still not been updated.
+
+We, of course, had to act. We immediately informed the DMA team and then launched a series of surveys to demonstrate how detrimental this would be to businesses and users in the EU. We had over a thousand responses in a few short days and this allowed us to hand the EU excellent information about the immediate cost of Apple breaking Web Apps.
+
+We then worked shifts around the clock to launch our [incredibly successful open letter to Tim Cook](https://letter.open-web-advocacy.org/). The letter has already garnered worldwide support and has had 4264 individuals and 441 organisations sign. Signatures include two European MEPs (Karen Melchior & Patrick Breyer); a number of significant EU companies such as social media platform Mastodon; and individuals (advocating in their personal capacity) who work for SwissLife, Tchibo, W3C, Mozilla, Google, Microsoft, Vivaldi, BBC, Financial Times, ​​Red Hat, Oracle, Amazon, Wikimedia, Vercel, Netlify, Shopify, Spotify, AirBNB, Berlin University of the Arts, Open State Foundation - Netherlands, Cloudflare, Meta, Chase, Squarespace, Reddit, Atlassian, Maersk, Paypal, Salesforce, block, Adobe, ebay, Zynga, booking.com and thoughtworks; and many other developers and organisations from over 100 countries.
+
+## What happens next?
+
+While this is a stunning victory for the web, it is just one part of a longer battle.
+
+Since iOS’s inception Apple has [essentially banned third party browsers](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) from competing on iOS. All browsers currently on iOS are essentially re-skinned versions of Safari.
+
+Further Apple has set a ceiling on Web App functionality by denying them access to key features they need to compete. Apple has deliberately ensured that web apps are hidden in the operating system, and have not provided the ability to show an install button as they do with native apps.
+
+Combined [with significant bugs](https://open-web-advocacy.org/walled-gardens-report/#ios-safari-is-buggy), this has suppressed the uptake of Web Apps on mobile devices globally. Despite this, a significant number of consumers and organisations use them as a secure, open, interoperable and untaxed alternative to Apple’s and Google’s proprietary App Stores.
+
+This has also been noted by multiple regulators world wide:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+> <cite>[The Australian Competition and Consumer Commission](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf)</cite>
+
+> *Mandatory use of WebKit and reluctance to support web apps in browsers (Apple)*
+> Third-party browsers are forced to provide services based on WebKit, which lacks support for web apps, and competition through ingenuity among browsers may be impeded.
+> <cite>[Japan’s Headquarters for Digital Market Competition](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf)
+</cite>
+
+The reason the DMA states to open up browser engine competition (and iOS is the only major consumer operating system that bans competing engines) was to prevent gatekeepers from stopping third party browsers using their own engines to bring features to “web software applications”. This is stated in the act itself:
+
+> When gatekeepers operate and **impose web browser engines**, they are in a position to **determine the functionality** and standards that will apply not only to their own web browsers, but also to **competing web browsers** and, **in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)<br>
+(emphasis added)
+</cite>
+
+The fight is not over and will not be over until Apple allows both browsers and web apps to compete fairly on all their platforms globally. OWA will continue to work with both the EU Commision and regulators worldwide.
+
+In particular readers should look out for:
+* [The UK’s Market Investigation Reference into Browsers](https://open-web-advocacy.org/blog/cma-reopens-investigation-into-apple/)
+* [The UK’s Digital Markets, Competition and Consumers Bill (DMCC)](https://open-web-advocacy.org/blog/owa-2023-review/#uk) 
+* The [upcoming digital competition law in Japan](https://open-web-advocacy.org/blog/owa-2023-review/#japan) which focuses on 4 areas, one of which is browsers.
+* [Upcoming digital competition laws in Australia](https://open-web-advocacy.org/blog/owa-2023-review/#australia)
+* [Upcoming laws in India, Brazil and Korea](https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india)
+
+## We couldn’t do this without you!
+
+The enormous impact we’ve had over the last few weeks could not have been achieved without your support! Thank you to everyone who submitted a response to a survey, signed the letter or shared our calls to action on social media.  We couldn’t have done this without you.
+
+Behind the scenes, a small team of dedicated volunteers have worked almost non-stop for the past month to build and launch our surveys, open letters, social media campaigns, translate content, provide technical advice and write multiple lengthy regulatory submissions. 
+
+We’d like to personally thank, John Ozbay, Jasper Van den Ende, Lukasz Olejnik, Bruce Lawson, Runos, [Mysk](https://twitter.com/mysk_co), and Stuart Langridge for their support and we’d like to especially thank the open letter team, for putting in near full-time hours to keep the letter up and running 24/7, namely, [Art Müller](https://indieweb.social/@artmllr), [Steven Beshensky](https://hachyderm.io/@sbesh), [Jasper Van den Ende](https://mastodon.social/@Jespertheend), [Nick Chomey](https://mastodon.social/@nickchomey), [Roderick Gadellaa](https://mastodon.social/@rgadellaa) and [Angela Ricci](https://indieweb.social/@gericci). We’d like to say thank you to so many people at different organisations, who also fought hard on our side.
+
+OWA is incredibly grateful for your time and dedication and the web will be forever in your debt.
+
+We’d also like to thank everyone who has donated time or money, and all of our friends, family and colleagues who have allowed us the space and time to dedicate ourselves to this work in this extremely high-pressure moment. Thank you. ❤️
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+
+* [Donate to help with our running costs](https://open-web-advocacy.org/donate/)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Contact your local government representatives
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/ja/posts/apple-dma-changes.md
+++ b/src/ja/posts/apple-dma-changes.md
@@ -1,0 +1,68 @@
+---
+title: Apple's plan to allow browser competition dubbed unworkable
+date: '2024-01-27'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: James Moore
+relatedLinks:
+  - url: >-
+      https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/
+    title: >-
+      Apple announces changes to iOS, Safari, and the App Store in the European
+      Union
+    date: 2024-01-25T00:00:00.000Z
+permalink: /ja/blog/apple-dma-changes/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The #AppleBrowserBan Ends in the EU!
+
+After 3 years of campaigning by @OpenWebAdvocacy and in a victory for developers and consumers, Apple has been forced to allow third-party browsers in the EU.   
+
+The Digital Markets Act compels them to finally allow browser vendors to port their real browsers to iOS by March 7th, 2024, offering users in the EU (for the first time) a legitimate choice.
+
+This news is tempered by the fact that Apple's proposed solution to comply with the DMA rules to allow browser competition has not been well received.
+
+> Apple’s proposals fail to give consumers viable choices by making it as painful as possible for others to provide competitive alternatives to Safari
+<br>&mdash; [Damiano DeMonte - Mozilla spokesperson](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox)
+
+Others in the industry we have spoken to described Apple's compliance plan as it relates to browsers as "unworkable", "a massive problem for us" and "doing everything they can to make the DMA fail".
+
+## Competing via the Web
+{% image
+  "/images/blog/apple-dma-changes.webp",
+  "Apple claims the Web is the alternative.
+  For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too. Of course, there is always the open Internet and web browser apps to reach all users outside of the App Store."
+%}
+
+Apple claims repeatedly, if you don’t like their app store, don’t use it. You can use the web and web apps to reach your customers.
+
+They say this, while at the same time preventing this from happening by not providing the tools needed in their own browser and blocking other browsers from providing them.
+
+It is clear that Apple far from being embarrassed at, for over a decade, having effectively banned all third party browsers will only change this policy where legally compelled to do so.
+
+Further, Apple’s language is rife with fear mongering:
+> “Apple argues (without any particular merit or evidence) that these other engines are a security and performance risk and that only WebKit is truly optimized and safe for iPhone users.”  <br>&mdash; [David Pierce - The Verge](https://www.theverge.com/2024/1/25/24050478/apple-ios-17-4-browser-engines-eu)
+
+Apple's decision to [geo-lock this change](https://developer.apple.com/support/alternative-browser-engines/#:~:text=for%20dedicated%20browser%20apps%20and%20apps%20providing%20in%2Dapp%20browsing%20experiences%20in%20the%20EU) underscores their on-going resistance to a truly open web. We will be actively analysing their compliance solution as well as identifying and challenging any loopholes that hinder fair competition.
+
+We need your help to scrutinise every aspect of the compliance proposal for anything that is designed to undermine the DMA’s intent. You can read about Apple’s proposal for compliance here:
+* [Apple announces changes to iOS, Safari, and the App Store in the European Union - Apple](https://www.apple.com/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/)
+* [Using alternative browser engines in the European Union - Support - Apple Developer](https://developer.apple.com/support/alternative-browser-engines/)
+* [BrowserEngineKit | Apple Developer Documentation](https://developer.apple.com/documentation/browserenginekit)
+* [Designing your browser architecture | Apple Developer Documentation](https://developer.apple.com/documentation/browserenginekit/designing-your-browser-architecture)
+* [AppStore Guidelines](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20JavaScript.%20You%20may%20apply%20for%20an%20entitlement%20to%20use%20an%20alternative%20web%20browser%20engine%20in%20your%20app.%20Learn%20more%20about%20these%20entitlements.)
+
+**This victory wouldn't have been possible without your unwavering support**. While we celebrate this important step, let's remember the fight for global browser competition continues. Stay tuned, and let's work together to ensure browser choice for all users, everywhere!
+
+**Your browser, your choice!**
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/apple-dma-review.md
+++ b/src/ja/posts/apple-dma-review.md
@@ -1,0 +1,462 @@
+---
+title: Apple DMA Review
+date: '2024-06-21'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+relatedLinks: null
+permalink: /ja/blog/apple-dma-review/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<p>
+  The Digital Markets Act (DMA) aims to restore contestability, interoperability,
+  choice and fairness back to digital markets in the EU. These fundamental
+  properties of an effectively functioning digital market have been eroded by the
+  extreme power gatekeepers wield via their control of “core platform services”.
+</p>
+<p>
+  The lack of competition on mobile ecosystems is, at its heart, a structural one.
+  Gatekeepers wield vast power due to the security model that these devices are
+  built on. Traditionally, on operating systems such as Windows, macOS and Linux,
+  users can install any application they want, with no interaction from the
+  operating system gatekeeper, either by the business or the end user. Users can
+  then grant these programs the ability to do anything they desire.
+</p>
+<p>
+  Locking down what applications can do, such as restricting which APIs they can
+  access behind user permissions, is not by itself anti-competitive and can bring
+  legitimate security advantages. However, the manner in which it has been
+  implemented on mobile devices is both self-serving and in its current form,
+  significantly damages competition.
+</p>
+<p>
+  This damage surfaces in several forms:
+</p>
+<p>
+  First, the gatekeeper can control what is allowed to be installed on devices
+  they have already sold to consumers, often for a significant profit. They
+  utilize this device-level control to demand a 30% cut of all third-party
+  software that the consumer installs, not on merit, but simply because they
+  control the only mechanisms available to businesses to release that software,
+  and can further block or hinder the consumer from using or acquiring services
+  outside of their app store.
+</p>
+<p>
+  The second is more subtle. In order to deliver their “native” apps to consumers
+  on Android or iOS, developers must create custom applications in specific
+  programming languages for each individual platform. Typically, companies will
+  require separate development teams for each OS. This not only multiplies
+  development and maintenance cost, but puts in place an invisible barrier to
+  interoperability. Even the built up expertise for creating software for a
+  specific platform provides significant lock-in advantages to the platform’s
+  gatekeeper.
+</p>
+<p>
+  Finally, even if a developer has no desire to interact with the gatekeeper, they
+  are forced into a commercial and legally binding relationship with them. This is
+  due to the fact that the gatekeeper inserts itself between the customer and
+  these third party developers. With smartphones now 15 years old, this may seem
+  normal to us now, but imagine if Microsoft demanded that every software provider
+  signed an onerous contract with them or be barred from releasing a product on
+  Windows. What would have been unacceptable, anti-competitive behavior to both
+  consumers, businesses and regulators on desktop, has been tolerated on mobile
+  simply because these computers were considered a “new” category.
+</p>
+<p>
+  Mobile devices are just small computers whose primary input is touch, there is
+  no sacred or magical property that means they have to run on a proprietary app
+  store model. Nothing is stopping mobile computers running on the open model that
+  desktop computers run on, just as there is nothing stopping a desktop computer
+  running the app store model. Inertia and great profits are however powerful
+  forces. Between them, Apple and Google have created a powerful and entrenched
+  duopoly.
+</p>
+<p>
+  Even with the DMA forcing Apple to open up the ecosystem to competition, Apple
+  is still inserting themselves front and center between consumers and app
+  developers. They insist all developers for iOS/iPadOS (including developers who
+  have no intention of using their app store) pay them $100 per year, that they
+  sign the full Apple developer program contract and submit themselves to what is
+  effectively app store review (although nominally locked to security). Worse,
+  they are attaching significant recurring penalty fees to developers who dare to
+  make their software available outside of Apple’s app store. Apple is using every
+  tool at their disposal to dissuade developers from leaving their app store and
+  to undermine the goals of the DMA.
+</p>
+<p>
+  Apple's key excuse to impose this control is security. Apple's argument is, in
+  essence, that only they can be trusted to vet what consumers are allowed to
+  install on their devices. All third parties must submit to their review.
+</p>
+<p>
+  What is needed is a way to securely run interoperable and capable software
+  across all operating systems. Luckily, such a solution already exists and is not
+  only thriving on open desktop platforms but is dominating, and that
+  dominance is growing every year. The solution is of course, the Web and more
+  specifically Web Apps. Today, more than 60% of users' time on desktop is done
+  using web technologies, and that looks set to only grow.
+</p>
+<p>
+  Web Apps have a number of properties that allow them to solve this critical
+  problem. They are run in the security of the browser's sandbox, which <a rel="noreferrer" target="_blank" href="https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf">even
+    Apple admits is “orders of magnitude more stringent than the sandbox for native
+    iOS apps.”</a>. They are truly interoperable between operating systems. They
+  don't require developers to sign contracts with any of the OS gatekeepers. They
+  are capable of incredible things and 90% of the apps on your phone could be
+  written as one today.
+</p>
+<p>
+  So why aren't they thriving on mobile? The simple answer to this question is
+  lack of browser competition on iOS and active hostility by Apple towards
+  effective Web App support, both by their own browser and by their OS. Apple's
+  own browser faces no competition on iOS, as they have effectively barred the
+  other browsers from competing by prohibiting them from using or modifying their
+  engines, the core part of what allows browser vendors to differentiate in
+  stability, features, security and privacy.
+</p>
+<p>
+  The DMA explicitly sets out to right this wrong by mandating that gatekeepers
+  can no longer enact such a ban:
+</p>
+
+<blockquote>
+  <p>In particular, each browser is built on a web
+    browser engine,
+    which is responsible for key browser functionality such as
+    speed, reliability and web compatibility. When gatekeepers
+    operate and impose web browser engines, they are in a position
+    to determine the functionality and standards that will apply
+    not only to their own web browsers, but also to competing web
+    browsers and, in turn, to &gt;web software applications.
+    Gatekeepers
+    should therefore not use their position to require their
+    dependent business users to use any of the services provided
+    together with, or in support of, core platform services by the
+    gatekeeper itself as part of the provision of services or
+    products by those business users.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG">Digital
+        Markets Act - Recital 43</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  The intent stated for this in the DMA is to prevent gatekeepers from dictating
+  the speed, stability, compatibility and feature set of “web software
+  applications”.
+</p>
+<p>
+  Apple has announced new rules that would, at first glance, allow browser vendors
+  to port their real browsers to iOS. However, on closer inspection, this is a
+  mirage. Instead Apple appears intent on making it <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox">“as
+    painful as possible” for browser vendors</a> to port their engines to
+  iOS/iPadOS. As we will outline in our paper, Apple's current proposal falls far
+  short of compliance. Apple is not only undermining browser competition on iOS,
+  but appears to be actively attempting to prevent the growth of an entire open
+  and interoperable ecosystem that could feasibly supplant and replace their app
+  store model.
+</p>
+<p>
+  Apple have seen the Web as a threat to their app store as far back as 2011, when
+  Philip Schiller internally sent an email to Eddie Cue titled “HTML5 poses a
+  threat to both Flash and the App Store”.
+</p>
+
+<blockquote>
+  <p>
+    Food for thought: Do we think our 30/70% split will last forever? While I am a
+    staunch supporter of the 30/70% split and keeping it simple and consistent across
+    our stores, I don’t think 30/70 will last unchanged forever. I think someday we will
+    see a challenge from another platform or a web based solution to want to adjust our
+    model.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html">
+        Phil Schiller - Apple Upper Management
+      </a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  This attitude appears not to have changed. Faced with the genuine possibility of third-
+  party browsers effectively powering Web Apps, Apple's first instinct appears to have
+  been to <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/">
+    remove Web Apps support entirely with no notice to either businesses or
+    consumers</a>. Luckily, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/">
+    under significant pressure, Apple backed down</a> from this particular
+  stunt at the last moment.
+</p>
+
+<p>
+  Apple is very explicit in its public statement that they initially planned to remove the
+  functionality as the DMA would force them to share it with third-party browsers. Even in
+  their statement backing down, they make it clear they do not intend to allow third-party
+  browsers that use their own engine to be able to install and manage Web Apps. In both
+  statements, Apple cites "security" as the reason for their decisions.
+</p>
+<p>
+  Unfortunately for Apple, it has been unable to prove that Safari or WebKit are actually
+  more secure than its competitors. When obligated by the UK’s Competition and Markets
+  Authority to provide evidence to back up its assertion that WebKit was more secure than
+  Blink or Gecko, Apple failed to do so.
+</p>
+
+<blockquote>
+  <p>... the evidence that we have seen to date does not suggest that there are material
+    differences in the security performance of WebKit and alternative browser engines.
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>Overall, the evidence we have received to date does not suggest that Apple's
+    WebKit restriction allows for quicker and more effective response to security threats
+    for dedicated browser apps on iOS.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Apple's actions not only hurt the Web ecosystem, third-party businesses (be they
+  browser vendors or software developers), but also make their devices worse for their own
+  consumers. By depriving their consumers of the choice and competition that fair and
+  effective browser and Web App competition would bring, they are worsening the
+  functionality, interoperability, stability, security, privacy, and price of services on their
+  devices.
+</p>
+<p>
+  A reasonable person might argue
+  <em>Why would Apple make their own devices worse, surely
+    better devices means more hardware sales?</em> This behavior comes, however, with key
+  advantages for Apple, even if they harm Apple's own consumers.
+</p>
+
+<p>
+  Critically, service revenue is of growing importance for Apple as
+  <a rel="noreferrer" target="_blank" href="https://www.bbc.com/news/articles/c99zxzjqw2ko">their hardware sales have
+    peaked and are declining</a>. Apple has not had a “hit” new product for 14 years, namely the
+  iPad, and, if you are being generous, 9 years for the Apple Watch. It does not currently
+  seem likely that Apple’s VR/AR headset
+  <a rel="noreferrer" target="_blank" href="https://mashable.com/article/apple-vision-pro-sales-drop">will
+    have any significant impact on Apple’s overall
+    hardware sales</a>.
+</p>
+
+<p>
+  The UK regulator cites two incentives: protecting their app store revenue from
+  competition from Web Apps, and protecting their Google search deal from competition
+  from third-party browsers.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple receives significant revenue from Google
+      by setting Google Search as the
+      default search engine on Safari</strong>, and therefore benefits financially
+    from high usage
+    of Safari. [...] <strong class="stressed">The WebKit restriction may help to
+      entrench this position</strong> by limiting
+    the scope for other browsers on iOS to differentiate themselves from Safari [...] As
+    a result, it is less likely that users will choose other browsers over Safari, which in
+    turn <strong class="stressed">secures Apple’s revenues from Google</strong>.
+    [...]
+    Apple generates revenue through its App Store, both by charging developers for
+    access to the App Store and by taking a commission for payments made via Apple
+    IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring
+    all browsers on iOS to use the WebKit browser engine,
+    <strong class="stressed">Apple is able to exert control
+      over the maximum functionality of all browsers on iOS</strong> and, as a consequence,
+    hold up the development and use of web apps. This limits the <strong class="stressed">competitive
+      constraint that web apps pose on native apps</strong>, which in turn protects and benefits
+    Apple’s App Store revenues.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report">
+        UK CMA - Interim Report into Mobile Ecosystems</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  These two revenue streams are vast, even for a company of Apple’s size. Apple collected
+  <a rel="noreferrer" target="_blank" href="https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.">
+    $85 billion USD in App Store fees in 2022</a>,
+  of which it keeps approximately 30%. Apple
+  reportedly receives
+  <a rel="noreferrer" target="_blank" href="https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22">
+    $18-20 billion USD</a> a year from their Google Search engine deal,
+  accounting for 14-16 percent of Apple's annual operating profits.
+</p>
+<p>
+  A third and interesting incentive the CMA does not cite, but which the US's Department of
+  Justice does, is that this behavior greatly weakens the interoperability of Apple's devices,
+  making it harder for consumers to switch or multi-home. It also greatly raises the barriers
+  of entry for new mobile operating system entrants by depriving them of a library of
+  interoperable apps.
+</p>
+
+<blockquote>
+  <p>
+    <strong class="stressed">Apple has long understood how middleware can help promote
+      competition</strong> and
+    its myriad benefits, including increased innovation and output,
+    <strong class="stressed">by increasing scale and interoperability</strong>.
+    [...]
+    In the context of smartphones, examples of
+    <strong class="stressed">middleware include internet browsers</strong>,
+    internet or cloud-based apps, super apps, and smartwatches, among other products
+    and services.
+    [...]
+    <strong class="stressed">
+      Apple has limited the capabilities of third-party iOS web browsers, including by
+      requiring that they use Apple’s browser engine, WebKit</strong>.
+    [...]
+    Apple has sole discretion to review and approve all apps and app updates.
+    <strong class="stressed">Apple
+      selectively exercises that discretion to its own benefit</strong>, deviating from or changing
+    its guidelines when it suits Apple’s interests and allowing Apple executives to control
+    app reviews and decide whether to approve individual apps or updates. Apple often
+    enforces its App Store rules arbitrarily.
+    <strong class="stressed">And it frequently uses App Store rules and
+      restrictions to penalize and restrict developers that take advantage of
+      technologies that threaten to disrupt, disintermediate, compete with, or erode
+      Apple’s monopoly power</strong>.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.justice.gov/opa/media/1344546/dl?inline">
+        DOJ Complaint against Apple</a>
+      <br>(emphasis added)
+    </cite>
+  </p>
+</blockquote>
+
+<p>
+  Interoperability via middleware would reduce lock-in for Apple’s devices. Lock-in is a clear
+  reason for Apple to block interoperability, as can be seen in this email exchange where
+  Apple executives dismiss the idea of bringing iMessage to Android.
+</p>
+
+<blockquote>
+  <p>
+    The #1 most difficult [reason] to leave the Apple universe app is iMessage ...
+    iMessage amounts to serious lock-in
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Unnamed Apple Employee</a>
+    </cite>
+  </p>
+</blockquote>
+
+<blockquote>
+  <p>
+    iMessage on Android would simply serve to remove [an] obstacle to iPhone
+    families giving their kids Android phones ... moving iMessage to Android will hurt us
+    more than help us, this email illustrates why.
+    <cite>
+      <a rel="noreferrer" target="_blank" href="https://www.theverge.com/2021/4/9/22375128/apple-imessage-android-ecosystem-lock-in-epic-games-filings-app-store-dispute">
+        Craig Federighi - Apple's Senior Vice President of Software Engineering</a>
+    </cite>
+  </p>
+</blockquote>
+
+<p>The DMA has the power to fix all of these underlying issues and unleash a powerful,
+  open, interoperable and secure competitor to not only Apple's
+  app store but also Google's. Lack of
+  contestability for mobile app stores and mobile operating systems is
+  a key concern for the DMA that viable Web
+  Apps solve.
+</p>
+
+<p>This will also remove a heavy burden from new entrants into the operating system
+  market; lack of apps. No longer will developers need to develop custom apps
+  for each operating system, any
+  operating system with good web app support and browser competition will support
+  all web apps automatically. Web
+  Apps support operating systems that developers have not even heard of.
+  The impact of allowing them to compete
+  fairly on mobile will be profound.
+</p>
+
+<p>
+  We request the Commission open a proceeding into Apple and investigate what we allege
+  is severe and deliberate non-compliance. The number of ways that Apple is not complying is so myriad that we,
+  recognising that the commision does not have infinite resources to pursue all of them simultaneously, have split
+  them into three tranches of remedies.
+</p>
+<p>Some remedies require time and/or pre-requisite remedies in order to be effective.
+  Remedies in this document are ordered to ensure that either competitive benefits are delivered earlier or to
+  unlock future remedies. In this way, we propose a program of continual improvement in the competitive landscape,
+  delivering wins at every step along the path.
+</p>
+
+<p>While we have attempted to be comprehensive, it is possible, and perhaps even likely,
+  that there will be infringements that we have not included or are not yet aware of.
+</p>
+
+<p>Our proposed remedies include:</p>
+
+<ul>
+  <li>Restricting Apple's API contract for browsers down to strictly necessary,
+    proportionate and justified security measures.</li>
+  <li>Make clear what the security measures are for third party browsers using
+    their own engine by publishing them in a single up-to-date document.</li>
+  <li>Removing any App Store rule that would prevent third party browsers from
+    competing fairly.</li>
+  <li>Allow browser vendors to keep their existing EU consumers when switching
+    to use their own engine.</li>
+  <li>Removing the special placement of Safari.</li>
+  <li>Making Safari uninstallable.</li>
+  <li>Implementing Install Prompts in iOS Safari for Web Apps.</li>
+  <li>Allowing Browser Vendors and Developers to be able to test their browsers
+    and web software outside the EU.</li>
+  <li>Allowing Browsers using their own engine to install and manage Web Apps.</li>
+  <li>Make notarization a fast and automatic process, as on macOS.</li>
+  <li>Allow direct browser installation independently from Apple’s app store.</li>
+  <li>Allow users to switch to different distribution methods of a native
+    app and allow developers to promote that option to the user.</li>
+  <li>Don't break third party browsers for EU residents who are traveling.</li>
+  <li>Opt-Into Rights contract should be removed.</li>
+  <li>Core Technology Fee should be removed.</li>
+  <li>Apple should publish a new more detailed compliance plan.</li>
+</ul>
+
+<p>Apple is obligated under Articles 5(7), 6(3), 6(4) and 6(7) to fix each
+  of the above issues. Apple has failed to achieve effective compliance
+  with these obligations contrary to Article 13(3). Further Apple has
+  taken numerous and significant steps that obstruct and undermine it in
+  contravention of Article 13(4). Apple has introduced conditions and
+  restrictions on DMA-conferred rights that have no legal basis in the
+  DMA and gone far beyond the restrictions that the DMA does allow by
+  introducing rules that have no basis in security or that are not justified,
+  strictly necessary or proportionate.
+</p>
+
+<p>Any intervention that the Commission makes will have global ramifications. Regulators around the world are carefully watching the implementation of the DMA as they plan their own regulatory regimes. Already <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/japan-ends-the-apple-browser-ban/">Japan has become the second jurisdiction in the world to explicitly prohibit banning browser engines</a>. <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/">Australia</a>, <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/owa-2023-review/#korea%2C-brazil%2C-india">India, Korea and Brazil</a> are all planning on implementing their own versions of the DMA. The UK has just <a rel="noreferrer" target="_blank" href="https://open-web-advocacy.org/blog/uk-passes-dmcc/">passed the Digital Markets, Competition and Consumers Bill</a> that grants their regulator great power to enforce codes of conduct against tech giants.
+</p>
+
+<p>Successful resolution of these issues have an exceptional chance of becoming de facto global, as no jurisdiction will want to miss out on clear benefits being enjoyed by EU consumers. However, if Apple manages to successfully avoid complying with the DMA, these problems could persist indefinitely.
+</p>
+
+<p>
+  We urge the Commission to enforce the DMA and obligate Apple to allow
+  browsers and Web Apps to compete fairly and effectively on their mobile ecosystem.
+  This will unlock contestability, fairness and interoperability. Companies will then
+  have to compete for users on merit, not via lock-in or control over operating
+  systems. Consumers will benefit from choice, better quality and cheaper software,
+  interoperability, and the genuine ability to multihome across devices and operating
+  systems offered by different companies.
+</p>
+
+<p>
+  These changes can finally fix a mobile ecosystem that has been
+  structurally broken, and artificially hindered, for more than a decade.
+</p>
+
+
+<p>That was the introduction to our report. You can read the <a href="/apple-dma-review/#h.3znysh7">full far more detailed report here.<a></p>

--- a/src/ja/posts/apple-filing-eu-appstores.md
+++ b/src/ja/posts/apple-filing-eu-appstores.md
@@ -1,0 +1,38 @@
+---
+title: Apple files another challenge to the EU Digital Markets Act
+date: '2024-01-09'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: Frances Berriman
+permalink: /ja/blog/apple-filing-eu-appstores/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/apple-appstore-filing-img.webp",
+  "Apple will be allowed to continue not offering alternative browsers to their users via the default mechanism those users get apps - Open Web Advocacy"
+%}
+
+We’ve previously covered filings from Apple [claiming Safari is actually 3 browsers](https://www.macrumors.com/2023/11/04/apple-argued-safari-is-three-different-browsers) and that [iPadOS shouldn’t be regulated under the DMA](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) at all, which are arguments that have not held much water in our minds. But on Monday the EU published Apple's November filing, so we’ve been [able to see a bit more about what they’re requesting](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:C_202400563). 
+
+In this latest filing, Apple claims that:
+
+1. That the EU’s application of the DMA is a disproportionate intervention in response to iOS market distortions. 
+2. The AppStore should be considered five separate entities, one for each OS (iPadOS, iOS, watchOS, tvOS and macOS). We’ve [previously discussed](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) how Apple’s distinction between iPadOS and iOS is tenuous.
+3. That iMessage should not be designated, because iMessage is neither hardware nor subscription dependant.
+
+At OWA, we don’t have a ton of opinions on the third claim, but we do on the first two, as they’re material to the interests of web developers and relevant browser competition.
+
+If Apple is able to convince the EU not to regulate their AppStore, Apple will be allowed to continue effectively banning third party browsers from being available to their users via the default mechanism those users get apps. As [discussed extensively](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) Apple has banned third party browsers on iOS from using their own engine or modifying an existing engine, instead forcing third party browser vendors to build a browser on top of the system supplied WebKit WebView over whose functionality Apple has exclusive control. A possible outcome of avoiding EU regulation of their App Store is that users may only be allowed to later have additional browsers via side-loading, but OWA is sceptical about this as a path to a fairer landscape.
+
+[With 57 days remaining until the Digital Markets Act enforcement begins](https://digital-markets-act.ec.europa.eu/about-dma_en), we expect to see a few more filings from Gatekeepers, as well as responses from the EU. We’ll keep you posted!
+
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/apple-implements-six-of-owas-dma-compliance-requests.md
+++ b/src/ja/posts/apple-implements-six-of-owas-dma-compliance-requests.md
@@ -1,0 +1,188 @@
+---
+title: Apple implements six of OWA's DMA compliance requests
+date: '2024-10-25'
+tags:
+  - Policy
+  - Apple
+  - EU
+  - DMA
+author: OWA
+permalink: /ja/blog/apple-implements-six-of-owas-dma-compliance-requests/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: Apple has fixed 6 important issues with allowing browsers and Web Apps to compete on iOS (including allowing browser vendors to test their own browsers outside the EU) but a massive list of issues remain to be fixed in order to be in compliance with the DMA.**
+
+**Most importantly, there is no indication that Apple will allow Web Apps to run in a browser's own engine despite the [news](https://www.macrumors.com/2024/10/24/ios-18-2-eu-third-party-browser-web-apps/) [reports](https://9to5mac.com/2024/10/23/ios-18-2-web-apps-browser-engine-in-the-eu/) OR that browsers will be able to use their own engine without being forced to lose their existing customers.**
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1849747949317914780), [Mastodon](https://mastodon.social/@owa/113367403899362760) and [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_apples-ios-182-has-implemented-6-of-owas-activity-7255515996558381056-0nig).
+
+Readers Note: When you see the term "EU Only" in this article it's important to recognize this as a reflection of Apple's anti-competitive practices. Such measures should ideally be implemented on a global scale, promoting fair competition for all their users in all jurisdictions.
+
+## What have they done?
+
+Apple has announced a series of changes in iOS 18.2 related to third-party browsers in the EU.
+
+> Following feedback from the European Commission and from developers, in these releases developers can develop and test EU-specific features, such as alternative browser engines, contactless apps, marketplace installations from web browsers, and marketplace apps, from anywhere in the world. Developers of apps that use alternative browser engines can now use WebKit in those same apps.
+> <cite>[Apple - Blog on iOS 18.2](https://developer.apple.com/news/?id=qs5bol0g)</cite>
+
+### Dual Engine Browsers (EU ONLY)
+
+Due to Apple’s 16 year ban of third-party browser engines, browser vendors will need to gradually phase in their own engines over time using phased roll-outs and multi-variant testing. Deploying an engine to a new operating system is a complex process and has to be done in a slow and methodical manner to identify bugs and performance issues.
+
+As a result, it is essential that all browser vendors be allowed to ship dual engine browsers. That is, browsers that can use both the system provided WKWebView and their own engine within a single binary. The binary would only contain the code for a single engine, the one the browser vendor provides, since the WKWebView is an operating system provided component.
+
+Browser vendors also need to be allowed to keep their existing EU users. Allowing dual engine browsers also makes this simple by letting browser vendors simply toggle their own engine on or off depending on if Apple allows them to use it in a particular jurisdiction.
+
+However, Apple had added a rule in their contract to explicitly ban this:
+
+> Be a separate binary from any Application that uses the system-provided web browser engine;
+> <cite>[Apple Browser Engine Entitlement Contract - 2024-06-24](/files/Apple%20Browser%20Engine%20Entitlement%20Contact%20(2024-06-24).pdf)</cite>
+
+To our knowledge there was no reasonable or rational reason to impose this restriction. It would also appear to be in violation of the DMA which only allows APIs to be restricted on the grounds of strictly necessary, proportionate and justified security grounds.
+
+On October the 23rd, [the contract](/files/Apple%20Browser%20Engine%20Entitlement%20Contact%20(2024-10-23).pdf) was updated to remove that single line. 
+
+Apple also announced the change in this blog post:
+
+> Developers of apps that use alternative browser engines can now use WebKit in those same apps.
+> <cite>[Apple - Blog on iOS 18.2](https://developer.apple.com/news/?id=qs5bol0g)</cite>
+
+Importantly this means that browser vendors currently need two browsers. A Webkit only one for outside the EU and their existing EU customers, and a new one that uses their own engine (and can now also use the WebKit engine). 
+
+### Allowing Browser Vendors to Test their own Browsers Outside the EU
+
+Astonishingly, Apple decided earlier this year to make it impossible for browser vendors to test their own browsers if the developers were not physically located in the EU.
+
+> The Register has learned from those involved in the browser trade that Apple has limited the development and testing of third-party browser engines to devices physically located in the EU. That requirement adds an additional barrier to anyone planning to develop and support a browser with an alternative engine in the EU. <br><br>
+> It effectively geofences the development team. Browser-makers whose dev teams are located in the US will only be able to work on simulators. While some testing can be done in a simulator, there's no substitute for testing on device – which means developers will have to work within Apple's prescribed geographical boundary.
+> <cite>[Thomas Claburn - The Register](https://www.theregister.com/2024/05/17/apple_browser_eu/)</cite>
+
+This was clearly ridiculous. With iOS 18.2, Apple now allows not only browser vendors but all app developers (wherever they are in the world) to test their own apps which use APIs or functionality that Apple currently restricts to the EU.
+
+However, there is still no solution proposed by Apple to allow web developers outside the EU the ability to test and maintain their websites and Web Apps for EU consumers on third-party browsers which use their own engine. This is and will remain a significant barrier to browser competition on iOS.
+
+Our proposal is that web developers outside the EU should be able to download test versions of EU browsers via an Apple Developer Account for the purpose of testing their own products.
+
+### Centralised Defaults (GLOBAL)
+
+For the last 16 years Apple has had no centralised location to change defaults. Up until iOS late 2020 (iOS 14\) it wasn’t even possible to change the default browser. When Apple finally did allow users to change the default browser, they added the [brazen deceptive pattern of hiding the dropdown to change default browser if Safari was already the default](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/). This was only quietly fixed in iOS 17.5 [due to OWA](https://open-web-advocacy.org/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/) [and later Ars Technica](https://arstechnica.com/tech-policy/2024/04/report-people-are-bailing-on-safari-after-dma-makes-changing-defaults-easier/) calling Apple out on the behaviour.
+
+In [our review of Apple’s DMA compliance](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api) we outlined that Apple needed to add a centralised location to change defaults.
+
+[In August](https://www.theverge.com/2024/8/22/24226110/apple-iphone-ipad-default-apps-eu-competition) Apple announced that they were making this change for the EU. Now, this change is being rolled out globally. Our assumption is that Apple struggled to explain to other regulators worldwide why this change, already implemented for EU users, should be withheld from global users.
+
+### Browsers can Detect if Default Browser (EU ONLY)
+
+Browsers can now detect if they are the default browser **once per year**.
+
+> In iOS 18.2 and iPadOS 18.2, a new API will allow a browser app to check if it is currently the default browser app. To reduce the likelihood that users will face continuous requests to set a browser as their default, this API will only tell the browser app if it is the default once per year. This API will be further documented in an upcoming beta release of iOS 18.2 and iPadOS 18.2.
+> <cite>[Apple - Default Apps](https://developer.apple.com/documentation/updates/defaultapps)</cite>
+
+We had previously written about [how browser vendors need the ability to detect whether they are the default browser](https://open-web-advocacy.org/apple-dma-review/#default-browser-dark-patterns-and-prompt-api) in order to allow better onboarding processes and not bother users who have already set their browser as default.
+
+While there is some rationale for preventing browsers from repeatedly asking users, it is not clear that it is necessary to limit the ability to check the current status. Apple has for example felt there is no need to add a limit on the number of times a native app [can check if they have permission to use notifications](https://developer.apple.com/documentation/usernotifications/asking-permission-to-use-notifications#Customize-notifications-based-on-the-current-authorizations).
+
+We’ll be checking in with the browser vendors and pro-consumer groups to see what they think of the once per year limit, to work out our own opinions as to whether this is reasonable consumer protection measure or if it’s simply anti-competitive. Safari pulls in $20 billion USD annually for Apple and 14-16 percent of Apple's annual operating profits, so any decisions like this have to be examined with a fine-tooth comb.
+
+### Prompt for Default Browsers missed in Previous Choice Screen to be Placed in the Hotseat/HomeScreen (EU ONLY)
+
+[In August Apple announced they would implement one of our recommendations](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/) that browsers chosen in the choice seat would get placed in the hotseat/dock/first homescreen replacing Safari.
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser that is not currently installed on their device from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen
+> <cite>[Apple - About the browser choice screen in the EU (2024-08-19)](https://web.archive.org/web/20240919123712/https://developer.apple.com/support/browser-choice-screen/)</cite>
+
+
+One issue with this, [which we wrote about at the time](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/), is it does not apply to browsers which are already installed. Apple needed to update this to move already installed browsers onto the hotseat to replace the Safari icon when it had been selected on the choice screen.
+
+Apple have now update the policy with the following relatively complex paragraphs:
+
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user selects a browser that is not currently installed on their device from the choice screen, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen. If the user selects a browser that is currently installed on their device from the choice screen but not on the first page of the Home Screen or the Dock, the selected browser will replace the Safari icon in the user’s Dock or in the Home Screen. <br><br>
+> If Safari is currently in the user’s Dock or on the first page of the Home Screen and the user had previously selected another other browser as their default from the choice screen before updating to iOS 18.2, they will be prompted once upon first launch of Safari about whether they want to swap Safari’s icon with the icon of their default browser. This is only if their default browser is not on the first page of the home screen or the Dock.
+> <cite>[Apple - About the browser choice screen in the EU](https://developer.apple.com/support/browser-choice-screen/)</cite>
+
+This means that any browser chosen on the choice screen will replace Safari on the dock/first home screen if it is there.
+
+For browsers that were already installed prior to the previous choice screen, chosen as default on the choice screen (and which Apple decided not to move onto the dock/first home screen), these browsers will now prompt the user if they would like to swap with Safari’s icons location on first launch of Safari.
+
+Prompting the user when they are trying to open Safari feels like an attempt to get the user to dismiss the prompt, as they are likely midway through a task; and it’s hard to see a reason for this other than an anti-competitive attempt to add friction to the user switching which browser they primarily use. This prompt should happen as part of the iOS 18.2 update process.
+
+### Users can uninstall Safari (EU ONLY)
+
+Apple will now let EU users uninstall Safari. This is psychologically important as it indicates to users that Safari is just another app on their phone that can be uninstalled and replaced, just like any other non-Apple app.
+
+This is a change that is required by the DMA and that [we argued in favour of](https://open-web-advocacy.org/apple-dma-review/#safari-is-not-uninstallable) earlier this year. Importantly, the WKWebView and SFSafariViewController should be treated as system components, and it should not be possible to uninstall them.
+
+## What's Left?
+
+### Browsers still can't install Web Apps powered by their Own Engine
+
+> With the release of the first beta of iOS 18.2 to developers on Wednesday, Apple has published documentation for a new API that will let third-party browsers add web apps to the iPhone Home Screen using their own custom engine. **This means that the entire web app experience will run using the same engine as the browser through which it was added.**<br><br>
+> Of course, there’s a catch. Currently, only web browsers distributed in the EU can have a custom engine. In the rest of the world, Apple still requires web browsers for iPhone and iPad to use Safari’s WebKit. Unsurprisingly, the new API for web apps is also only available in the EU.
+> <cite>[Filipe Espósito - 9to5mac](https://9to5mac.com/2024/10/23/ios-18-2-web-apps-browser-engine-in-the-eu/)<br>(emphasis added)</cite>
+
+When we first saw the article headline we were incredibly excited, as this would finally be a key step into unlocking Web Apps. Web Apps are amazing because you only have to code them once, they work on every device, have significantly better security, and don't require you to pay excessive rents to gatekeepers.
+
+However, having looked through Apple's documentation we believe this functionality won't allow third-party browsers to install web apps powered by their own engine, and will simply continue to exclusively offer Apple's WebKit based Web Apps in contravention of the DMA.
+
+We have contacted Filipe Espósito from 9to5mac to request that he verify this statement with Apple and the other major browser vendors. At the time of publishing this article, we have yet to receive a response.
+
+### Browser Vendors are still Obligated to Ship a Brand New App
+
+Apple has chosen to restrict browser competition on iOS to the EU. Apple’s actions seek to force third-party browser vendors to build, develop, and maintain two versions of their apps for iOS while Apple’s own Safari bears no such costs.
+
+Apple’s rules appear to force browser vendors to ship a brand new version of their app in the EU, rather than update existing apps to use their own engines. This will cause browser vendors to lose existing customers, as consumers will need to manually download the new browser.
+
+This complexity and friction is a direct result of Apple’s own anti-competitive actions over the past 16 years. Apple’s insistence that competitors will be allowed to compete on a level playing field (with their own engines) only in the EU is already a high burden, and this rollout plan would levy additional transition costs on competitors. It is reasonable and proportionate that Apple takes steps to mitigate the damage they appear intent on causing.
+
+Forcing browser vendors to ship two distinct products in Europe will lead to end user confusion and significant harm to these browser vendors. We do not believe that such an approach would be either fair or compliant with the DMA.
+
+Apple should not be forcing browser vendors to reacquire existing users. Apple will need to implement a solution where browser vendors can use their own engines and keep their existing EU users.
+
+Absent the real good faith solution of just allowing browser competition globally, there remains a simple solution: to simply allow browser vendors to ship their browsers globally under a single bundle ID with both Webkit and their own engines and let them know if that user is allowed to use the browser’s own engine with a true/false environment variable or equivalent.
+
+Additional complexity and questions arise when users move in and out of the EU, will their browser continue to work when they are on holiday?  How does data transfer work (cookies, Indexeddb, localstorage etc) internally between the WebKit version and the browsers own engine’s version. These are challenging issues that arise from Apple's reluctance to address anti-competitive behaviour except in jurisdictions where they are compelled to do so.
+
+### Other Problems
+
+While today's news are important steps to allowing fair and effective browser and web app competition on iOS, a great many DMA compliance issues remain, including:
+
+* [Allow browser vendors to keep their existing EU consumers when switching to use their own engine.](https://open-web-advocacy.org/apple-dma-review/#allow-browser-vendors-to-keep-their-existing-EU-customers)  
+* [Allowing Developers to be able to test their browsers and web software outside the EU.](https://open-web-advocacy.org/apple-dma-review/#testing-for-browser-vendors-and-developers-outside-the-EU)  
+* [Restricting Apple's API contract for browsers down to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/apple-dma-review/#remove-non-security-terms)  
+* [Make clear what the security measures are for third party browsers using their own engine by publishing them in a single up-to-date document.](https://open-web-advocacy.org/apple-dma-review/#security-rules-must-be-clear)  
+* [Implementing Install Prompts in iOS Safari for Web Apps.](https://open-web-advocacy.org/apple-dma-review/#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers)  
+* [Allowing Browsers using their own engine to install and manage Web Apps.](https://open-web-advocacy.org/apple-dma-review/#web-app-installation-and-management-for-third-party-browsers)  
+* [Removing any App Store rule that would prevent third party browsers from competing fairly.](https://open-web-advocacy.org/apple-dma-review/#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43)  
+* [Make notarization a fast and automatic process, as on macOS.](https://open-web-advocacy.org/apple-dma-review/#apple-should-make-notarization-for-directly-downloaded-browsers-automatic)  
+* [Allow direct browser installation independently from Apple’s app store.](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation)  
+* [Allow users to switch to different distribution methods of a native app and allow developers to promote that option to the user.](https://open-web-advocacy.org/apple-dma-review/#allow-users-to-switch-the-distribution-method-of-native-apps)  
+* [Respect the users choice of default browser in SFSafariViewController](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* [Don’t lock Safari to Apple Pay](https://open-web-advocacy.org/apple-dma-review/#safari-is-locked-to-apple-pay)  
+* [Don't break third party browsers for EU residents who are travelling.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu)  
+* [Opt-Into Rights contract should be removed.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu:~:text=with%20the%20DMA.-,4.3.6.%20Opt%2DIn%20Rights%20Contract%20Should%20Be%20Removed,-All%20businesses%20serving)  
+* [Core Technology Fee should be removed.](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed)  
+* [Publish a new more detailed compliance plan.](https://open-web-advocacy.org/apple-dma-review/#apple-should-publish-a-new-more-detailed-compliance-plan)
+
+## What now?
+
+The EU Commission seems to be a slow-moving, but unstoppable, force. Despite the DMA having no legal power outside of the EU, this is already having a global impact with beneficial changes being exported worldwide such as [Apple allowing game emulators](https://au.pcmag.com/mobile-apps/104689/apple-is-finally-allowing-retro-game-emulators-in-the-app-store) and the [new fairer centralised defaults screen](https://www.theverge.com/2024/10/23/24277926/apple-iphone-default-messaging-apps-ios-18-2).
+
+> When Apple said that iPhone owners in the EU would be able to set new default apps for things like calling and messaging, it sounded a lot like only people in the EU would get that option.<br><br>
+> That’s not the case<br><br>
+> [...]<br><br>
+> But the big stuff, like support for alternative app stores and browser engines, has mostly been confined to the EU. A side effect is that a European iPhone was starting to look quite a bit different from one in the US, which was weird. But by spreading some of these new options across borders, Apple will maintain better consistency in its product. At the very least, it’s a little more fun.
+> <cite>[Allison Johnson - The Verge](https://www.theverge.com/2024/10/23/24277926/apple-iphone-default-messaging-apps-ios-18-2)</cite>
+
+We wholeheartedly agree with the Verge, more competition and more ability for developers to innovate is more fun and, most importantly, it’s what is best for consumers.
+
+With each step the EU takes we are starting to see a future where gatekeepers' anti-competitive hold on their operating systems is broken, and the Web can compete fairly on mobile. These DMA changes are spreading out globally and [regulators in other countries are watching carefully as they plan their own policies to allow for fair and effective competition](https://open-web-advocacy.org/blog/owa-2023-review/). 
+
+Stay tuned and follow us in all the usual places:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/apple-loses-on-appeal.md
+++ b/src/ja/posts/apple-loses-on-appeal.md
@@ -1,0 +1,97 @@
+---
+title: 'Apple loses on Appeal, CMA can restart investigation into browsers'
+date: '2023-12-01'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Alex Moore
+permalink: /ja/blog/apple-loses-on-appeal/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/AppleLosesonAppeal.webp",
+  "Apple loses on Appeal,  CMA Investigation into browsers to reopen. This ruling gives the CMA the backing it needs to protect consumers and promote competition in UK. As this judgement clearly states, the previous ruling by the CAT would have had ‘serious consequences’ for the CMA’s ability to investigate potential breaches of the law. We launched this investigation over a year ago in order to make sure that UK consumers get the best services and apps on their mobile phones, and that UK developers can invest in innovative new apps. We stand ready to reopen it when the legal process is complete. Sarah Cardell, Chief Executive of the CMA"
+%}
+
+In a victory for consumers and developers, London's Court of Appeal [has ruled against Apple](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445) and in favour of the UK’s Competition and Markets Authority (CMA), allowing the CMA to reopen their [Browser and Cloud Gaming Market Investigation Reference](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming).
+
+This is important as, Apple has effectively banned third party browsers via [their 2.5.6 rule](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20Javascript.):
+> 2.5.6 Apps that browse the web must use the appropriate WebKit framework and WebKit Javascript.
+
+We believe that browsers should compete on merit and user choice, not via control of operating systems or other underhanded behaviour. Browser competition is important as it is this competition that pushes browser vendors to secure their products, fix bugs and add new features. Without the constant threat of users potentially moving to another browser, browsers have limited incentive to compete. This threat is entirely absent on iOS, the other browsers on iOS have extremely limited ability to compete as Apple has banned them from editing their core, the browser engine. Instead iOS provides a uneditable Webview whose security, features set and stability is entirely under Apple's control. **Under these conditions there is effectively no browser competition on iOS**.
+
+As readers may remember the CMA conducted a Market Study into Mobile Ecosystems.
+
+The CMA [found in their market investigation](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction) that:
+> As a result of the WebKit restriction, **there is no competition in browser engines on iOS and Apple effectively dictates the features that browsers on iOS can offer** (to the extent that they are governed by the browser engine as opposed to by the UI)."
+
+> Importantly, due to the WebKit restriction, **Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS**. This not only restricts competition (as it materially **limits the potential for rival browsers to differentiate themselves** from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, depriving iOS users of useful innovations they might otherwise benefit from.
+
+The report also ruled against Apple’s security arguments. Apple had claimed that Safari’s engine’s security was better than that of third party browsers. This was alluded to in the CMA’s interim report:
+
+> ... in Apple's opinion, WebKit offers a better level of security protection than Blink and Gecko.
+
+The CMA rejected this claim stating:
+>... the evidence that we have seen to date **does not suggest that there are material differences** in the security performance of WebKit and alternative browser engines.
+
+> Overall, the evidence we have received to date **does not suggest that Apple's WebKit restriction allows for quicker and more effective response** to security threats for dedicated browser apps on iOS
+
+Amusingly Apple dropped their claim that Safari’s security was superior to other major browsers in their response to the final report.
+
+The report also notes that Apple has incentives to inhibit third party browser from competing due to its search deal with Google:
+
+> Apple receives **significant revenue from Google by setting Google Search** as the default search engine on Safari, and therefore benefits financially from high usage of Safari. Safari has a strong advantage on iOS over other browsers because it is pre-installed and set as the default browser. The WebKit restriction may help to entrench this position by limiting the scope for other browsers on iOS to differentiate themselves from Safari (for example being less able to accelerate the speed of page loading and not being able to display videos in formats not supported by WebKit). As a result, it is less likely that users will choose other browsers over Safari, which in turn secures Apple’s revenues from Google.
+
+Apple reportedly receives [$18-20 billion USD](https://www.theregister.com/2023/10/10/google_pays_apple_18_20_claims_bernstein/#:~:text=%22We%20estimate%20that%20the%20ISA,of%20Apple's%20annual%20operating%20profits.%22) a year from their Google Search engine deal, accounting for 14-16 percent of Apple's annual operating profits. Apple has not published the annual budget for Safari/Webkit but based on anecdotal evidence it is likely significantly less than 2% of this sum.
+
+The report goes on to note:
+
+>Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This **limits the competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+
+That is Apple appears to also have incentives to inhibit the capabilities of the Web on iOS Safari. Apple collected [$85 billion USD in App Store fees in 2022](https://www.cnbc.com/2023/01/10/apple-app-store-revenue-update-shows-slowing-growth-.html#:~:text=If%20all%20developers%20paid%20a%2030%25%20cut%20to,billion%20in%202022%2C%20based%20on%20a%20CNBC%20analysis.), of which it keeps approximately 30%. Were Web Apps to have a comparable features set, stability and visibility as Native Apps this revenue would be threatened. 
+
+While it has not published the costs of App Store review, payment processing, refund handling etc, it has been estimated that the iOS App Store has a nearly [80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506). Industries with healthy competition feature leading firms with profit margins between [5 and 20 percent](https://www.brex.com/blog/what-is-a-good-profit-margin). This imbalance strongly implies that Apple’s removal of functional competition in the App Store and beyond have broken the mobile phone market for software and services for more than half of the UK’s consumers.
+
+Based on the findings of their Market Study, the CMA decided to launch a Market Investigation Reference into Browser and Cloud Gaming.
+
+In their [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) they listed the following potential remedies:
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services. 
+
+Unfortunately, they delayed starting the investigation while waiting to see if the UK government was going to pass [new laws](https://bills.parliament.uk/bills/3453) granting them stronger powers to deal with anti-competitive behaviour by tech giants. These laws are currently working their way through parliament and are currently expected to be passed into law in 2024.
+
+Due to this Apple managed to successfully get the MIR dismissed not by arguing before the tribunal that the CMA was substantially wrong about any of its anti-competitive behaviour but on the legal technicality based around the timing of the opening of the investigation.
+
+The CMA appealed this decision and today the London's Court of Appeal has overruled the [Competition Appeal Tribunal's decision](https://www.catribunal.org.uk/cases/157661223-apple-inc-others) and stated that the MIR can be reopened.
+
+It is worth noting that Apple has the right to seek permission to appeal this decision and that the investigation is on hold pending this. Apple is almost certain to appeal to the supreme court. Even if they end up losing, each month browser competition on iOS is delayed is arguably worth billions to them.
+
+Apple reportedly has a legal budget of over $1 billion dollars a year and adopts an exceptionally aggressive stance. If you want to understand Apple’s approach to legal, Bruce Sewell, Apple’s former general counsel discusses it [in a talk](https://www.youtube.com/watch?v=-wuf3KI76Ds) where discussing Apple's legal strategy he says:
+
+> work out how to get closer to a particular risk but be prepared to manage it if it does go nuclear, … steer the ship as close as you can to that line because that's where the competitive advantage occurs. … Apple had to pay a large fine, Tim [Cook]'s reaction was that's the right choice, don't let that scare you, I don't want you to stop pushing the envelope.
+> <cite>[Bruce Sewell, Apple’s former General Counsel](https://www.youtube.com/watch?v=-wuf3KI76Ds)</cite>
+
+This gives some clear insight into Apple’s mindset, and explains a lot of their behaviour.
+
+Despite that, this court victory is a huge step towards restoring browser competition, ending Apple's effective ban of third party browsers and ensuring Web Apps have the ability to compete.
+
+Right now, if competition was restored, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often BETTER than Native Apps. Native Apps will still have a lead in cutting edge graphics and gaming technology but if companies see the web platform as viable this gap will decrease over time.
+
+It is for this reason that allowing browser competition on iOS is critical. Apple’s effective browser ban prevents the emergence of such an open and free universal platform for mobile apps. Unlike desktop, developers cannot build their application once and have it work across all consumer devices. Instead, these policies combine with Apple’s trailing and feature-poor engine to force companies to create separate applications for iOS, significantly raising the cost and complexity of development and maintenance. This severely undermines any interoperability advantages Web Apps have between iOS and Android. A single prominent OS holding back the Web is enough to undermine its entire value proposition as a frictionless, capable and secure distribution mechanism for Web Apps.
+
+The fight to allow browser and Web App competition on iOS is not over. We would like to thank everyone for their support over the last 3 years and ask that consumers, developers and businesses write in and engage with the market investigation reference to arm them with all the data and information they need to successfully restore competition to a broken mobile ecosystem. 
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
+++ b/src/ja/posts/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.md
@@ -1,0 +1,136 @@
+---
+title: Apple on course to break all Web Apps in EU within 20 days
+date: '2024-02-15'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: OWA
+relatedLinks:
+  - url: >-
+      https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
+    title: Safari 17.4 Beta Release Notes
+    date: 2024-02-13T00:00:00.000Z
+permalink: /ja/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+
+
+
+{% image
+  "/images/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days.png",
+  "OWA Logo and open-web-advocacy.org with the text: Apple on course to break all Web Apps in EU within 20 days. No Fix: Beta 1, Beta 2, Beta 3. New UI indicates deliberate choice. Nothing in release notes. No mention in compliance proposal. No response to bug tickets. No response from Apple. NOT required by the DMA."
+%}
+
+In 2011, Philip Schiller internally sent an email to Eddie Cue to discuss the threat of HTML5 to the Apple App Store titled **“HTML5 poses a threat to both Flash and the App Store”**.
+
+> Food for thought:
+> **Do we think our 30/70% split will last forever?** While I am a staunch supporter of the 30/70% split and keeping it simple and consistent across our stores, I don’t think 30/70 will last unchanged forever. **I think someday we will see a challenge** from another platform or **a web based solution** to want to adjust our model
+> <cite>[Internal Apple Emails](https://www.patentlyapple.com/2021/05/in-the-epic-vs-apple-trial-today-epic-revealed-apple-memos-discussing-whether-the-70-30-split-with-developers-would-stand.html)<br>
+(emphasis added)</cite>
+
+That is, as early as 2011, Apple's management viewed Web Apps as a credible threat to the App Store revenue model. This is perhaps unsurprising as [Steve Jobs originally intended Web Apps to be the only way to deliver third party apps on iOS](https://open-web-advocacy.org/walled-gardens-report/#steve-jobs'-original-vision-for-ios).
+
+Luckily for Apple, they had a powerful tool to keep the Web at bay: ironclad control of iOS and the ability to [block other browser vendors from bringing their more powerful platforms to Apple users](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers).  Meanwhile, Cupertino retained full control over the feature set of the only iOS browser engine, allowing it to suppress potential competition from the web through inaction. By simply failing to add important features, Apple could ensure the web never came within striking distance of being a credible threat.
+
+Regulators around the world have taken note:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+> <cite>[The Australian Competition and Consumer Commission](https://www.accc.gov.au/system/files/Digital%20platform%20services%20inquiry%20-%20September%202022%20interim%20report.pdf)</cite>
+
+> *Mandatory use of WebKit and reluctance to support web apps in browsers (Apple)*
+> Third-party browsers are forced to provide services based on WebKit, which lacks support for web apps, and competition through ingenuity among browsers may be impeded.
+> <cite>[Japan’s Headquarters for Digital Market Competition](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf)
+</cite>
+
+The Digital Markets Act even stated it as the primary motivation to prohibit banning browser engines:
+
+> When gatekeepers operate and **impose web browser engines**, they are in a position to **determine the functionality** and standards that will apply not only to their own web browsers, but also to **competing web browsers** and, **in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)<br>
+(emphasis added)
+</cite>
+
+We wrote last week [about concerning changes in  iOS 17.4 Beta 1 (EU)](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/). Sites installed to the homescreen failed to launch in their own top-level activities, opening directly in the default browser instead, even when the default browser is the browser that installed it. This demotes Web Apps from first-class citizens to mere shortcuts. Developers have since confirmed this does not occur outside the EU. Two betas later it is becoming more likely that this is a deliberate choice on the part of Apple to remove the ability to install Web Apps.
+
+Beta 2 [contained a more detailed message](https://twitter.com/mysk_co/status/1754978973417672794) to the user stating:
+> "Open 'WEB APP NAME' in Safari. 'WEB APP NAME' will open in your default browser from now on.".
+
+This message occurs even if both the browser that installed the Web App and your default browser is iOS Safari.
+
+{% image
+  "/images/blog/web-apps-turned-into-bookmarks-message.png",
+  "An image of Apple's new pop up informing the user that the web app will now instead open as a webpage in the default browser."
+%}
+
+No mention of this seismic change has been made in the usual places. Not the [Safari release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes) nor in the [iOS Beta release overview](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17_4-release-notes).
+
+Apple’s silence has been deafening. No reply has been provided in  [a WebKit ticket](https://bugs.webkit.org/show_bug.cgi?id=268643), [Apple developer forums](https://forums.developer.apple.com/forums/thread/745414), [twitter discussions](https://twitter.com/firt/status/1755406923485122615), and no statement has been provided to the  [many journalists](https://www.theregister.com/2024/02/08/apple_web_apps_eu/) [seeking](https://www.macrumors.com/2024/02/08/ios-17-4-nerfs-web-apps-in-the-eu/) [comment](https://www.theverge.com/2024/2/14/24072764/apple-progressive-web-apps-eu-ios-17-4).
+
+This cannot be mere oversight. The inability of third-party browsers to compete in the provision of web app functionality was discussed in no less than four regulator's investigations. Potential competition from Web Apps was directly stated in the DMA as the motivation to prohibit banning competing browser engines. it seems highly unlikely that the policy team working for Apple were unaware that they were required to allow third-party browsers to install and power Web Apps using their own browser engines.
+
+Yet when Apple announced their [compliance proposal for the DMA](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/), Web Apps were noticeable by their absence. This is the same Apple that again and again claims that Web Apps are the alternative distribution method for Apps in their mobile ecosystem.
+
+> QUESTION: Apple is the sole decision maker as to whether an app is made available to app users though the Apple Store, isn't that correct?<br>
+> REPLY: If it’s a Native App, yes sir, if it’s a Web App no.
+> <cite>[Tim Cook - Speaking to US Congress](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s)
+</cite>
+
+> Web browsers are used not only as a distribution portal, but also as platforms themselves, hosting “progressive web applications” (PWAs) that eliminate the need to download a developer’s app through the App Store (or other means) at all.
+> <cite>[Apple Lawyers - Court Filing in Australia](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple/)
+</cite>
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+Apple had four choices here:
+
+* **The Good**<br>
+Allow third-party browsers to install Web Apps, powered by the browser that the user chooses to install the Web App with. This is the only near-term viable solution.  This enables browsers to compete in the provision of functionality for web apps.
+
+* **The Broken**<br>
+Allow browsers to install web apps but power them all by the default browser.  While at first glance this may seem like a reasonable solution, it is an unworkable model. Each Web App’s data is stored within its installing browser.  Each browser stores the data in different locations and raw formats.  Due to complexity, no import/export functionality exists to allow a user to “port” a Web App from one browser to another along with its data. This means users would be logged out of and lose all their data for every Web App every time they switched default browser. <br><br>Having every Web App break each time a user switches default browser would be a disaster for the ecosystem. If anyone were to suggest this was a reasonable model, simply ask, would they be happy if all native apps lost their data every time you switched the default App Store.
+
+
+* **The Devious**<br>
+Provide the share menu with third party browsers, burying the ability to install Web Apps powered by Safari’s engine in a high-friction UI. This obviously doesn’t allow third party browsers to compete in the provision of Web App features but may have been sneaky enough for Apple to attempt to slip past.
+
+* **The Outrageous**<br>
+Outright remove support for Web Apps by converting them all to bookmarks. This removes the ability to act like an App from the an operating system and user interface perspective. This fundamentally undermines the already tenuous competitiveness of Web Apps due to Apple policies. Recall that Safari deletes data for any site that the you fail to visit for more than 7 days , but not for installed Web Apps. The outrageous strategy now subjects Web Apps in the EU to the same disadvantage. Apple policy also restricts the availability of Push Notifications to installed Web Apps. This change  looks set to wreck the most requested Web App feature of the last decade. Lastly, this change hobbles homescreen-installed Web Apps that request to run in full-screen mode, such as games. Demoting Web Apps to shortcuts is a triple disability that Apple cannot be ignorant of. Finally Apple can then attempt to refuse to share the ability to install apps with third party browsers, because now Safari can’t, despite the fact it has been able to for 15 years.
+
+We considered that Apple might try something like this, but dismissed it as too blatantly anti-competitive, [even for them](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Now, even as it looks increasingly less likely that Cupertino is acting in good faith, Apple could declare this unfinished or a bug. That would go some way towards alleviating concerns, but if the Beta breakage of Web Apps ever makes it onto users’ devices, it will show that Apple is actively seeking to block the Web from ever competing fairly with their App Store.
+
+Some defend Apple's decision to remove Web Apps as a necessary response to the DMA, but this is misguided.
+
+Apple has had 15 years to facilitate true browser competition worldwide, and nearly two years since the DMA’s final text. It could have used that time to share functionality it historically self-preferenced to Safari with other browsers. Inaction and silence speaks volumes.
+
+The complete absence of Web Apps in Apple's DMA compliance proposal, combined with the omission of this major change from Safari beta release notes, indicates to us a strategy of deliberate obfuscation. Even if Apple were just starting to internalize its responsibilities under the DMA, this behaviour is unacceptable.  A concrete proposal with clear timelines, outlining how third party browsers could install and power Web Apps using their own engines, could prevent formal proceedings, but this looks increasingly unlikely. Nothing in the DMA compels Apple to break developers' Web Apps, and doing so through ineptitude is no excuse.
+
+Apple still has the opportunity to fix this ‘misunderstanding’. An Apple that is confident in its own products could take the following steps:
+
+* Announce that this is indeed a bug.
+* Publish a blog post explaining how they intend to let third party browsers (with their own engines) compete in the provision of functionality for Web Apps.
+* Create an API whereby browsers with the entitlement, subject to narrow scope, proportional and heavily justified security rules could install Web Apps powered by the browser that the user chooses to install them with.
+* Roll out these changes globally.
+
+If Apple truly believed that the Web and Web Apps were no threat to their App Store, why not appease the regulators by letting them compete fairly on their mobile ecosystem.
+
+Apple’s defenders might have been able to argue that [a history of inadequate Web App functionality](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features) and [crippling bugs](https://open-web-advocacy.org/walled-gardens-report/#safari-has-been-buggy-for-a-long-time) were simply benign neglect. Web Apps make no money for Apple, so why expend effort on them? But the suppression of competing engines, attempts to geofence their emergence, and radio silence about complete breaking of Web Apps paints a less benevolent picture of Apple not as a bumbling giant, but as a clear enemy of the Web.
+
+Apple looks to be taking active and provocative steps to scuttle Web Apps and to prevent other browsers from providing them. This suggests that Apple is still fearful of a future where users and developers can simply bypass Apple’s App Store using the power of the Web. OWA welcomes that future and will continue to work to ensure it becomes reality, in Europe and beyond -- just as Steve Jobs promised.
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/donate.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>

--- a/src/ja/posts/apples-one-weird-trick-to-stop-you-changing-your-default-browser.md
+++ b/src/ja/posts/apples-one-weird-trick-to-stop-you-changing-your-default-browser.md
@@ -1,0 +1,106 @@
+---
+title: Apple's one weird trick to stop you changing your default browser
+date: '2024-03-28'
+tags:
+  - Policy
+  - Apple
+author: OWA
+permalink: >-
+  /ja/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+Long time readers will already know that [Apple has effectively banned all browsers from iOS by preventing them from bringing or modifying their own engines](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). That makes all browsers on iOS essentially skins round Safari. We brought this up in one of our questions to Apple at their DMA workshop where we stated that _"Apple’s 15 year ban of third-party browser engines has effectively removed browser competition from iOS."_, [surprisingly there was no rebuttal from Apple, even veiled, of our assertion](https://www.youtube.com/watch?v=s41Ha8lZ0Zk&t).
+
+But let's put that aside for now to discuss a different topic: defaults.
+
+The Digital Market Act introduces obligations for gatekeepers to make it easy for users to change defaults including obligating a choice screen.
+
+There is a common phrase about following the letter and spirit of the law. The spirit being: are you making good faith efforts to comply with the intent? In the case of the intent of the DMA, you don't need to guess as the act itself contains 26 pages of recitals that in very clear language explain exactly what the act is trying to achieve via the letter of the law as spelt out in the articles.
+
+In the case of the defaults the recitals have this to say:
+
+> Recital 49: **A gatekeeper can use different means to favour its own or third-party services or products on its operating system**, virtual assistant or web browser, to the detriment of the same or similar services that end users could obtain through other third parties.
+> ...
+> **Gatekeepers should also allow end users to easily change the default settings on the operating system**, virtual assistant and web browser **when those default settings favour their own software applications and services. This includes prompting a choice screen** ...
+
+On dark patterns the recitals had this to say:
+>Gatekeepers should not engage in behaviour that would undermine the effectiveness of the prohibitions and obligations laid down in this Regulation. Such behaviour includes the design used by the gatekeeper, the presentation of end-user choices in a non-neutral manner, or using the structure, function or manner of operation of a user interface or a part thereof to subvert or impair user autonomy, decision-making, or choice.
+
+While on defaults Article 6(3) simply says:
+> The gatekeeper shall allow and technically enable end users to easily change default settings on the operating system, virtual assistant and web browser of the gatekeeper that direct or steer end users to products or services provided by the gatekeeper
+
+Recently our own John Ozbay attended a workshop where [Apple could explain how it was complying with the DMA](https://digital-markets-act.ec.europa.eu/events-poolpage/apple-dma-compliance-workshop-2024-03-18_en).
+
+In Apple's opening speech on changing defaults, Apple's spokesperson had this to say:
+> In this session we are going to provide a summary of what we are doing on the web browser choice screen and defaults pursuant to the DMA. Lets start with defaults and specifically the ability to select a default browser. **For a long time Apple have made it easy for users to choose a browser in the settings app**. Many users have already chosen to set a non-Safari default browser even before the DMA. **They can do it in just a few taps.**
+
+This is a little surprising. Apple didn't even let users change the default browser until late 2020. When they did add the ability to do so the design was awkward and confusing. There is no centralised location to change defaults, no way of searching for the option in the OS settings and the option to change the default is inappropriately shown on each browser settings page. Further they provide no API to allow newly installed browsers to prompt the user to switch default browser or even be aware that they are the default browser.
+
+Now, some may think it is unfair to suggest that Apple deliberately designed it to be as awkward as possible to change the default browser but **they went one critical step further that unambiguously shows that they maliciously intended to undermine user choice**.
+
+In an astonishingly brazen dark pattern Apple engineers added code to the Safari's settings page to hide the option to change the default browser if Safari was the default but then to prominently show it if another browser was the default.
+
+This video demonstrates it, and you can test it yourself right now.
+<iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/o6uwiG1nKK4?si=269jgW7xPT_KnlQk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+**There is absolutely no plausible defence for this behaviour.**
+
+We had John ask Apple directly about this at Apple DMA Workshop.
+
+> I am going to continue to focus on one more question regarding the prompt to change the default browser. You mentioned earlier that users are always prompted to change their default browser. At the moment there is no way for browsers to detect if they are the default browser nor a one click system prompt to allow users to set the default browser. This is standard on all other major operating systems except iOS. The friction Apple has added to this process undermines users' switching to a new default browser that needs to be fixed in order for them to be in compliance with 6(3) and 13(4).<br><br>
+> Similarly changing the default browser at the moment is quite difficult as well. Currently Apple does not have a centralised location to change the default browser in the settings. Searching "default" or "default browser" yields no results in settings and you can try it right now. Instead they have inappropriately placed it in each individual browser's settings page.<br><br>
+> Astonishingly Apple has added custom code to hide the option to change default browser in the Safari settings if Safari is the default browser, and prominently show it if a different browser is default. We had thought that Apple would have fixed such an outrageous dark pattern prior to the DMA coming into force but in the latest version of iOS it is still present.<br><br>
+> My question to Apple is, are they planning on addressing these or not?
+
+Apple's spokesperson responded with:
+> In terms of the first question, the choice as required by the DMA is presented once to users. Obviously there are a ton of other ways in which users can choose different browsers, different default browsers if they so choose. We have worked to make this simple and straightforward. And we know from the experience over the last couple of years that millions of users around the world choose alternative browsers all the time. We also know that many of them will choose to make that browser their default one of choice. That happens all the time. In terms of what's being required here by the DMA our focus is on presenting this choice even more clearly to consumers the first time you use Safari. Obviously there are not choices being presented when you use other browsers on iOS. So we are complying from our perspective with the spirit here.
+
+The video of John's question and the reply is at the top of the article.
+
+Let's break down Apple's reply.
+
+> Obviously there are a ton of other ways in which users can choose different browsers, different default browsers if they so choose. **We have worked to make this simple and straightforward.**
+
+This is clearly false, and does not address any of the specifics in John's question.
+
+> And we know from the experience over the last couple of years that millions of users arround the world choose alternative browsers all the time.
+
+This phrasing is very carefully steps arround the fact that Apple only started letting users change the default browser in late 2020. Clearly it's embarrassing that for 13 years it was impossible to change the default browser on iOS.
+
+> We also know that many of them will choose to make that browser their default one of choice. That happens all the time.
+
+Apple doesn't publicly share any aggregated data on browser defaults, so it's hard to check.
+
+> In terms of what's being required here by the DMA our focus is on presenting this choice even more clearly to consumers the first time you use Safari. Obviously there are not choices being presented when you use other browsers on iOS.
+
+The framing here again is false. As Apple stated in their opening speech there are two aspects of the DMA they have to comply with one making it easy to change the default, and two allowing a choice screen. Apple obviously has no defence on the first and so tries to deflect by focusing on the second.
+
+> So we are complying from our perspective with the spirit here.
+
+We disagree and clearly so does the EU Commission, which on 25 March [opened a proceeding against Apple investigating them over Article 6(3)](https://ec.europa.eu/commission/presscorner/detail/en/ip_24_1689).
+
+In their press release they stated:
+> The Commission has opened proceedings against Apple regarding their measures to comply with obligations to (i) enable end users to easily uninstall any software applications on iOS, (ii) easily change default settings on iOS and (iii) prompt users with choice screens which must effectively and easily allow them to select an alternative default service, such as a browser or search engine on their iPhones.<br><br>
+> The Commission is concerned that Apple's measures, including the design of the web browser choice screen, may be preventing users from truly exercising their choice of services within the Apple ecosystem, in contravention of Article 6(3) of the DMA.
+
+This is just one topic among many but we should know more when the EU releases its non-confidential version of its initial findings and invites third parties to comment which according to the act could take up to 3 months.
+
+In order to be compliant with this specific aspect of the DMA we believe Apple should make the following changes:
+1. Remove the dark pattern of hiding the option to switch default browser if the default is Safari.
+2. Move the option to change default browser out of the browser settings and into a centralised location.
+3. Have this option visible even if Safari is the only currently installed browser.
+4. Have this option show up in search if the user searches for "default", "browser" or "default browser".
+5. Allow browsers to know if they are the current default browser
+6. Provide a system prompt to browsers (with the usual anti-nagging protections on all permission prompts) that allows browsers to prompt the user to one click set them as the new default browser as is standard on all other operating systems.
+
+Stay tuned and follow us in all the usual places:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/cma-reopens-investigation-into-apple.md
+++ b/src/ja/posts/cma-reopens-investigation-into-apple.md
@@ -1,0 +1,38 @@
+---
+title: UK browser investigation to restart Jan 24 after Apple fail to appeal
+date: '2023-12-18'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Frances Berriman
+permalink: /ja/blog/cma-reopens-investigation-into-apple/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/CMA-restarts-investigation.webp",
+  "The deadline for Apple to seek the Court of Appeal’s permission to appeal the Court’s decision has now lapsed, therefore in accordance with the Court’s order dated 30 November 2023, the market investigation will recommence on 24 January 2023. Competition and Markets Authority, UK Government"
+%}
+
+
+Nearly three weeks ago, [we reported that](https://open-web-advocacy.org/blog/apple-loses-on-appeal/) London's Court of Appeal [had ruled against Apple](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445) and in favour of the UK’s Competition and Markets Authority (CMA), allowing the CMA to reopen their [Browser and Cloud Gaming Market Investigation](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming). There was a 21 day grace period before that investigation could restart to allow Apple to respond.
+
+> 30 November 2023: In a [unanimous judgment (available on the National Archives website)](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445), the Court of Appeal has determined that the CMA’s decision to make a market investigation reference in relation to the market for mobile browsers and cloud gaming was lawful, setting aside the CAT’s judgment of 31 March 2023. 
+
+>Consequently, the Court has ordered that the market investigation will continue to be suspended until permission to appeal (if sought) has been determined and an additional 21 days has lapsed. &ndash; [Competition and Markets Authority](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming?utm_medium=email&utm_campaign=govuk-notifications-topic&utm_source=1c322e66-03ab-4704-ba89-5cf1839a587e&utm_content=immediately#court-of-appeal-judgment)
+
+That 21 days has now passed, and no permissions to appeal were received, and as such the CMA will restart their investigation in the new year.
+
+> 18 December 2023: the deadline for Apple to seek the Court of Appeal’s permission to appeal the Court’s decision has now lapsed, therefore in accordance with the Court’s order dated 30 November 2023, the market investigation will recommence on 24 January 2023. Further updates will follow in due course. &ndash; [Competition and Markets Authority](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming?utm_medium=email&utm_campaign=govuk-notifications-topic&utm_source=1c322e66-03ab-4704-ba89-5cf1839a587e&utm_content=immediately#court-of-appeal-judgment)
+
+[Our previous article](https://open-web-advocacy.org/blog/apple-loses-on-appeal/) covers why this investigation is so important for protecting consumers in the UK.
+
+Once the investigation reopens, you can be sure we'll be covering everything the CMA learns, so stay tuned to our social media.
+
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/developers-react-apple-eu-dma-compliance.md
+++ b/src/ja/posts/developers-react-apple-eu-dma-compliance.md
@@ -1,0 +1,60 @@
+---
+title: Web Developers React to Apple’s DMA Compliance Proposal
+date: '2024-01-31'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: Frances Berriman
+permalink: /ja/blog/developers-react-apple-eu-dma-compliance/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/developers-react.webp",
+  "Image showing three pull quotes, stating: To me, it's an excellent demonstration of why browser choice is crucially important [...] legal compliance are clearly not incentive enough. Brian LeRoux, Begin. Apple has been forced to lift this restriction, but how they react to this will show us their attitude to the web. Jake Archibald, Shopify. It would be quite disappointing if—when the rubber meets the road—browser variability were dependent on the country in which you reside! Zach Leatherman, 11ty, CloudCannon"
+%}
+
+Since [Apple released their plans for compliance](https://open-web-advocacy.org/blog/apple-dma-changes/) with the EU’s DMA regulations on 25th January, we’ve been asking web developers how these changes may affect how they work, their businesses and the web as a whole.
+
+[Jake Archibald](https://jakearchibald.com/), senior developer for Shopify, reflected "It seemed unbelievable to me that users on iOS were restricted to one browser engine, and one that in the past has been slow to fix serious bugs, and lagged behind on features. Apple has been forced to lift this restriction, but how they react to this will show us their attitude to the web"
+
+Begin co-founder [Brian LeRoux](https://brian.io//) said “Lots of us are trying to make sense of the recent EU regulatory rulings and Apples' bad faith letter to the law implementation. To me, it's an excellent demonstration of why browser choice is crucially important as standards participation and legal compliance are clearly not incentive enough.”, continuing his thoughts [in a public thread.](https://indieweb.social/@brianleroux/111828910555229207)
+
+Many spoke to us about concerns that Apple is ring-fencing access to new browsers, especially with regards to testing.
+
+[Jason Grigsby](https://cloudfour.com/is/jason-grigsby/), Co-founder of Cloud Four, asked “What happens if someone in the EU runs into a bug that isn’t happening in other browsers? How do we troubleshoot it? I’m trying to think of a comparable time when we had no way to test in a browser. The closest I can come to is the earliest days of mobile when the Android browser was different on each carrier. But even then, I could go to a carrier store to test and/or buy a phone if I needed more time with it. What do I do now?”
+
+He continued with some thoughts on how he may solve this, “For us, maybe BrowserStack or a similar service will give us a way to see what our European users are seeing? Absent that, I think we're stuck.”
+
+[Peter-Paul Koch,](https://www.quirksmode.org/about/) a long time web standards and browser compatibility expert, echoed these worries, asking, “Will there be a way around this problem? For instance a VPN, or non-EU web devs becoming 'members' of an EU entity that gives them an EU Apple account and thus access to the new browsers?” and although an EU citizen himself, he showed concern for developers in other locales and wondered if this opened opportunities for legal challenges in other countries, “This puts non-EU web devs at a clear competitive disadvantage. Would that be an argument that regulatory authorities are willing to listen to? US web devs are put at a disadvantage by Apple, so Apple has to solve the situation - by also giving them access to the other browsers?”
+
+[Scott Jenson](https://jenson.org/about-scott/), UX strategist, opened on a positive note but quickly turned to scepticism, “Excellent start however but rather shocking that the needs of the EU are totally different from the rest of the world.” and continued with a now familiar concern, “As a developer this is very frustrating as how are we even to test our web pages now between regions?”
+
+Moving on from topics of testing, developers reflected on a future with more browser choice for consumers on iOS.
+
+Beginning “I think that only time will tell..” [Léonie Watson](https://tink.uk/about-leonie/), Director at TetraLogical and W3C board member, was hesitant “iOS only has one screen reader. VoiceOver works well with Safari and reasonably well with Firefox and Chrome, but whether that will continue when those browsers use their own engines is unknown at this stage.” Watson also has fears for diversity, “I also think there is a chance that Chrome could become the dominant browser across the board, and if it should, that we'll have a near unshakable monoculture.”
+
+[Andy Davies](https://andydavies.me/about/), consultant for SpeedCurve, noted that the changes in the EU do open up some opportunities to really get to know Safari better in relation to its competitors, “Probably the most interesting thing for me is we’ll finally be able to do like for like comparisons of web performance in the wild and we’ll be able to compare the speed of sites in Chrome on Android vs Chrome on iOS and so begin to get a real world understanding of the gap between the performance of Android and iOS devices”
+
+Others see more hope in an increase in the competitive landscape. [David Darnes](https://darn.es/), a lead at NordHealth, told us “I guess as a web developer I should see this as a win for the browser landscape. With these changes other browser engines will be able to run on iOS, which in turn creates healthier competition.”
+
+[Zach Leatherman](https://www.zachleat.com/), creator of 11ty and CloudCannon developer, had a similar opinion, “I’m nervous to applaud the changes outright as it seems to introduce additional variability but I am quite happy to celebrate a future of more choices for developers and consumers.”
+
+Both had concerns, however, "That being said from what I’ve seen the amount of red tape to cut and hoops to jump through, one of which being just living in the EU, makes me worried that that silver lining will be lost in it all.”, said Darnes. Leatherman noted, “There has always been some unnerving variability in how iOS has handled in-app web browsers, so much so that I have recommended folks never use an in-app browser spawned from a native app lest they compromise the well established privacy norms usually afforded to them by the web browser.“
+
+[Dave Rupert](https://daverupert.com/), of ShopTalk fame and co-founder of Luro, gave us a position of hopeful curiosity, “It will be interesting to see what happens from here. Will we break out of the Chromium/Webkit duopoly? Or will we fall headlong into a Chromium monopoly? Regardless, the EU ruling is a win for the Open Web because now more users have choice beyond the OS-provided default browser.”
+He expanded these thoughts [on his blog](https://daverupert.com/2024/01/browser-choice/).
+
+Ultimately Zach Leatherman sums up the concerns for most, “It would be quite disappointing if—when the rubber meets the road—browser variability were dependent on the country in which you reside!  I thought web browsers were supposed to be for the world wide web?”
+
+How will these changes affect how you work? Let us know at our social media locations:
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/did-apple-just-break-web-apps-in-ios17.4-beta-eu.md
+++ b/src/ja/posts/did-apple-just-break-web-apps-in-ios17.4-beta-eu.md
@@ -1,0 +1,60 @@
+---
+title: Did Apple just break Web Apps in iOS 17.4 Beta (EU)?
+date: '2024-02-03'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: James Moore
+permalink: /ja/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+[We have been alerted](https://twitter.com/mysk_co/status/1753402489049616427) that Apple has broken Web App (PWA) support in the EU via iOS 17.4 Beta. Sites installed to the homescreen failed to launch in their own top-level activities, opening in Safari instead. This demotes Web Apps from first-class citizens in the OS to mere shortcuts. Developers confirmed the bug did not occur [outside the EU](https://twitter.com/mysk_co/status/1753402489049616427).
+
+This bug should have been picked up within seconds of testing any Web App. So how did this issue slip through? One possibility is Web Apps aren’t routinely tested by the Safari or iOS teams and that automated regression testing is not in place. This might explain the parade of show stopping iOS Web App bugs that shipped to stable over the past 15 years. 
+
+Another explanation might be the complexity posed by Apple’s  [mess of a compliance proposal](/blog/owa-review-apple-dma-compliance-for-web/) which creates a separate version of iOS for the EU. We wrote about [the testing problems Apple’s proposal looks set to cause web developers](/blog/developers-react-apple-eu-dma-compliance/), and perhaps Apple is the first casualty of this self-defeating attempt at geofencing browser progress. 
+
+The author of this article can not even personally test this due to not being physically located in the EU. This is the madness that Apple's malicious and spiteful Digital Markets Act compliance proposal will inflict on web developers and businesses globally.
+
+This is almost certainly a bug, but it gives rise to suspicion among the developer community thanks to Apple’s long history of [neglect and denial of features for iOS Safari](/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features). The choice to underinvest might only be problematic, save for [Apple's effective ban of third party browsers.](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) Because third-party browsers cannot provide their own Web App features, if it doesn't work in iOS Safari, it doesn't work on iOS.
+
+The UK’s Competition and Markets Authority noted Apple’s potential App Store revenue protection motive:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)
+(emphasis added)</cite>
+
+Despite this, Apple has always claimed that Web Apps are the alternative to their app store:
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+Recently, an argument between David Heinemeier Hansson (“DHH”) and Apple erupted over what DHH took to be a threat to eject the HEY email/calendar from their App Store if they didn’t share revenue:
+
+> Apple just called to let us know they're rejecting the HEY Calendar app from the App Store (in current form). Same bullying tactics as last time: Push delicate rejections to a call with a first-name-only person who'll softly inform you it's your wallet or your kneecaps.
+><cite>[David Heinemeier Hansson - Creator of Ruby on Rails and CEO of Hey](https://twitter.com/dhh/status/1743341929675493806)</cite>
+
+When DHH announced that he would promote and build tooling for Web Apps, [Apple quickly backed down and approved the app:](https://twitter.com/dhh/status/1744745276932604413)
+
+> We're going to make Rails 8 the damn best framework for creating full-stack PWAs. Web Push, badges, install prompts, service workers, the works. I was motivated before, but now it's really on. Let's get back to making apps where we don't have to beg for permission or mercy!
+><cite>[David Heinemeier Hansson - Creator of Ruby on Rails and CEO of Hey](https://twitter.com/dhh/status/1743664413964374505)</cite>
+
+Netflix also made waves when it declined to port their app to Apple's new AR/VR headset, the Apple Vision Pro:
+
+> Our members will be able to enjoy Netflix on the web browser on the Vision Pro, similar to how our members can enjoy Netflix on Macs
+><cite>[Netflix](https://variety.com/2024/digital/news/apples-vision-pro-netflix-youtube-spotify-1235877784/)</cite>
+
+
+Upon release it was revealed that Apple had [astonishingly entirely removed the ability to install Web Apps from their headset](https://twitter.com/SteveMoser/status/1749438049300124008). This is a brazen omission in the current regulatory moment
+
+All of this leads to intense suspicion in the developer community.
+
+The simple fact is it doesn't matter if this is incompetence or malice, the end result is the same. Unusably poor support for Web Apps on iOS. Apple does not face effective browser competition, leading to show stopping iOS web bugs with shocking regularity. 
+
+Imagine now that genuine and effective browser competition was allowed on iOS. 
+Under these conditions, showstopping Safari bugs would allow developers to recommend more capable browsers. This, in turn, would force Apple to invest in Safari, reducing the incidence of terrible web experiences for iOS users. This would lead to a vibrant, capable web that would unlock investment by developers and businesses, allowing them to deliver services via the web to iOS users.
+
+Browser competition is critical for security, functionality, stability and privacy. It is this competition that Apple has denied iOS since its inception and that must be restored globally, not just in the EU.

--- a/src/ja/posts/eu-opens-dma-investigations.md
+++ b/src/ja/posts/eu-opens-dma-investigations.md
@@ -1,0 +1,79 @@
+---
+title: 'EU opens DMA investigations of Apple, Meta, Google'
+date: '2024-03-25'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /ja/blog/eu-opens-dma-investigations/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+This morning, the [EU announced](https://ec.europa.eu/commission/presscorner/detail/en/ip_24_1689) that
+
+> the Commission has opened non-compliance investigations under the Digital Markets Act (DMA) into Alphabet's rules on steering in Google Play and self-preferencing on Google Search, Apple's rules on steering in the App Store and the choice screen for Safari and Meta's “pay or consent model”.
+
+> The Commission suspects that the measures put in place by these gatekeepers fall short of effective compliance of their obligations under the DMA.
+
+> In addition, the Commission has launched investigatory steps relating to Apple's new fee structure for alternative app stores and Amazon's ranking practices on its marketplace.
+
+We welcome the investigations, and it's telling that it comes after last week's compliance workshops, when gatekeepers were invited by the EU to answer questions on their compliance plans from stakeholders (but not from the EU themselves).
+
+Certainly, in the case of Apple, we found their responses to questions to be just that: responses, rather than answers. See for yourself! Our very own John Ozbay asked why a user who selects Firefox from the browser choice screen will still see Safari in the 'hot seat' position.
+
+Apple's legal team respond by telling us how customisable the home screen is. But they forget to tell us why they continue to give Safari the hot seat, rather than promote Firefox after the user chose it.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/_m6tQtDpSbM' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 1 - Safari gets exclusive rights to default hot-seat incl via choice screen?"></iframe></div>
+
+John then asks why there is no centralised system on iOS to change the default browser. He notes that each browser's setting page has the option to change the default browser, except for Safari's which does not offer a change default, and asks
+
+> we  had thought that Apple would have fixed such
+a dark pattern prior to the DMA coming into  force but in the latest version of iOS, it seems that it is still present. My question  is, is Apple planning on addressing these or not?
+
+Strangely, again, John's question is not answered. We are told that millions of people have changed their default browser (we know! choice is good!) and
+
+> we are complying from our  perspective with the spirit here.
+
+From <em>our</em> perspective, this is not complying.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/AiiU_zBirXc' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 2 - Will Apple address the dark patterns when changing the default browser?"></iframe></div>
+
+This pattern of forgetting the question continues. John notes Apple's DMA compliance plan includes a Browser Entitlement Contract full of legal traps for competing browsers, effectively making it impossible for competing browser vendors to sign the contract and ship their browser engines on iOS for their EU users. John asked
+
+> Will you at least make them  minimally viable in the EU by enabling browsers to ship their  own engines under a single app ID and rewrite your contract so  that they're both reasonable and compliant with the DMA?
+
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/s41Ha8lZ0Zk' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 4 - Apple's ludicrous contract and impossible conditions for browser vendors"></iframe></div>
+
+Apple's reply was that the changes required under the DMA are "a very massive complicated engineering effort". We don't doubt that; luckily, Apple employs very talented engineers and probably has enough money in the bank to employ a few more.
+
+But after this uplifting tale of Herculean efforts undergone in Cupertino, John's questions were not answered–even after another questionner asked
+
+> Is it admissible that I give my speaking time back
+to refer to the questions that the  colleagues from the Open Web Advocacy had asked about the contracts and the possibility that those are incompatible with DMA,  because those haven't been answered at all?
+
+Another workshop attendee and John asked whether Apple would abide by the DMA and allow Progressive Web Apps (in Apple parlance, Home Screen Apps) to use third-party engines.
+
+Amazingly, the Apple representatives forgot that a direct queston had been asked of them a mere 23 seconds previously, merely noting that Home Screen Apps will work "as before" (only with WebKit, so presumably: "no").
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/yHdG_3sSSqQ' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 6 - Will Apple allow Progressive Web Apps to use other browser engines?"></iframe></div>
+
+Towards the end of the workshop, John noted that Apple's 12 page compliance report was immensely lighter in detail than Microsoft's 421 pages or Google's 271 pages, and asked
+
+> does Apple honestly believe their  12-page document enables third parties like us to comprehensively assess whether they comply with  all of the obligations laid down in the DMA?
+
+This at least got a straight answer:
+
+> I think everyone in this room  understands what Apple has done to comply with the DMA. So I think  we've accomplished our goal there.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/aR83Cs47A-Y' frameborder='0' allowfullscreen title="OWA v Apple: EC DMA Q&A 5 - Do you think a 12 page compliance report is legal and in good faith?"></iframe></div>
+
+Sadly, however, not everyone in the room understood what Apple has done to comply with the DMA, hence today's announcement.
+
+Ultimately, of course, our hope is that the investigations don't take 12 months and result in fines.
+
+The better outcome would be for Apple to acknowledge that their initial compliance plans do not come near to meeting the intent of the DMA, and for them to re-think and submit detailed plans, with timings, on how they will provide customers with a fair, genuine browser choice.
+
+We would also like to understand if, how and when Apple intends to fix their ridiculous and clearly non-compliant contractual terms that make it [as Mozilla put it "as painful as possible"](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox) for browser vendors to port their real browsers to iOS.

--- a/src/ja/posts/google-must-share-the-ability-to-install-web-apps-in-android.md
+++ b/src/ja/posts/google-must-share-the-ability-to-install-web-apps-in-android.md
@@ -1,0 +1,87 @@
+---
+title: Google must share the ability to install Web Apps in Android
+date: '2024-09-19'
+tags:
+  - Policy
+  - Google
+  - Australia
+  - EU
+  - Japan
+  - UK
+author: OWA
+permalink: >-
+  /ja/blog/google-must-share-the-ability-to-install-web-apps-in-android/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: For 7 years, Google has failed to keep its commitment to share the ability to install Web Apps with third-party browsers on Android, despite [public requests](https://issues.chromium.org/issues/40195497) from Samsung, Microsoft, Brave & Kiwi browser. With regulatory intervention from the EU, Japan and the UK that may be changing.**
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1836647016052724100), [Mastodon](https://mastodon.social/@owa/113162700151879686
+).
+
+In 2015, Google introduced a method on Android to install Web Apps and subsequently replaced it with a better system called "WebAPK minting" in 2017. This system allows Chrome on Android to install Web Apps that integrate well with the operating system. At the time, now more than 7 years ago, [Google promised to share this with third-party browser vendors](https://web.dev/webapks/). However, as of today this functionality is still exclusive to Chrome on most Android devices (Note: Samsung has implemented their own version for Samsung Internet on Samsung devices).
+
+> **QUESTION: I am a developer of another browser on Android, can I have this seamless install process?**<br><br>
+> We are working on it. We are committed to making this available to all browsers on Android and we will have more details soon.
+> <cite>[Google - On WebAPK minting (7 years ago)](https://web.dev/webapks/)</cite>
+
+## What is WebAPK minting?
+A [WebAPK](https://web.dev/webapks/) is a thin wrapper Native App that provides a splash screen, system launcher integration, and system settings configuration points. When launched, a WebAPK essentially starts a tab in the browser which installed the WebAPK, loading the specific URL the Web App developer configures.
+
+All native apps on Android are packaged as APKs, either via an app store such as Google Play or via sideloading. WebAPKs allow Web Apps to be integrated into the OS for the purposes of discoverability, permissions management, shortcut creation, registering url with the operating system (so links will open in the web app instead of a browser tab) and uninstallation. This means that web apps installed as WebAPKs are able to be shown in Android’s app drawer and search, system app pages such as apps, storage, screen time and battery usage, and shown without a browser badge.
+
+<figure>
+    {% image
+        "/images/blog/webapkminting.png",
+        "Example of installing web apps on Android.",
+        null, null
+    %}
+    <figcaption>Left to right: narrow.one installed on Chrome, Firefox & Edge. Only the WebAPK version is able to be shown anywhere other than this homescreen.</figcaption>
+</figure>
+
+Android’s security model is built around signed native APKs. In order for Web Apps to integrate properly on Android without significant architectural changes, Web Apps need to be wrapped in a signed native APK. This allowed Google to support Web Apps across existing versions of Android without having to introduce a new architecture to support Web Apps and wait for years for it to be updated.
+
+## Why is not sharing it bad?
+
+First, this damages competition between browsers on Android. By controlling WebAPK minting, Google stifles innovation in the browser market. Other browsers cannot offer the same seamless and native-like PWA install experience as Chrome on Android, limiting their ability to compete. This behaviour unfairly allows Google to provide better functionality for Chrome than other browsers on Android phones. It also means that only Google can decide what functionality Web Apps should have and makes it impossible for other browsers to effectively compete in the provision of Web App features.
+
+Second, this limits the end user's choice of browser when it comes to Web Apps. They are essentially forced to use Chrome if they want the best Web App experience. Users should be free to choose browsers that offer better Web App functionality, but this is impossible if other browsers are prevented from installing them.
+
+Finally, this damages the Web App ecosystem. Web Apps are the only open and interoperable competitor to the Android and iOS app stores. Allowing them to flourish will apply significant competitive pressure on the mobile app stores.
+
+Opening up WebAPK minting would benefit developers and businesses by making it easier for them to reach a wider audience with their Web Apps. This can result in cheaper, higher quality software that automatically works on all major platforms.
+
+Web Apps installed through other browsers are not as integrated with the Android system as those installed through Chrome. This can lead to a less user-friendly experience for consumers. Some features of Web Apps do not work as well or at all when installed through other browsers. This can limit the functionality and usefulness of Web Apps for consumers.
+
+One of Google's stated goals is to promote open web standards, and [they are a supporter of the open web foundation](https://en.wikipedia.org/wiki/Open_Web_Foundation#:~:text=According%20to%20its%20web%20site,Google), yet they contradict this by keeping WebAPK minting closed and exclusive to Chrome.
+
+## OWA’s Work
+
+We have been campaigning for the last 3 years to fix this issue. We have made our case to multiple regulators including the [Australian Competition and Consumer Commission](https://open-web-advocacy.org/files/OWA%20-%20ACCC%20(Australia)%20-%20Response%20to%20Discussion%20Paper%20for%20Interim%20Report%20No.%205%20-%20v1.0.pdf), [Japan's Head Quarters for Digital Competition](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf), [the UK's Competition and Markets Authority](https://assets.publishing.service.gov.uk/media/66d6d1d5c63bb34da0709f21/OWA_WP_1__2__3__4__5___6_-_TO_BE_PUBLISHED.pdf) and [the EU Commission](https://open-web-advocacy.org/files/OWA%20-%20DMA%20Interventions%20-%20Web%20App%20Install%20on%20Android%20-%20v1.0.pdf).
+
+> Google’s refusal to provide competitors a method of minting WebAPK’s prevents competing browsers from producing viable Web Apps.
+> <cite>[Walled Gardens Report (2021)](https://open-web-advocacy.org/walled-gardens-report/#:~:text=Google%E2%80%99s%20refusal%20to%20provide%20competitors%20a%20method%20of%20minting%20WebAPK%E2%80%99s%20prevents%20competing%20browsers%20from%20producing%20viable%20Web%20Apps.)</cite>
+
+This work is showing signs of significant progress.
+
+First, Google's behaviour appears to be explicitly banned by the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) and [Japan's new Smartphone Act](https://competitionlawblog.kluwercompetitionlaw.com/2024/07/02/the-japanese-smartphone-act-teaching-competition-law-new-tricks/). Specifically rules that Gatekeepers such as Google must share APIs with rivals.
+
+Next, the [UK's Market Investigation Reference into Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) has extensively covered this issue:
+
+> **OWA submitted that on Android devices running the Google Play store, only Chrome has the ability to mint (create) WebAPKs (except on Samsung devices). OWA submitted this prevents competing browsers from producing viable web apps.**<br><br>
+> [...]<br><br>
+> Google submitted that the WebAPK minting service provides WebAPK minted apps with certain additional functionality. Google submitted that it has not yet deployed a way for other browsers to use the WebAPK minting service.<br><br>
+> [...]<br><br>
+> Overall, the evidence available to date indicates that Google engages in self-preferencing less, in respect of access to functionalities on Android compared to Apple’s approach on iOS. Lack of access to WebAPKs, which is essential for installing PWAs, is the main issue highlighted by third parties (see paragraphs 4.6 to 4.7). **Whilst Google has acknowledged this restriction, its latest submission to the CMA indicates that it is working to resolve it.**
+> <cite>[UK Browsers and Cloud MIR - WP3)](https://assets.publishing.service.gov.uk/media/667d31fa7d26b2be17a4b3e2/Working_paper_3_Access_to_browser_functionalities_within_the_iOS_and_Android_mobile_ecosystems.pdf) <br>(emphasis added)</cite>
+
+While we are delighted that Google has indicated to the CMA that they will fix the issue, we request that any regulators reading this legally compel Google to do so on a reasonable timeline (within 6 months). We are concerned that this could be strung out for years [or even eventually cancelled](https://www.theregister.com/2024/07/23/google_cookies_third_party_continue/) when the regulatory heat dies down.
+
+Importantly, given this service is provided by Google Play Services, Google should be able to provide this on almost all existing Android devices (Play Services currently goes back to Android 5.0 - 2014, [so includes around 99.6% of users](https://apilevels.com/)). This fix should not be restricted to new Android updates.
+
+To Google, we request that they fix this promptly, globally and fairly. We ask that Google not play any regulatory games by only fixing it where they are legally compelled to do so and at the earliest possible date publicly publish a full plan on how they intend to share this functionality. We ask that they reach out and talk to interested browser vendors directly.
+
+We would also like to thank everyone who supports us for making our work possible. Without it we would not be able to apply this pressure to improve competition for both browsers and Web Apps.
+
+

--- a/src/ja/posts/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of.md
+++ b/src/ja/posts/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of.md
@@ -1,0 +1,75 @@
+---
+title: 'In-App Browsers: The worst erosion of user choice you haven''t heard of'
+date: '2024-03-26'
+tags:
+  - Policy
+  - Apple
+  - Google
+  - Meta
+  - TikTok
+author: OWA
+permalink: >-
+  /ja/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<iframe style="max-width: 100%;" width="560" height="315" src="https://www.youtube-nocookie.com/embed/-6mFC__dMWM?si=dCn6x88fPOox76WL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+In-App Browsers subvert user choice, stifle innovation, trap users into apps, break websites and enable applications to severely undermine user privacy. In-App Browsers hurt consumers, developers and damage the entire web ecosystem.
+
+OWA recently met with both the Digital Markets Act team and the UK's Market Investigation Reference into Cloud Gaming and Browsers team to discuss how tech giants are subverting users' choice of default browser via in-app browsers and the harm this causes.
+
+In-App browsers is a complex topic, so to outline our thoughts we wrote [a detailed 61 page submission](/files/OWA%20-%20DMA%20Interventions%20-%20In-App%20Browsers%20v1.2.pdf) to the EU Commission which we are now publicly publishing today.
+
+So what are In-App Browsers, and what problems do they cause?
+
+An In-App Browser can open when users tap on links in a non-browser app. Rather than switching out of the app and to the user's default browser, in-app browsers open a pane within the host native app to render web pages. Hence the name, “in-app browser”.
+
+When you click on a link to a third-party website, many popular apps ignore your choice of default browser and instead automatically and silently replace your default browser with their own in-app browser. Many users - likely most users! - are not aware that this switch has taken place.
+
+Worst of all, this switch grants these apps the ability to spy and manipulate third-party websites. Popular apps like Instagram, Facebook Messenger and Facebook [have all been caught injecting JavaScript](https://krausefx.com/blog/ios-privacy-instagram-and-facebook-can-track-anything-you-do-on-any-website-in-their-in-app-browser) via their in-app browsers into third party websites. TikTok was running [commands that were essentially a keylogger](https://krausefx.com/blog/announcing-inappbrowsercom-see-what-javascript-commands-get-executed-in-an-in-app-browser). While we have no proof that this data was used or exfiltrated from the device, the mere presence of JavaScript code collecting this data combined with no plausible explanation is extremely concerning.
+
+It is possible to use in-app browsers in a way that preserves privacy. Both iOS and Android provide a system components (SFSafariViewController and Android Custom Tabs respectively), which do not allow the hosting app to inject JavaScript or otherwise spy on the user. Android Custom Tabs solution also (by default) invokes the users default browser.
+
+Thus, this behavior would be impossible if links were simply opened in the user's default browser or in the system provided in-app browser.
+
+This is the reality users face on their phones today. It doesn't have to be this way. Mandating that apps respect browser choice isn't just a matter of convenience; it's about empowering both consumers and companies to thrive in a more open, stable, feature rich, secure and private digital ecosystem.
+
+Disrespect of users' choice of browser also stifles innovation. The Web thrives when browsers compete on functionality and user experience. In-app browsers, however, don't compete as browsers. Many, perhaps even most, users are unaware they are being foisted upon them. They're also unaware of the quality, security and privacy risks associated with them. In-app browsers operate in a vacuum, immune from competitive pressure to improve.
+
+This stagnation hurts everyone. Users are stuck with forgetful, subpar in-app browsers. Businesses struggle to reach and engage with audiences due to missing features and bugs in browsers that no one made an affirmative choice to use.
+
+**The solution is clear – respect the user's choice of browser.**
+
+Mandating that non-browser apps utilise a users' default browser for third-party websites will unlock a more vibrant and equitable digital landscape. Users will enjoy familiar tools they trust, experiencing websites as they were designed. Businesses and publishers will gain access to earned audiences, free from interference by native app developers.
+
+The intrusion of in-app browsers, along with the significant bugs, missing features and critical privacy and data protection concerns they introduce should be addressed. The Digital Markets Act and the UK's MIR have all of the necessary enforcement powers to right this wrong.
+
+Remote tab in-app browsers such as Android Custom Tabs are a potentially ideal solution for most users. Android Custom Tabs, by default, invokes the user's default browser and prevents the app injecting JavaScript. This is an interesting middle ground where the user (and the app) can benefit from not leaving the app context while still respecting the user's choice of default browser and preserving the user's privacy. However, it is currently possible for the hosting native app to lock Android Custom Tabs to a particular browser and override the user's choice of default browser. This ability needs to be removed.
+
+While iOS's remote tab in-app browser (SFSafariViewController) prevents the app injecting JavaScript, it is locked to Safari (or more specifically the WkWebView) and thus overrides the user's choice of default browser.
+
+We have proposed 6 remedies:
+* Designated Core Platform Services should respect the user's choice of default browser. (DMA specific)
+* App Store rules must mandate non-browser apps use the user's chosen default browser for http/https links to third-party websites/Web Apps.
+* Apple must update SFSafariViewController (Apple's system provided in-app browser for iOS) to respect the user's choice of default browser.
+* Third-Party businesses must be provided an explicit and effective technical opt-out from non-default In-App Browsers.
+* Operating systems must provide a global user opt-out. Apps must also request explicit permission from users in order to override their choice of default browser.
+* Google must remove the ability to override a user's choice of default browser via Android Custom Tabs (Google's system provided in-app browser for Android).
+
+These remedies overlap, addressing different aspects of the problem. When effected, these remedies will prevent gatekeepers from subverting the user choice of browser, provide users enhanced control over their privacy and security, and make technical fixes to the underpinnings of how web pages are loaded. These fixes will project a user's choice of browser in non-browser apps they use, providing users the security, privacy, stability and features on which browser wars are legitimately fought. No longer will apps be allowed to syphon web traffic for their own enrichment at the detriment of the community at large.
+
+We would in particular like to thank Lukasz Olejnik, Felix Krause, Jesper van den Ende, Stuart Langridge, Bruce Lawson and Adrian Holovaty for their work in helping make this case. We are also thankful for the broad support and feedback we have received from the web development and browser development community.
+
+We will continue to pursue this matter until it is fixed globally. Users' choice of browser is only important if that choice is actually respected.
+
+**Your browser, your choice!**
+
+Stay tuned:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/interop-2025-must-drop-secret-vetos.md
+++ b/src/ja/posts/interop-2025-must-drop-secret-vetos.md
@@ -1,0 +1,94 @@
+---
+title: Interop 2025 must drop secret vetos
+date: '2024-10-10'
+tags:
+  - Apple
+  - Google
+  - Microsoft
+  - Mozilla
+  - Interop
+author: OWA
+permalink: /ja/blog/interop-2025-must-drop-secret-vetos/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TLDR: Interop uses secret vetos, mobile NOT included in interop scores, Critical Safari scroll issues need fixing.**
+
+ **Please consider giving a 👍 to these issues:**
+
+1. [Interop Lack of Transparency & Accountability](https://github.com/web-platform-tests/interop/issues/888)  
+2. [Mobile Testing Results for Interop/WPT](https://github.com/web-platform-tests/interop/issues/891)  
+3. [Scrolling on Mobile Devices](https://github.com/web-platform-tests/interop/issues/788)  
+4. [Advanced Web Testing (Web Driver BiDi)](https://github.com/web-platform-tests/interop/issues/763)
+
+The voting process for Interop proposals is done in **secret** and each browser vendor involved can veto any feature without any transparency. Browser Vendors can sift through interop proposals and exclude items they believe are too difficult or don’t match their internal corporate goals. This is bad for the web and against the principle of openness and transparency that web standardization efforts rely on.  
+
+We propose that any votes or vetoes are made public with attribution, and any reasons for not proceeding with a particular feature are posted in the github issue along with attribution.  
+
+**We need your help to push for it to happen\!**
+
+## What is Interop?
+
+Interop is a collaborative project between browser vendors to reduce compatibility issues between browsers so the code we write works the same on all devices and all browsers.
+
+> The web is amazing. It makes collaborating, learning, and connecting easy for billions of people, because it’s intentionally designed to run **on radically different devices**. </br></br>
+> It’s your job as a web developer to ensure your project works in every browser and for every user — and that can be hard to do. It’s a far easier undertaking when browsers have identical implementations of the web technology you use. 
+> <cite>[Webkit blog on the aim of Interop](https://webkit.org/blog/14955/the-web-just-gets-better-with-interop/)</br>(emphasis added)
+</cite>
+
+## Interop Lack of Transparency & Accountability
+
+We believe that standards based efforts between browser vendors such as Interop should be transparent and public.
+
+As mentioned above the current interop veto process is secret, leading to lack of transparency over why issues are not included or not included.
+
+This lack of transparency has already been negatively received by developers and has been a source of mistrust and dissatisfaction with the Interop process:
+
+> Fans of the spec bemoan lack of transparency in Interop 2024 process
+> <cite>[Thomas Claburn \- The Register](https://www.theregister.com/2024/02/03/jpeg_xl_interop_2024/)
+</cite>
+
+> That's it? That's the response to what is, by several times, the most requested feature in Interop 2024? No explanation for rejecting the feature that got 4.5x more support than the runner-up? Really? 
+> <cite>[Tibet Tornaci](https://github.com/web-platform-tests/interop/issues/430#issuecomment-1923216914)
+</cite>
+
+A more open voting process ensures that decisions are made in the best interest of the broader developer and user community, helping to ensure that the web evolves in a way that is fair, inclusive, and sustainable.
+
+Give a **👍** here: [Interop Lack of Transparency & Accountability · Issue \#888](https://github.com/web-platform-tests/interop/issues/888)
+
+## Mobile Testing Results for Interop & WPT
+
+Currently the Interop process misleadingly implies that the scores cover mobile browsers. 
+
+Given that mobile devices make up the vast majority of all personal computers and accounts for the majority of global web traffic, the test results for mobile are significantly more important than the desktop results.
+
+We believe that Interop 2025 should include:
+
+* Building and Running Mobile Test Harnesses for WPT  
+* Include Mobile Test Results in Interop  
+* Upgrading WebDriver
+
+Give a **👍** here: [Mobile Testing Results for Interop/WPT · Issue \#891](https://github.com/web-platform-tests/interop/issues/891)
+
+## Scrolling on Mobile Devices 
+
+The inability to reliably block body scroll in Safari/Webkit and have a consistent scrolling experience across browsers on mobile devices is a very significant long-standing issue which greatly increases the difficulty of building advanced user interfaces and remains a significant compatibility issue between browsers.
+
+This is critical to building native-like or more complex interfaces on iOS.
+
+Give a **👍** here: [Scrolling on Mobile Devices · Issue \#788](https://github.com/web-platform-tests/interop/issues/788)
+
+## Advanced Web Testing (WebDriver BiDi)
+
+This issue isn’t posted by OWA but is an important one to allow for improved browser testing.
+
+WebDriver BiDi is a new protocol for browser automation. It extends the “classic” WebDriver protocol by introducing bidirectional communication. In place of the strict command/response format of WebDriver, this permits events to stream from the browser to the controlling software, better matching the evented nature of the browser.  
+
+Primarily this will lead to better testing for browsers and hopefully less bugs for the rest of us. It is also the only thing that will allow for testing of some of the more advanced browser features.
+
+Give a **👍** here: [WebDriver BiDi · Issue \#763](https://github.com/web-platform-tests/interop/issues/763)
+
+## How can you help?
+
+Please 👍 and/or comment on these tickets. If you have expertise or knowledge that will improve these issues please either email us or comment on the issue.

--- a/src/ja/posts/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen.md
+++ b/src/ja/posts/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen.md
@@ -1,0 +1,272 @@
+---
+title: 'iOS age restriction blocks all browsers except Safari, breaks choice screen'
+date: '2024-11-15'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: >-
+  /ja/blog/ios-age-restriction-blocks-all-browsers-except-safari-breaks-choice-screen/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**Share and join the conversation: [X/Twitter](https://x.com/OpenWebAdvocacy/status/1857393321922162818), [Mastodon](https://mastodon.social/@owa/113486859647211896
+), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7263159027944075264) and [Bluesky](https://bsky.app/profile/open-web-advocacy.org/post/3laydcxvns22x).**
+
+_Note: Throughout this article, references to iOS also encompass iPadOS._
+
+Apple is currently failing to comply with its obligations under Article 6(3) of the Digital Markets Act (DMA) regarding the provision of the browser choice screen. The iOS browser choice screen is currently broken for any user with age restrictions for apps enabled, effectively preventing them from selecting any browser other than Safari.
+
+Furthermore, Apple has been preventing the use or installation of third-party browsers when age restrictions for apps are enabled. This is despite the fact that Apple has exempted Safari from these restrictions and that parental content restrictions for the Web are handled by an entirely separate mechanism.
+
+While all browsers on iOS, including Safari, are rated 17+, Safari benefits from two exemptions:
+* As a pre-installed browser, Safari doesn't require users to actively download it.
+* Apple has implemented specific code that exempts Safari from age restrictions, allowing it to be displayed and opened despite being rated 17+. All other browsers are hidden when age restrictions are applied.
+
+We estimate that this issue impacts 11-15% of EU iOS users, significantly undermining the effectiveness of Apple's compliance with Article 6(3).
+
+Finally, Apple has yet to provide an API for third-party browsers using their own engines to support and interoperate with parental control features for web browsing, currently implemented via the WkWebView.
+
+To rectify this situation and be compliant with the DMA we believe that Apple should:
+* Remove the 17+ age rating from browser apps.
+* Allow all browsers listed on the choice screen to be selectable, installable, and usable even if age restrictions for apps is enabled.
+* Create an API that empowers third-party browsers using their own engines to effectively support parental control features.
+* Apply age restrictions for apps equally to Apple’s own apps.
+
+## 1. Age Restriction Controls on iOS
+
+On iOS, there are two independent parental supervision settings available to parents:
+
+1. **Web Content Restrictions**
+   This allows parents to restrict their childrens’ access to adult websites. This setting is respected by **all browsers** across iOS (Safari, and all competing third-party browsers). Currently this is implemented via the WkWebView and thus is automatically applied to all browsers that are currently available on iOS. <br><br> Apple will need to provide an API to third-party browsers using their own engine to allow them to effectively support this feature and for Apple to comply with their Article 6(7) obligations.
+
+2. **Age Restrictions for Apps**
+   This allows parents to restrict their childrens’ access to apps that are rated above the age-limit they've chosen. So if an app in the App Store is rated 17+, and parents set the age restriction to \<17, this effectively makes it so that their child cannot download apps that are 17+, or if these apps are already downloaded, the child can't use/launch these 17+ apps, as their icons are hidden.
+
+On Apple's App Store, all browsers (including Safari, despite it being preinstalled) have a 17+ age restriction, under the justification that they provide "Unrestricted Web Access". So if parents set app age restrictions on their children's devices, they cannot download or launch already installed competing third-party browsers. However, as discussed in the introduction, Safari is exempted from this.
+
+We would like to clarify that on iOS, at the moment, parents are free to set age restrictions for apps to 4+ years old (i.e. only apps that Apple believes are suitable for 4 year olds \- 8 year olds), yet still allow unrestricted internet access to all websites. These two mechanisms are entirely independent of each other.
+
+To emphasize the distinction, the age restrictions for apps setting has nothing to do with unrestricted internet access (i.e. to adult websites etc) — the restriction only affects which apps young users are allowed to download or use.
+
+## 2. Choice Screen Non-Compliance
+
+This issue with age restrictions for apps also breaks the browser choice screen. We've discovered that for iOS users with age restrictions enabled, the browser choice screen is completely broken:
+
+1. The screen displays a list of browsers to choose as the new system default.
+
+2. Upon selecting a third-party browser other than Safari, the system initiates a download process.
+
+3. Once the download reaches 100%, the screen becomes unresponsive, trapping the user without any further actions or navigation options. The user's only choice is to quit the choice screen.
+
+4. Quitting the screen reveals that the chosen browser has not been installed, leaving Safari as the only available browser.
+
+This effectively breaks the choice screen and denies that choice for all European Residents who are iOS users with age restrictions for apps turned on.
+
+## 3. How many users does this affect?
+
+Eurostat data reveals that [5.2% of EU residents are aged 15-19](https://ec.europa.eu/eurostat/cache/interactive-publications/demography/2023/04/index.html?lang=en), [while 15% are under 15](https://ec.europa.eu/eurostat/cache/interactive-publications/demography/2023/04/index.html?lang=en). Considering these figures, it is reasonable to estimate that approximately 15-20% of the EU population is under the age of 17\.
+
+We do not have precise figures on the number of users that switch on age restrictions for apps but the following pieces of data give us a rough idea:
+
+* [This survey](https://www.techradar.com/pro/how-to-put-parental-controls-on-an-iphone) states 39% of parents report using parental controls for blocking, filtering or monitoring their teen’s online activities.
+
+* [This study](https://www.pewresearch.org/internet/2016/01/07/parents-teens-and-digital-monitoring/) states 59.5% of them actively use parental controls on their child’s iPhone.
+
+* [This study](https://digitalwellnesslab.org/research-briefs/safety-and-surveillance-software-practices-as-a-parent-in-the-digital-world/) states 72% use parental controls to restrict time on devices.
+
+By combining the figures we can estimate that Apple is blocking its choice screen from working for approximately 11-15% of EU residents who use iOS, which is a significant percentage of the population.
+
+## 4. Why is this important?
+
+Apple effectively prevents users with age restriction for apps turned on from being able to download and use competing third-party browsers.
+
+Yet, on that same device, despite the fact that Safari itself has the same 17+ age restriction in the App Store, users can continue to use Safari without any restrictions or issues, and so can continue to access the web through Safari with no restrictions, including adult websites.
+
+Conversely, if the parent turned off age restriction for apps but enabled web content restrictions then adult websites would be blocked in all browsers on iOS.
+
+This is due to the fact that, as we mentioned earlier, the web content restriction settings are in fact independent from the age restriction settings.
+
+Currently, Safari having an exception effectively prevents all third-party browser competition on iOS for a significant segment of the European population (approximately 11-15% of EU iOS users). This practice not only significantly undermines the effectiveness of the browser choice screen but also more broadly stifles browser competition. In the next 5 \- 10 years, the effect of these restrictions could mean the majority of young users will grow up without being aware of alternative browsers or the features they offer.
+
+Finally, as an example of how this behavior could impede third parties contesting Apple’s app store, this will likely have a major impact on the online gaming industry. Once third-party browser engines start to make their way onto iOS, it will pave the way for an explosion in the online gaming industry. We can already see this from the vast number of online cloud-streaming game services that rely on web technologies.
+
+By gating young users' access to alternative browsers and browser engines behind an age restriction, Apple effectively forces the future of online gaming to take place in their browser, with its limited number of APIs and features, which nudges developers to instead build native apps and users to choose native games from which Apple can and will profit greatly from.
+
+## 5. Apple Agrees that Users should have at least One Browser
+
+When attempting to delete the only browser on iOS, Apple will display the following message:
+
+> **Download Browser App**
+> At least one browser app is required on iPhone. Download another browser app, then you can delete “Safari”.
+> \[Open App Store\] \[Cancel\]
+
+<figure>
+    {% image
+        "/images/blog/delete-only-browser-error-message.png",
+        "An error message on iOS. Reads At least one browser app is required on iPhone. Download another browser app, then you can delete 'Safari'.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Apple's error message for deleting only browser.</figcaption>
+</figure>
+
+However, Apple currently maintains this requirement by granting Safari a special exemption from its own age restrictions for apps. This exemption highlights the inconsistency in Apple's approach, as it recognizes the need for browser availability while simultaneously imposing barriers on third-party browsers.
+
+It's worth noting that if a user installs a third-party browser, deletes Safari, and then enables age restrictions, they will be left without any browser options, as the icons for all the third-party browsers will be removed and it will be hidden from search. This scenario further emphasizes the limitations of Apple's current system and the need for a more consistent and equitable approach.
+
+## 5. Apple's Inconsistent and Poorly Designed Age Ratings
+
+Apple has the following age rating settings available:
+
+<figure>
+    {% image
+        "/images/blog/age-settings.jpeg",
+        "The age restrictions settings page on iOS. It has the title apps and 5 settings. The settings are Don't Allow, 4+, 9+, 12+, 17+. The 17+ setting is ticked",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/age-rating-explanations.jpeg",
+        "A screenshot of an article by Apple explaining what age ratings apple has.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Apple's age rating settings and explanation.</figcaption>
+</figure>
+
+Bizarrely, Apple lacks an "Everyone" or G rating. This could be a strategic move by Apple to potentially claim that all apps are intended for users aged 4 and over. This approach might shield Apple from potential legal liabilities arising from younger children's use of apps.
+
+They also explain their age rating system [on their website.](https://developer.apple.com/help/app-store-connect/reference/age-ratings/) At the end, they snidely claim that adult content is only accessible on alternative app marketplaces or websites within the European Union.
+
+Possibly this is an attempt to cast alternative app stores as being unsavory but is odd in the context of 18+ ([depending on country](https://www.imdb.com/title/tt6263850/parentalguide/?ref_=tt_stry_pg#certificates)) films such as “Deadpool & Wolverine” being billion dollar box office hits, immensely popular and available on the iOS App Store via Disney+.
+
+### 5.1. 18+ Content on the Apple’s App Store
+
+Disney Plus has a 4+ rating, yet one of the first things advertised on its app store page is the Deadpool & Wolverine film, which is rated for 14+ and 18+ ([varies by country](https://www.imdb.com/title/tt6263850/parentalguide/?ref_=tt_stry_pg#certificates)).
+
+<figure>
+    {% image
+        "/images/blog/disney-plus-ios-app-store.jpeg",
+        "A screenshot of the disney+ iOS app store page. It has the age rating 4+.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/disney-plus-deadpool.jpeg",
+        "A screenshot of the disney+ iOS app store page showing the the new deadpool film is now available.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Disney Plus (4+) and Deadpool & Wolverine.</figcaption>
+</figure>
+
+
+### 5.2. Apps for Kindergarten Children
+
+<figure>
+    {% image
+        "/images/blog/kindergarten-app-1.jpeg",
+        "An screenshot of the bebi teaching app. It has a 4+ rating.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/kindergarten-app-2.jpeg",
+        "An screenshot of the bebi teaching app, it indicates it can help 2,3,4 and even 5 year olds learn.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>Teaching App for Babies and Kindergarten with 4+ rating</figcaption>
+</figure>
+
+For example, this app is marketed as being to help “2,3,4 and even 5 year olds” learn. Despite this it has a 4+ rating (the lowest rating that Apple will allow). It is not clear why apps like this should not have a G rating and if they are unsuitable for under 4 year olds, why they should be allowed to market themselves as being for that demographic.
+
+### 5.3. In-App Browsers
+
+Again, adult content is not filtered by the age rating setting for apps. Any apps that contain links (for example messaging and social media apps) will not be blocked by the age rating setting for apps, nor does this affect their age rating.
+
+For example adult websites can be visited in apps with low age ratings (such as Instagram which is rated 12+) by using Apple’s in-app browser SFSafariViewController:
+
+<figure>
+    {% image
+        "/images/blog/instagram-link-1.jpeg",
+        "A message being sent with a link on Instagram.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    {% image
+        "/images/blog/instagram-link-2.jpeg",
+        "That link opening into an in-app browser with the warning 18+ splash page for an adult website.",
+        null, null,
+        [300],
+        "300px"
+    %}
+    <figcaption>A link being opened in a 12+ app to an adult website.</figcaption>
+</figure>
+
+This highlights why age ratings on apps with links to the web doesn’t make sense: **it is the web content restriction setting which actually prevents** in-app browsers from visiting known adult websites. The age rating setting is ineffective here, as can be seen in these screenshots.
+
+### 5.4. Inconsistently Applied Ratings
+
+Apple’s age ratings are also wildly inconsistent.
+
+Disney+ is 4+ but Netflix and Apple TV are 12+. However, both contain between 15-18+ content and all three have built-in parental controls.
+
+Most messaging apps are 12+, some are 17+ but iMessage and Facetime are 4+ despite all messaging apps having the ability to transmit 18+ content.
+
+Large numbers of apps that should be G rated are assigned a 4+ rating.
+
+### 5.5. More Apple Apps Outright Ignoring the Rating System
+
+iMessage, Facetime, Apple Books and Apple TV all outright ignore the age restrictions for apps. That is, unlike other apps, they are not hidden and disabled when users turn on age restrictions for apps to an age below their rating.
+
+iMessage and Facetime (both rated 4+ but having the ability to display 18+ content) will continue to function if the age restriction for apps is set to “Don’t Allow” (a setting that seemingly disables all apps), despite being listed on the app store with age ratings.
+
+Apple TV, despite having a rating of 12+ ([and content that is rated between 12+ and 18+ depending on country](https://www.imdb.com/title/tt11280740/)) will continue to function if the age rating is set to 4+. Note: Apple TV does have its [own separate set of controls](https://support.apple.com/en-gb/guide/tvapp/atvb5408f9ae/web) within the app that allow parents to restrict the content.
+
+This is still problematic as [Netflix also has such controls](https://help.netflix.com/en/node/264), but setting the age restrictions for apps to 4+ will remove the icon for the Netflix app and make it impossible to open it. This is clearly an unfair, unhelpful and anti-competitive way to implement age controls.
+
+A more sensible solution, which would actually help parents who want to use such a setting, would be to:
+
+* Have a G-rating (or Everyone rating).
+
+* Acknowledge that the app store has 18+ content, and where necessary assign that rating to apps. Simply pretending it does not exist is not helpful. While films and TV shows vary in rating from country to country, to our knowledge Apple does not block these TV shows/films in countries where they are rated 18+.
+
+* Let apps have the lowest rating of all (or as much as reasonably possible) of the content on the app can be filtered using parental controls within each app.
+
+* Apply the ratings consistently to Apple’s apps. If that is a significant issue, then it's an indication the age rating system is not designed properly.
+
+* Have an allow and block list (like for the web content restriction setting) so that parents can individually allow or block apps that Apple has inappropriately or incorrectly rated.
+
+As it is, Apple, by their misdesign of the system, is not only harming competition, but is actively preventing parents from using these age restriction controls by making them difficult to use. A parent, upon discovering that their Netflix app will no longer function, despite it being set to only allow childrens content, might avoid using the setting altogether.
+
+## 6. Remedies
+
+In order to be in full compliance with Articles 6(3) and 6(7) of the DMA in relation to this issue, Apple must take the following steps:
+
+* **Remove Age Ratings from Browsers**
+  Given that parental controls for web browsing operate independently of app age ratings, Apple should remove age ratings from browsers. The 17+ age rating on browsers serves no significant purpose, **except** **to hinder competition** from third-party browsers, as evidenced by Apple's exemption of Safari from these restrictions.   <br><br>
+
+  All browsers that support Apple’s existing system of web content restrictions (currently all browsers on iOS, as it is implemented via the WkWebView) should be allowed with G rating or given a 4+ rating. EU users should have the option of setting both “web content restrictions” and “age restriction for apps” for their children and still be able to use third-party browsers.
+
+* **Compliant Browser Choice Screen**
+  The browser choice screen must be accessible to all EU residents regardless of their age, or whether they have age restriction for apps turned on, and the users must be able to select, install and use any browser from that choice screen. This must be fixed before the general roll out of the updated choice screen, or in the case it is not, be rerun on all of those devices after the fix has been applied.
+
+* **Third-Party Browser Support for Parent Controls**
+  Apple should develop an API that allows third-party browsers using their own engine to effectively support parental control features. This should be relatively straightforward for Apple to implement.
+
+* **Age Restrictions for Apps should apply equally to Apple’s own Apps**
+  Apple should not exempt its own apps from the setting. Where this causes problems Apple should carefully redesign the system. *Fixing the system, but doing so only for Apple’s apps, is not acceptable under the DMA*.
+
+By compelling Apple to implement these remedies, the EU Commission can help ensure equal treatment of all browsers and remove these barriers to choice. This benefits individual consumers by allowing them to make informed decisions about the software they use. Additionally, it stimulates innovation and competition among browser vendors, leading to a better user experience and a more diverse digital ecosystem.

--- a/src/ja/posts/its-official-apple-kills-web-apps-in-the-eu.md
+++ b/src/ja/posts/its-official-apple-kills-web-apps-in-the-eu.md
@@ -1,0 +1,65 @@
+---
+title: 'It’s Official, Apple Kills Web Apps in the EU'
+date: '2024-02-16'
+tags:
+  - Apple
+  - EU
+  - Safari
+author: OWA
+relatedLinks:
+  - url: 'https://developer.apple.com/support/dma-and-apps-in-the-eu#8'
+    title: Why don't users in the EU have access to Home Screen web apps?
+    date: 2024-02-19T00:00:00.000Z
+permalink: /ja/blog/its-official-apple-kills-web-apps-in-the-eu/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+<div class="prom-banner" style="max-width: 30em;">
+    <p class"illustration"><img src="/images/owa-home-logo.svg" alt="" /></p>
+    <p><strong>If you ship a Web App in the EU and will be impacted by this, please sign our open letter to Tim Cook.</strong> It is critical that we gather as much evidence as possible to prevent Apple from breaking Web Apps in the EU.</p>
+
+    <div>
+        <p><a href="https://letter.open-web-advocacy.org/" class="donate-button">
+          Sign the letter to Tim Cook
+            <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"></circle><polyline points="12 16 16 12 12 8"></polyline><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        </a></p>
+    </div>
+</div>
+
+Nearly two weeks ago [we discussed a bug](https://open-web-advocacy.org/blog/did-apple-just-break-web-apps-in-ios17.4-beta-eu/) on iOS Beta 17.4 breaking Web App installation in the EU. Yesterday [we raised the alarm](https://open-web-advocacy.org/blog/apple-on-course-to-break-all-web-apps-in-eu-within-20-days/) that this appeared to be not a bug but a deliberate choice on Apple’s part. Today Apple officially confirmed our suspicions in an update to their compliance proposal.
+
+In a direct attack on the open web, its users, and its developers, [they have decided to kill Web Apps (PWAs) in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu#8):
+
+> And so, to comply with the DMA’s requirements, we had to remove the Home Screen web apps feature in the EU.<br><br>
+> EU users will be able to continue accessing websites directly from their Home Screen through a bookmark with minimal impact to their functionality. We expect this change to affect a small number of users. Still, we regret any impact this change — that was made as part of the work to comply with the DMA — may have on developers of Home Screen web apps and our users.”
+
+This is emphatically not required by the EU’s Digital Markets Act (DMA). It’s a circumvention of both the spirit and the letter of the Act, and if the EU allows it, then the DMA will have failed in its aim to allow fair and effective browser and web app competition.
+
+It’s telling that this is the feature that Apple refused to share. And it makes sense: the idea that users could install safe and secure apps that Apple can’t tax, block or control is terrifying to them.
+
+The legal obligation to allow third-party browsers onto iOS removes their ability to set a ceiling on web app functionality via their control of Safari and the WKWebView. Suddenly Web Apps would be a viable competitor. It is particularly galling for them to cite low adoption when they have had their thumb on the scale suppressing them for over a decade.
+
+The DMA compels them to allow third party app stores, but Apple’s plan is to cripple them with their hardware and software API fee (Core Technology Fee) and their ludicrous “opt-in to your legal rights” at a different price alternative contract.
+
+But web apps are much harder to stop. Even Apple admits WebKit’s sandbox is, [to quote them](https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf) ”orders of magnitude more stringent than the sandbox for native iOS apps”. They tried claiming to the UK regulator that Safari is more secure than other major browsers but decisively lost that argument.
+
+So this is their new tactic: Kill off a competitor while saying the EU made them do it.
+
+Apple has had 15 years to allow third party browsers the ability to compete in web app functionality and nearly 2 since they knew they would be legally compelled to do so.
+
+[Apple also makes tenuous, bordering on laughable, claims regarding web app security.](https://developer.apple.com/support/dma-and-apps-in-the-eu#dev-qa:~:text=Why%20don%27t%20users%20in%20the%20EU%20have%20access%20to%20Home%20Screen%20web%20apps%3F) In addition to unwarranted and unjustifiable attempts to project their own model onto competing browsers, Apple makes claims that ignore the history of web applications and browsers in providing strong privacy and security separation. Apple offers no evidence to back these assertions, and ignores the long track record of superior security of PWAs on other OSes.
+
+Again and again, Apple has offered paper-thin fig-leaf arguments based on security to duck regulation, only to have these ploys rejected in nearly every jurisdiction where evidence is critically examined. This appears to be another instance of the same willfully misleading pattern. If security posturing is the backbone of Apple’s attempt to duck conformance with the DMA, the EU must reject the proposal and find Apple willfully non-compliant.
+
+Apple also makes a self-fulfilling argument regarding the low use of iOS homescreen web apps. This is a situation of Apple’s own making and, indeed, a large part of why OWA has invested so much in reversing Apple’s history of self-preferencing towards native apps that Apple can tax through its App Store monopoly. Instead of offering equivalent affordances for websites looking to compete with App Store alternatives, Apple’s answer is to remove the capability, destroy critical features, and engender data loss for users and businesses that had invested in the web as a platform. Malicious destruction may be Apple’s attempt at an answer, but it is not a solution.
+
+The next question is: Why all the secrecy? There was nothing in their compliance plan, Safari’s release notes or the beta’s release notes. Given that they are now stating they knew all along, it seems they wanted to see if they could sneak this past.
+
+Clearly the backlash has caught them off guard and that’s why they had to rush out this panicked response, the only significant update they have made to their compliance proposal.
+
+We always assumed that the commission would have to fine Apple billions to force them to allow the web to compete fairly and effectively with their App Store but it’s still incredibly disappointing to see Apple behave like this.
+
+This is a message in a bottle to regulators world-wide: Apple will stop at nothing to protect its app distribution monopoly and the rent that comes with it, including removing critical features from its OSes without the slightest care for its users. It will not act in good faith, it must be forced.
+
+We will continue to work with the EC to ensure that Web Apps can remain first-class citizens for iOS users, businesses, and competing browser vendors.

--- a/src/ja/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
+++ b/src/ja/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
@@ -1,0 +1,94 @@
+---
+title: 'It''s time for a fairer, more competitive app ecosystem'
+date: '2024-10-24'
+tags:
+  - Policy
+  - EU
+  - DMA
+  - Apple
+  - Google
+  - Microsoft
+  - Meta
+  - Bytedance
+author: OWA
+permalink: /ja/blog/its-time-for-a-fairer-more-competitive-app-ecosystem/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Today, together with many others, we have co-signed [this important letter](/files/Open%20Letter%20-%20DMA%20enforcement.pdf) addressing the urgent need for DMA enforcement.  
+
+Share and join the conversation: [X/Twitter](https://twitter.com/OpenWebAdvocacy/status/1849318246358667748), [Mastodon](https://mastodon.social/@owa/113360687739265649), [LinkedIn](https://www.linkedin.com/posts/open-web-advocacy_its-time-for-a-fairer-more-competitive-activity-7255092980787593219-88eF).
+
+The Digital Markets Act (DMA) aims to restore contestability, interoperability, choice, and fairness to digital markets within the EU. These fundamental principles of a well-functioning digital market have been compromised by the excessive power gatekeepers exert through their control of "core platform services."
+
+The lack of competition in mobile ecosystems is fundamentally structural. Gatekeepers wield immense power due to the security model upon which these devices are built. Traditionally, on operating systems like Windows, macOS, and Linux, users can install any application they choose without interaction from the operating system gatekeeper, either by the business or the end user. Users can then grant these programs the necessary permissions to perform their desired functions.
+
+While restricting what applications can do, such as limiting their access to certain APIs behind user permissions, is not inherently anti-competitive and can offer legitimate security benefits, its implementation on mobile devices is both self-serving and significantly damaging to competition in its current form.
+
+This anti-competitive behaviour, hindering both browser and Web App competition, has and continues to cost consumers billions of dollars annually.
+
+This is not an exaggeration; if the Web were able to compete fairly and effectively with native app stores, these gatekeepers would not be able to demand a 30% cut of all third-party software. Gatekeepers obtain this cut not through merit but simply by blocking all alternative means of running third-party software, such as Web Apps.
+
+The harm extends beyond these taxes extracted through lock-in. It also damages the ecosystem in four other key ways:
+
+* Increased development costs  
+* The ability to block competitors or entire categories of apps  
+* Higher costs and friction associated with market entry, leading to fewer apps  
+* Deprivation of new mobile device ecosystems from a library of apps, blocking a new competitor to iOS and Android from emerging.
+
+The DMA was passed into law on 1st of November 2022 and its grace period for gatekeepers ended on March 7th 2024, more than 6 months ago. Despite this, gatekeepers (in particular Apple) are still not fully complying with either the letter or spirit of the DMA.
+
+While the DMA has had some significant success in obligating both Apple and Google to introduce reasonably designed browser choice screens, [fix this outrageous deceptive pattern](/blog/apples-one-weird-trick-to-stop-you-changing-your-default-browser/), [allow game emulators](https://au.pcmag.com/mobile-apps/104689/apple-is-finally-allowing-retro-game-emulators-in-the-app-store), [fairer default choice](https://open-web-advocacy.org/blog/apple-adopts-6-owa-choice-architecture-recommendations/) and have [three non-compliance investigations into Apple](https://www.theguardian.com/technology/article/2024/jun/24/apple-breach-eu-competition-rules-digital-markets-act), there is still much to be done.
+
+The following issues remain unresolved:
+
+**Apple:**
+
+* [Allow browser vendors to keep their existing EU consumers when switching to use their own engine.](https://open-web-advocacy.org/apple-dma-review/#allow-browser-vendors-to-keep-their-existing-EU-customers)  
+* [Allowing Browser Vendors and Developers to be able to test their browsers and web software outside the EU.](https://open-web-advocacy.org/apple-dma-review/#testing-for-browser-vendors-and-developers-outside-the-EU)  
+* [Restricting Apple's API contract for browsers down to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/apple-dma-review/#remove-non-security-terms)  
+* [Make clear what the security measures are for third party browsers using their own engine by publishing them in a single up-to-date document.](https://open-web-advocacy.org/apple-dma-review/#security-rules-must-be-clear)  
+* [Implementing Install Prompts in iOS Safari for Web Apps.](https://open-web-advocacy.org/apple-dma-review/#implement-web-app-install-prompts-for-ios-safari-and-wKWebView-browsers)  
+* [Allowing Browsers using their own engine to install and manage Web Apps.](https://open-web-advocacy.org/apple-dma-review/#web-app-installation-and-management-for-third-party-browsers)  
+* [Removing any App Store rule that would prevent third party browsers from competing fairly.](https://open-web-advocacy.org/apple-dma-review/#app-store-rules-for-browsers-must-not-violate-article-5-7-and-recital-43)  
+* [Make Safari uninstallable.](https://open-web-advocacy.org/apple-dma-review/#safari-is-not-uninstallable)  
+* [Make notarization a fast and automatic process, as on macOS.](https://open-web-advocacy.org/apple-dma-review/#apple-should-make-notarization-for-directly-downloaded-browsers-automatic)  
+* [Allow direct browser installation independently from Apple’s app store.](https://open-web-advocacy.org/apple-dma-review/#direct-browser-installation)  
+* [Allow users to switch to different distribution methods of a native app and allow developers to promote that option to the user.](https://open-web-advocacy.org/apple-dma-review/#allow-users-to-switch-the-distribution-method-of-native-apps)  
+* [Respect the user's choice of default browser in SFSafariViewController.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* [Don’t lock Safari to Apple Pay](https://open-web-advocacy.org/apple-dma-review/#safari-is-locked-to-apple-pay)  
+* [Don't break third party browsers for EU residents who are travelling.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu)  
+* [Opt-Into Rights contract should be removed.](https://open-web-advocacy.org/apple-dma-review/#apple-should-not-break-updates-for-eu-residents-traveling-outside-the-eu:~:text=with%20the%20DMA.-,4.3.6.%20Opt%2DIn%20Rights%20Contract%20Should%20Be%20Removed,-All%20businesses%20serving)  
+* [Core Technology Fee should be removed.](https://open-web-advocacy.org/apple-dma-review/#core-technology-fee-should-be-removed)  
+* [Publish a new more detailed compliance plan.](https://open-web-advocacy.org/apple-dma-review/#apple-should-publish-a-new-more-detailed-compliance-plan)
+
+**Google:**
+
+* [Share WebAPK Minting with third-party browser vendors subject to strictly necessary, proportionate and justified security measures.](https://open-web-advocacy.org/blog/google-must-share-the-ability-to-install-web-apps-in-android/)  
+* [Respect the user's choice of default browser in the Android Google Search App and the Google App.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)  
+* Make Chrome uninstallable on Android.
+
+**Microsoft:**
+
+* [Remove edge-links and instead respect the user's choice of default browser in various Microsoft apps.](https://www.tomshardware.com/news/microsoft-confirms-windows-11-edge-default-browser)  
+* [Remove and permanently disable various popups, banners in Windows, Bing and Edge that aim to discourage users from switching browser.](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf)  
+* [Allow filetype defaults for browsers to be changed more easily.](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf)  
+* Allow users to switch browser in S-Mode, subject to strictly necessary, proportionate and justified security measures.
+
+**Meta:**
+
+* [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
+
+**Bytedance:**
+
+* [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
+
+For this reason we are adding our voice to many others asking for a fairer, more competitive app ecosystem. Enforcing the DMA is the quickest way to get there.  
+
+We urge MEPs of the ECON and IMCO Committees to hold the gatekeepers accountable for compliance with the DMA.
+
+Read [our joint letter here](/files/Open%20Letter%20-%20DMA%20enforcement.pdf).
+
+
+

--- a/src/ja/posts/japan-ends-the-apple-browser-ban.md
+++ b/src/ja/posts/japan-ends-the-apple-browser-ban.md
@@ -1,0 +1,60 @@
+---
+title: 'Japan ends the #AppleBrowserBan'
+date: '2024-06-13'
+tags:
+  - Apple
+  - Japan
+  - Safari
+author: OWA
+relatedLinks: null
+permalink: /ja/blog/japan-ends-the-apple-browser-ban/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Yesterday, Japan’s parliament [passed into law a bill](https://www.nippon.com/en/news/yjj2024061200145/) to promote fair competition on smartphone operating systems, similar to the [EU’s Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) and the [UK’s Digital Markets, Competition and Consumers Bill](https://publications.parliament.uk/pa/bills/cbill/58-04/0003/230003.pdf).
+
+In particular, it prohibits Apple’s ban of third party browser engines on iOS, which is an [effective ban on browsers like Firefox, Chrome, Edge, Opera, Brave & Vivaldi](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Apple bans these browser vendors from choosing and modifying their own engines, and instead forces them to use Apple’s browser engine which they can’t modify and have no control over. This then ensures that there is no effective browser competition on iOS and deprives Web Apps of the functionality they need to compete with native apps. 
+
+This is the second jurisdiction (after the EU in the [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)) to explicitly codify this into law.
+
+> Article 1: In light of the role that smartphones play in Japan as the foundation of people's lives and economic activity, this Act aims to promote fair and free competition in the field of specific software by providing prohibitions on businesses that provide specific software that is particularly necessary for smartphone use from exploiting their position as businesses that provide specific software to give the products or services they provide a competitive advantage and from causing disadvantage to the business activities of businesses that use specific software, thereby contributing to the improvement of people's lives and the sound development of the national economy.
+> <cite>[Bill on the Promotion of Competition for Specified Software Used in Smartphones
+](https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/houan/g21309062.htm)</br>
+(machine translated)</cite>
+
+> The EU has pioneered new regulations in this field, and in order for the digital markets of the EU, US, and Japan to work in lockstep to set fair competition practices for platform operators, a new legal framework is also needed in the Japanese market to confront digital platform operators.
+> <cite>[Japan Fair Trade Commision
+](https://www.jftc.go.jp/file/240612EN3.pdf)</cite>
+
+This bill was based on the [Japan's Head Quarters for Digital Competition's Final Report](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_230616.pdf) which OWA consulted on. You can [read our paper here](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf).
+
+The bill aims to promote fair and free competition on smartphones by preventing large tech companies from abusing their position as providers of platforms to block or advantage their own services.
+
+Violators will face fines equivalent to 20% of the domestic revenue of the service that violated the law. The rate of the fine can be increased to 30% for repeated violations.
+
+The final bill contains a number of interesting articles relevant to browsers and Web Apps:
+* Banning browser engines is prohibited.
+* Must share APIs and services of the operating system to the same level as the services used by the designated providers. Justifiable measures may be applied.
+* Designated providers shall make it easy to change the default settings of the operating system.
+* Designated providers shall provide a choice screen for browsers.
+* When a designated business operator sets or changes the specifications, sets or changes the conditions for use, it must take necessary measures, such as securing a period for the business operator specified in each item to smoothly respond to the measure, disclosing information, and establishing a necessary system, as specified by the Fair Trade Commission rules.
+
+This law will go into effect at a date chosen by the government at least 1.5 years from signing. This would put the earliest date of being in force as December 12, 2025.
+
+This is an important step to restoring browser competition to iOS and enabling Web Apps to succeed on mobile as the world's only truly interoperable app development platform. Each jurisdiction that enforces rules to enable browsers and Web Apps to compete fairly is an important step on the road to a global solution. Apple has taken some [rather extreme measures](https://www.theregister.com/2024/05/17/apple_browser_eu/) [to geo-fence](https://support.apple.com/en-us/118110#:~:text=If%20you%20leave%20the%20European,apps%20from%20alternative%20app%20marketplaces.) [and undermine](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/) the Digital Markets Act in the EU but as the number of jurisdictions grow, the benefits to consumers and business become clear and the scare tactics are shown to be groundless, the harder it will be to maintain and justify such tactics.
+
+Next up, [the UK](https://open-web-advocacy.org/blog/uk-passes-dmcc/), [the USA](https://open-web-advocacy.org/blog/us-doj-files-apple-antitrust-case/) [and Australia](https://open-web-advocacy.org/blog/new-digital-competition-laws-for-australia/)…
+
+</br>
+
+**This victory wouldn't have been possible without your unwavering support**. While we celebrate this important step, let's remember the fight for global browser competition continues. Stay tuned, and let's work together to ensure browser choice for all users, everywhere!
+
+**Your browser, your choice!**
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/our-response-cma-interim-report.md
+++ b/src/ja/posts/our-response-cma-interim-report.md
@@ -1,0 +1,593 @@
+---
+title: OWA response to the CMA interim report
+date: '2022-03-08'
+tags:
+  - Policy
+  - Updates
+  - UK
+author: Alex Moore
+permalink: /ja/blog/our-response-cma-interim-report/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The CMA invited responses to its [interim report](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study).
+You can read our [response with suggested browser and web-app remedies (PDF)](/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf).
+
+<a href="/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf" class="action-button">Download response</a>
+
+<!--
+1. Table of Contents
+2. Introduction
+   2.1. Interim Report Remedies
+3. Effective Competition?
+4. Remedies
+   4.1. Require equivalent API access for rival browsers
+       4.1.1. iOS
+       4.1.2. Android
+       4.1.3. Effectiveness of Remedy
+   4.2. Require Safari/Webkit to support key Web App Features
+   4.3. Require iOS to Allow Third Party Browser Engines
+   4.4. Require Broad Web App Support
+5. Security and Privacy
+6. International Outreach
+7. Summary
+8. References
+9. Open Web Advocacy-->
+
+
+## 2. Introduction
+We agree overwhelmingly with the findings of fact and, with comments, agree that the
+proposed interventions contained within the CMA’s December 14th, 2021 “[Mobile ecosystems
+market study interim report](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)”
+are both warranted and timely.
+
+
+iOS Safari faces no effective competition as Apple has not provided access to private APIs that
+competing browsers need and has banned competing engines. The CMA have highlighted the
+second aspect (labelling it "the Webkit Restriction") accurately and extensively in their report
+and [write](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction):
+
+
+> &ldquo;As a result of the WebKit restriction, there is no competition in browser engines on iOS
+> and Apple effectively dictates the features that browsers on iOS can offer (to the extent
+> that they are governed by the browser engine as opposed to by the UI).&rdquo;
+
+> &ldquo;Importantly, due to the WebKit restriction, Apple makes decisions on whether to support
+> features not only for its own browser, but for all browsers on iOS. This not only restricts
+> competition (as it materially limits the potential for rival browsers to differentiate
+> themselves from Safari on factors such as speed and functionality) but also limits the
+> capability of all browsers on iOS devices, depriving iOS users of useful innovations they
+> might otherwise benefit from.&rdquo;
+
+
+They also note that Apple has [two perverse incentives](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Potential%20strategic%20reasons%20for%20Apple%E2%80%99s%20WebKit%20restriction) to hold back Webkit and to hinder Web
+Apps ability to compete with the iOS App Store:
+
+
+> &ldquo;First, Apple receives significant revenue from Google by setting Google Search as the
+> default search engine on Safari, and therefore benefits financially from high usage of
+> Safari. Safari has a strong advantage on iOS over other browsers because it is
+> pre-installed and set as the default browser. The WebKit restriction may help to entrench
+> this position by limiting the scope for other browsers on iOS to differentiate themselves
+> from Safari (for example being less able to accelerate the speed of page loading and not
+> being able to display videos in formats not supported by WebKit). As a result, it is less
+> likely that users will choose other browsers over Safari, which in turn secures Apple’s
+> revenues from Google.&rdquo;
+
+> &ldquo;Second, and as discussed in Competition in the distribution of native apps, Apple
+> generates revenue through its App Store, both by charging developers for access to the
+> App Store and by taking a commission for payments made via Apple IAP. Apple therefore
+> benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use
+> the WebKit browser engine, Apple is able to exert control over the maximum functionality
+> of all browsers on iOS and, as a consequence, hold up the development and use of web
+> apps. This limits the competitive constraint that web apps pose on native apps, which in
+> turn protects and benefits Apple’s App Store revenues.&rdquo;
+
+Apple’s incentives and behaviour bear additional scrutiny.
+
+Apple receives [$15 billion USD a year](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/) from their Google Search engine deal, representing 9% of
+Apple’s 2019 gross profit. Apple has not published the annual budget for Safari/Webkit but
+based on [anecdotal evidence](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug#:~:text=whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition) it is likely significantly less than 2% of this sum.
+
+Apple collected [$72.3 billion USD in App Store fees](https://appleinsider.com/articles/21/01/05/app-store-earns-723-billion-in-2020-almost-double-google-play-revenues)
+in 2020. While it has not published the
+costs of App Store review, payment processing, refund handling etc, it has been estimated that
+the iOS App Store has a nearly [80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506).
+Industries with healthy competition feature
+leading firms with profit margins between [5 and 20 percent](https://www.brex.com/blog/what-is-a-good-profit-margin).
+This imbalance strongly implies
+that Apple’s removal of functional competition in the App Store and beyond have broken the
+mobile phone market for software and services for more than half of the UK’s consumers.
+
+If Safari/Webkit had competition on iOS, Apple would have great incentive to retain users on
+their browser by making a better, more functional browser. A competitive web ecosystem may
+also put pressure on rent extracting behaviour without sacrificing user safety as browser
+makers compete aggressively on security, privacy, and user-empowering features such as
+extensions. If Web Apps are competitive with Native Apps, without sacrificing safety,
+system-default app stores may become less important to both users and software makers.
+
+Our primary submission **“[Bringing Competition to Walled Gardens](https://open-web-advocacy.org/walled-gardens-report/)”**
+outlines our arguments in detail.
+
+### 2.1. Interim Report Remedies
+
+The interim report proposes [three potential remedies](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Remedies%20designed%20to%20enhance%20functionality%20and%20interoperability%20of%20browsers):
+
+1.   Require equivalent API access for rival browsers
+
+2. Require that iOS and the version of Webkit provided by iOS support specific features
+  required by Web Apps
+
+3. Require that iOS allows third party browser engines
+
+We believe and argue below that while Remedy 2 (Requiring Webkit Features) may provide
+some value in the short term, in the long term it will ultimately be unworkable as a replacement
+for Remedy 1 (Equivalent API) and Remedy 3 (Third Party Engines), and only both Remedy 1
+(Equivalent API) and Remedy 3 (Third Party Engines) will restore competition between
+browsers on iOS and between Web Apps and Native Apps on iOS.
+
+We also propose a 4th Remedy “Require Broad Web App Support” which has specific technical
+aspects not covered by Remedy 1 (Equivalent API) and Remedy 2 (Requiring Webkit Features).
+
+In addition we believe that Remedy 1 (Equivalent API) needs to be significantly strengthened to
+prevent gaming by Apple.
+
+## 3. Effective Competition?
+
+> &ldquo;Businesses that face effective competition dare not raise prices, or cut down on quality
+> standards, for fear of losing customers to their competitors (and so losing money)&rdquo;
+>
+> &mdash; [Dr Michael Grenfell](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+> &ldquo;For the foreseeable future, iOS will be the dominant access pathway, passport,
+> monetizer and platform for not just digital life, but virtual ones. Apple holds this role
+> because it makes best-in-class hardware, offers the best apps, and operates the most
+> lucrative app store.&rdquo;
+>
+> &mdash; [Matthew Ball - Venture Capitalist, Writer](https://www.matthewball.vc/all/applemetaverse)
+
+iOS Safari faces no effective competition as Apple has banned competing engines. These
+engines, in turn, differentiate other browsers. Without substantive competition in browsers,
+consumers have little recourse short of buying another phone. Businesses and developers,
+meanwhile, are forced to consider the Web as an uncompetitive environment in which to launch
+services, as Apple’s neglect has ensured that for more than half of UK users, browsers cannot
+be a reasonable replacement for Apple’s proprietary App Store and APIs.
+
+The development, maintenance and lost opportunity costs of supporting a buggy browser that
+misses key features are mostly hidden from end users. It is hard for consumers to see a missing
+feature or an entire Web App that didn’t get built (due to poor support in iOS Safari). When they
+do encounter a bug caused by Safari they are more likely to blame the Web App than the
+browser. The user may get the impression that the Web is buggy, slow and that Native Apps
+are better, which then has negative flow on effects for the entire web ecosystem.
+
+Businesses have little recourse as they can not suggest their customers install another real
+browser (there are none) and they are unwilling to lose more than half their mobile customers
+(51% in the UK, 66% in Japan, 56% in Australia, 46% in the US). Additionally iOS users tend to
+be wealthier and [spend more](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+making them a higher priority for companies. In the end the
+majority of large businesses simply throw in the towel and make an iOS Native App and in doing
+so agree to pay Apple 15-30% of their revenue.
+
+As such, Apple faces little effective competitive pressure to improve the quality of their iOS
+Safari browser and has incentives to inhibit it from competing with native. Thus Apple’s decade
+long prohibition on competition for Safari on iOS has a compounding anti-competitive effect as
+companies sink money into non-interoperable native iOS applications instead of Web Apps.
+
+Even Apple executives appear to be aware only their stranglehold on iOS installation is allowing
+their 30% tax on revenue, something they can not achieve on Mac OS.
+
+> &ldquo;Neither is on the store because they don't have to be. They can be on Mac and
+> distribute to users without sharing the revenue with us.&rdquo;
+>
+> &mdash; Philip Schiller - Apple Upper Management - [On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+## 4. Remedies
+
+### 4.1. Require equivalent API access for rival browsers
+
+We believe that Third Party Apps access to operating system APIs and features should be, at a
+minimum, equivalent to the access provided to Apps and functions provided by the Gatekeeper
+or its business partners. Currently on iOS and Android there exist features that are exclusive to
+the browsers owned by the gatekeeper of the operating system.
+
+#### 4.1.1. iOS
+
+Apple's hobbling of third party browsers doesn't stop at mandating a specific version of
+Webkit, Apple provides Safari significant unfair advantages.
+
+The major issues include:
+
+   1.   **Full Screen**
+
+        iOS Safari allows video elements to become full screen, but frustratingly, not other
+        element types. This hobbles many gaming scenarios on the Web. The HTML5 canvas
+        element is essential for games (where Apple derives the lion’s share of App Store
+        revenue) which cannot be made full screen.
+
+        Competing browsers, based on other engines, have long pro**vided reasonable behaviour
+        in this regard, including on Android.
+
+   2. **No Web Apps**
+
+        Only Safari is allowed to install Web Apps to the iOS home screen via private APIs that
+        are not available to competing browsers, even if they are set as the user’s default.
+        Should competing engines become available for iOS browsers, it’s essential that
+        expansion of Web App installation also allow those competing engines to “back” the
+        Apps they install so that developers do not experience Web Apps as being held back by
+        Apple’s trailing-edge engine technology.
+
+   3. **Extensions**
+
+        Only Safari can use extensions which are used by many users, including to block ads
+        and improve privacy.
+
+   4. **Apple Pay**
+
+        Apple forces competing browsers to provide only Apple Pay as a payment mechanism
+        for use within the Web Payments API. This is blatantly anti-competitive.
+
+  5. **In-App Browsers**
+
+       Regardless of the user’s default browser setting, iOS developers that invoke the
+       SFSafariViewController tool for creating Remote Tab-based In-App Browsers are always
+       forced to invoke Safari, rather than a user’s default browser (
+       <em>Please see our other submission regarding In-App Browsers and how they negatively affect
+      browser competition</em>).
+
+#### 4.1.2. Android
+
+While Android browsers other than Chrome can install PWAs, Google has [not yet provided
+access to the latest mechanism](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583).
+This can lead to bugs, and far poorer operating system
+integration and user experience. This remedy would compel Google to fix this and we support
+the CMA’s proposal in this regard.
+
+#### 4.1.3. Effectiveness of Remedy
+Consider a fictional scenario where Apple removed the ability to install Web Apps via Safari.
+
+Under the proposed language identifying this remedy, Apple would no longer need to provide
+this functionality to other rival browsers. This is an extreme example as it would immediately
+draw the ire of regulators, but it highlights how Apple can (more subtly) hinder the
+development of all browsers on iOS by removing or not adding certain iOS integrations via
+Safari and then use regulatory conformance as a shield, contra the spirit of the law. Protecting
+App Store profits from Web Apps requires nothing more than keeping the Web at bay. A safe,
+user-respecting platform that mobile Operating System platform vendors cannot collect rents
+from is a transparent threat to their oligopoly interests.
+
+The CMA should prepare for subtle, underhanded behaviour from Apple.
+
+With this in mind, we believe this remedy needs to be strengthened to overcome this sort of
+gaming. One alternative might be to require Gatekeepers provide browser vendors access to
+**all functionality** available to **any** App or function provided by the Gatekeeper or their business
+partners (subject to very narrow, and heavily justified privacy/security concerns with
+consideration given to the level of unmitigatable risk vs the loss of useful functionality for end
+users).
+
+An example of this is iOS Safari does not technically require access to Bluetooth, as they do not
+intend to provide Web Bluetooth (but many other Apps on iOS do). Under the existing remedy
+Apple would not be required to grant rival browsers access to the iOS Bluetooth APIs if Apple
+chose to not provide it to iOS Safari. Thus Apple could limit the functionality of rival browsers
+by not providing access to particular iOS system features to iOS Safari.
+
+Finally there exist Web App specific features that no App currently has on iOS, that would not
+be effectively covered by this remedy. As such we have proposed a 4th remedy to cover these
+narrow cases.
+
+This is a useful remedy and will improve browser competition. That said, we do not believe it is
+sufficient individually to enable effective competition, as without the other remedies such as
+allowing third party engines the same perverse incentives to either underinvest or withhold key
+features from Webkit (the version provided with iOS) persist.
+
+### 4.2. Require Safari/Webkit to support key Web App Features
+
+Web Standards evolve quickly, spurred on by competing browser makers working with
+developers. This involves collaboration in standards bodies to improve compatibility, however if
+each Browser vendor had to wait until there was complete agreement between every vendor
+for each of the various standards (and each standards body operates differently), it would be
+possible for a single vendor (e.g. Apple) to game these processes to halt progress, especially in
+areas where they have an interest in preserving the proprietary nature of their own solutions.
+
+Typically, cutting edge features are deployed by browser makers' own engines first. Real world
+feedback from developers (typically over several years) informs eventual standardisation. No
+feature starts out as a web standard.
+
+> “Web Standards are voluntary. The force that most powerfully compels their adoption is
+> competition, rather than regulation. This is an inherent property of modern browsers.
+> Vendors participate in standards processes not because they need anyone else to tell
+> them what to do, and not because they are somehow subject to the dictates of
+> standards bodies, but rather to learn from developers and find agreement with
+> competitors in a problem space where compatibility returns outsized gains.”
+>
+> &mdash; Alex Russell - Program Manager on Microsoft Edge &ndash; [Why Browser Security UI Isn't Specified](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+No one can predict what web technologies will be important in the future, and disagreements
+between browser makers on the exact path forward are reasonable and expected. It is very
+difficult, if not impossible for regulators to predict which standards will be the most important
+and what their exact definition will end up being. It's a subtle and complex topic.
+
+The [perverse incentives for Apple](http://localhost:8080/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf#h.450o3cyx9zpm)
+are not removed by this remedy and consumers have no
+recourse should Apple choose not to include a feature in Webkit (the version provided with
+iOS). If the case for adding the feature is not overwhelming then the regulator may not feel
+enabled to force them to add it.
+
+The primary issue is competition. When there is a [severe bug](https://bugs.webkit.org/show_bug.cgi?id=198277),
+there are no panicked meetings
+at Apple within the iOS Safari team about how to quickly fix the issue, because Web App
+developers are urging their users to switch to Edge, Firefox and Chrome on iOS. Developers
+know that all browsers on iOS are essentially identical, so the competitive pressure that forces
+Apple to stem users on iOS fleeing to other browsers is removed. There is no real fear of
+losing browser market share because there is almost zero risk of users changing phone brand
+over broken/missing browser features.
+
+The next issue with this measure is that it requires Apple to attempt to comply in good faith.
+Recently, Dutch regulators mandated that Apple must allow dating app providers in the
+Netherlands to [use alternative payment methods](https://www.reuters.com/technology/dutch-watchdog-fines-apple-5-mln-euros-failure-comply-app-store-2022-01-24/).
+
+Apple's response shows [utter contempt](https://world.hey.com/dhh/apple-turns-the-legislative-contempt-up-to-11-7c65eeec)
+for the regulator and at every step appears designed
+to undermine the regulator's ruling with the aim of making it all but impossible (and pointless)
+for developers to use alternative payment methods. Apple's [documentation](https://developer.apple.com/support/storekit-external-entitlement/)
+is really quite
+incredible in the degree and brazen way they seek to avoid complying with the regulator. It is
+clear that regulators must operate under the assumption that Apple will act in bad faith and
+plan their regulatory regimes accordingly.
+
+Mandating Web App features is complex and subtle. Apple will have plenty of ambiguity to hide
+behind in undermining, slow rolling and crippling key Web App features. Additionally, it's very
+hard to regulate that software must be stable and not have bugs. All Browser Engines have
+bugs, it is competition that is the force that compels fixing them.
+
+Thus while there may be significant benefit from compelling Apple to add the clearest and most
+needed Web App features in the short term, **we believe that this remedy will be unworkable in
+the long term** given these adversarial dynamics.
+
+Rather than mandating Gatekeepers support particular standards, a better approach is to
+regulate such that effective competition is possible without direct intervention of regulators
+regarding every single proposed API. Policies that create a space for browser vendors to
+compete and deliver features enhances competition **both between rival browsers** and
+**between Web Apps and Native Apps**. Such a regime is possible – it is the status quo in every
+other popular operating system, including Apple’s macOS – and most effectively harnesses the
+spirit of competition to respond to both user and developer needs.
+
+### 4.3. Require iOS to Allow Third Party Browser Engines
+
+We strongly support the CMA’s findings of fact and proposed remedies in this area. This is the
+most vital proposed remedy to enable unlocking truly competitive browsers.
+
+Apple enjoys iron control over what features make it into Webkit, the specific version of Webkit
+provided by iOS, and the feature set of iOS Safari. Without allowing third party browsers
+engines it is not possible (or excessively difficult) for third parties to provide these features to
+consumers.
+
+Currently if Apple wishes to block a feature from appearing on iOS Safari they do not need to
+fear that their users will switch to another browser, as the other browsers on iOS will also be
+missing this feature (as they are required to use a specific version of Webkit).
+
+If both remedy 1 and 3 were applied, that is browser vendors can supply browsers with their
+own engines on iOS and be provided all the same system APIs that Safari and iOS are provided,
+then competition would be restored.
+
+Were Apple to choose not to add a particular feature to their browser, then other companies
+would have the option of adding that feature (or their version of that feature) to their browser.
+Users could be alerted by websites and Web Apps that a particular required feature was
+missing in iOS Safari and that they could switch to one of the other browsers.
+
+This is important in four ways:
+
+1. Browsers would be free to experiment on what the correct new Web Standard should
+   be
+
+2. Users would have recourse to switch to another browser (if iOS Safari was missing key
+   features)
+
+3. If these features were truly useful/popular, Apple would now have an incentive to
+   implement them on its own browser (even if these features enabled Web Apps to
+   compete more effectively with the App Store) or risk losing browser share on iOS
+
+4. Additionally, Apple would now have a powerful incentive to properly fund their browser
+
+Thus, the perverse incentives highlighted earlier completely evaporate and the regulator is not
+put in the difficult position of having to write and enforce Web Standard Specifications.
+
+### 4.4. Require Broad Web App Support
+
+We are grateful to the CMA’s attention to the state of Web Apps on iOS vs. competing OSes.
+
+We believe gatekeepers must provide sufficient functionality, integration and APIs to enable
+browser vendors (where possible) to provide Web Apps feature parity with Native Apps. For the
+most part the changes required to allow this are not significant relative to the **competitive
+benefits this will unlock (outlined in detail within “[Bringing Competition to Walled Gardens](https://open-web-advocacy.org/walled-gardens-report/)”)**.
+
+We propose this be a **fourth remedy** that the CMA considers in combination with the other
+remedies.
+
+To ensure long-term parity between Apple’s proprietary APIs and competition potentially
+provided by Web Apps and competing browsers, it’s important that controlling regulations
+create an expectation that Web Apps will not be restricted from integrating deeply into OSes,
+even if that means exposing currently private APIs to Browsers.
+
+For example:
+
+- In general, Web Apps should act like Native Apps from the users perspective once installed
+- iOS Permissions for Web Apps should not be harder to manage than those of Native Apps
+- Integration into OS-level management surfaces should be required
+- Web Apps should not face hurdles to accessing sufficient system resources to enable
+important applications (e.g., storage space and durability)
+- Integration with system-provided services (application backup/sync, AI assistant
+ services, etc.) should be possible for both third-party browsers and Web Apps
+
+Additionally we believe that there are significant competitive benefits from compelling Apple to
+allow Web Apps to be directly listed on the iOS App Store.
+
+Currently iOS Apps on the iOS App Store must be written in programming languages specific to
+Apple. This acts as a form of lock-in by requiring that developers write their Apps multiple
+times. Proper Web App support would allow developers to bypass the iOS App Store, but some
+(particularly larger developers) may see value in the listing there.
+
+This will increase competition and benefit users:
+
+- These Apps will be interoperable across operating systems (with a single code base)
+- Developers could advertise to users via the App Store or avoid the App Store entirely,
+gather their own users via the Web or **both** at the same time.
+- Browser environments and its APIs are significantly more locked down and sandboxed
+than Native equivalents. Users could benefit from this improved security.
+
+## 5. Security and Privacy
+
+It’s important to note here that we are not lawyers and anything in this section is merely to
+provide ideas to solve potential technical problems with enforcement.
+
+All of the measures could be balanced by a security and privacy provision, perhaps similar to
+the one found in the proposed [Open App Markets Act](https://www.congress.gov/bill/117th-congress/senate-bill/2710/text):
+
+<ol class="alpha">
+  <li>**In General** &mdash;Subject to section (b), a Covered Company shall not be in violation of a
+subsection of section 3 for an action that is&mdash;
+  <ol>
+    <li>necessary to achieve user privacy, security, or digital safety;</li>
+    <li>taken to prevent spam or fraud; or</li>
+    <li>taken to prevent a violation of, or comply with, Federal or State law.</li>
+    </ol>
+  </li>
+  <li>**Requirements** &mdash;Section (a) shall only apply if the Covered Company establishes by
+clear and convincing evidence that the action described is&mdash;
+  <ol>
+    <li>applied on a demonstrably consistent basis to Apps of the Covered Company or its
+business partners and to other Apps;</li>
+    <li>not used as a pretext to exclude, or impose unnecessary or discriminatory terms
+on, third-party Apps, In-App Payment Systems, or App Stores; and</li>
+    <li>narrowly tailored and could not be achieved through a less discriminatory and
+technically possible means.</li>
+  </ol></li>
+</ol>
+
+One important feature of this is, that it allows gatekeepers to take necessary steps to protect
+the security/privacy of their users while requiring them to **prove with convincing evidence** that
+the measures are consistent, narrow and non-malicious in intent.
+
+It may be useful to add Web Apps to the list in 2 b).
+
+Additionally we believe it is important that the Gatekeeper must prove with clear and
+convincing evidence that the **benefits to users** of any privacy or security measure outweigh
+the costs to users of the measure. This is to preclude **very fringe but non-zero security
+issues** being used to block users from useful functionality.
+
+Finally we would like to see provisions that **ban any secret measures** and allow companies to
+compel the gatekeeper to **provide detailed technical answers** to reasonable questions related
+to these measures.
+
+## 6. International Outreach
+
+The issues that affect competition in the UK within mobile ecosystems are the same issues
+globally. If a UK company wishes to sell their product internationally, which most do, then
+these remedies have to be global remedies.
+
+We believe it is **essential** that the CMA work together with other regulatory and legislative
+bodies so that these remedies become global and not only applied to the UK. As part of the
+market study and the work of the Digital Markets Unit, close collaboration with other regulators
+should be considered a high priority.
+
+That said, there are still some benefits from the UK leading the way in this regulation as it will
+provide data and leverage to regulators in other countries, who can point to the UKs successes
+and use them as a blueprint for their own regulations. Additionally even in the complete
+absence of global support for such regulations UK customers will still benefit significantly.
+
+## 7. Summary
+
+We are heartened by the depth of research and thoughtfulness embodied in the CMA’s interim
+report. We concur with the findings of fact and strongly support many of the proposed
+remedies.
+
+To recap, we believe that the following remedies are necessary:
+
+   1. Gatekeepers must provide browser vendors access to all functionality available to any
+      App or function provided by the Gatekeeper or their business partners.
+   2. iOS must allow third party browser engines
+   3. Mobile OSes must provide broad and deep Web App support
+
+While we feel there may be some significant short term benefit by requiring Webkit and iOS
+Safari support particular Web App features, we believe that in the long term this will be
+unworkable. True, meaningful competition is the only long-term and durable fix.
+
+All of the measures could be balanced by a [security and privacy provision](http://localhost:8080/files/OWA%20-%20Response%20to%20Mobile%20Ecosystem%20Interim%20Report%20-%20v1.1.pdf#h.jvpdxnx9j3v2).
+
+The above measures combined will restore competition between browsers on iOS and between
+Web Apps and Native Apps on iOS.
+
+This has a number of benefits to consumers including:
+
+- Cost savings (in the billions annually)
+- Higher quality software
+- More private and secure software
+- Greater control by end users
+- Greater interoperability with devices from other manufacturers
+
+A ban on third-party browsers benefits Apple and harms users, developers and businesses.
+
+**Competition not walled gardens leads to the best outcomes.**
+
+## 8. References
+
+- CMA - [Impact of the Webkit Restriction](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction)
+
+- CMA - [Possible incentives for the Webkit Restriction](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Potential%20strategic%20reasons%20for%20Apple%E2%80%99s%20WebKit%20restriction)
+
+- Forbes - [iOS Google Search deal worth $15 Billion](https://www.forbes.com/sites/johanmoreno/2021/08/27/google-estimated-to-be-paying-15-billion-to-remain-default-search-engine-on-safari/)
+
+- The Register - [Is Safari underfunded?](https://www.theregister.com/2021/06/16/apple_safari_indexeddb_bug#:~:text=whether%20its%20Safari%20team%20is%20understaffed%20compared%20to%20the%20competition)
+
+- Apple Insider - [$72.3 billion USD in App Store fees in 2020](https://appleinsider.com/articles/21/01/05/app-store-earns-723-billion-in-2020-almost-double-google-play-revenues)
+
+- [iOS App Store is estimated to have an 80% profit margin](https://www.marketwatch.com/story/how-profitable-is-apples-app-store-even-a-landmark-antitrust-trial-couldnt-tell-us-11622224506)
+
+- [5-20% profit margin is normal for successful companies](https://www.brex.com/blog/what-is-a-good-profit-margin)
+
+- CMA - [Potential Remedies to enhance functionality and interoperability of browsers](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Remedies%20designed%20to%20enhance%20functionality%20and%20interoperability%20of%20browsers)
+
+- Dr Michael Grenfell - [On Effective Competition](https://www.gov.uk/government/speeches/michael-grenfell-should-competition-authorities-intervene-in-digital-markets)
+
+- Matthew Ball - Venture Capitalist, Writer -[On the dominance of iOS](https://www.matthewball.vc/all/applemetaverse)
+
+- [iPhone Users spend more than Android Users](https://www.entrepreneurshiplife.com/why-iphone-users-spend-more-money-than-android-users/)
+
+- Philip Schiller - Apple Upper Management - [On the Mac App Store](https://applescoop.org/story/apple-execs-discuss-why-the-mac-app-store-has-not-been-successful-in-internal-email)
+
+- Google - [Missing PWA install functionality for browsers other than Chrome on Android](https://bugs.chromium.org/p/chromium/issues/detail?id=1243583)
+
+- Alex Russell - Program Manager on Microsoft Edge - [On Web Standards](https://infrequently.org/2020/07/why-ui-isnt-specified/)
+
+- [Apple must allow dating app providers in the Netherlands to use alternative payment methods](https://www.reuters.com/technology/dutch-watchdog-fines-apple-5-mln-euros-failure-comply-app-store-2022-01-24/)
+
+- [Apple's response shows utter contempt for the dutch regulator](https://world.hey.com/dhh/apple-turns-the-legislative-contempt-up-to-11-7c65eeec)
+
+- Apple - [Distributing dating apps in the Netherlands](https://developer.apple.com/support/storekit-external-entitlement/)
+
+
+## 9. Open Web Advocacy
+
+Open Web Advocacy is a loose group of software engineers from all over the world, who work
+for many different companies who have come together to fight for the future of the open web
+by providing regulators, legislators and policy makers the intricate technical details that they
+need to understand the major anti-competitive issues in our industry and potential ways to
+solve them.
+
+It should be noted that all the authors and reviewers of this document are software engineers
+and not economists, lawyers or regulatory experts. The aim is to explain the current situation,
+outline the specific problems, how this affects consumers and suggest potential regulatory
+remedies.
+
+This is a grassroots effort by software engineers as individuals and not on behalf of their
+employers or any of the browser vendors.
+
+We are available to regulators, legislators and policy makers for presentations / Q&A and we
+can provide expert technical analysis on topics in this area.
+
+For those who would like to help or join us in fighting for a free and open future for the web,
+please contact us at:
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/owa-2023-review.md
+++ b/src/ja/posts/owa-2023-review.md
@@ -1,0 +1,179 @@
+---
+title: Open Web Advocacy 2023 in Review
+date: '2023-12-31'
+tags:
+  - Policy
+  - Updates
+author:
+  - Alex Moore
+permalink: /ja/blog/owa-2023-review/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+{% image
+  "/images/blog/owa-2023-review.webp",
+  "Let’s ring in the new year with a review of everything OWA achieved in 2023. The whole team would like to thank our kind volunteers and donors. We couldn’t do it without you! Happy New Year! Open-Web-Advocacy.org"
+%}
+
+We’re living through a moment of real potential for change. For over a decade the Web has been prevented from fairly competing. That’s changing, and we’re working without fear or favor to direct change toward a safe, open future for computing and a better Web for all.
+
+Competition is the engine of progress and OWA is working hard to spread the word on anti-competitive practices holding the Web back, how to fix them and the Web’s incredible potential to improve consumers' lives further.  By meeting with regulators, giving talks, writing countless technical papers and advocating online, we’re going to take the fight for a better Web to every corner of the globe.
+
+We hope you’ll [join us in 2024](/get-involved/) as we continue to convert potential into reality. Speak up and demand a web that works for everyone.
+
+It’s been an incredibly busy year, so here’s just the highlights of 2023 by region:
+
+## European Union
+
+The European Union is a key focus of ours, not only due to its economic size, but also due to its new digital competition regulation the Digital Markets Act.
+
+This act was passed into law on [November 1st 2022](https://www.europarl.europa.eu/RegData/etudes/ATAG/2022/739226/EPRS-AaG-739226-DMA-Application-timeline-FINAL.pdf). To our delight it included explicit wording prohibiting companies such as Apple from banning rival companies porting their real browsers with their own browser engines. 
+
+Specifically the following section:
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications. Gatekeepers should therefore not use their position to require their dependent business users to use any of the services provided together with, or in support of, core platform services by the gatekeeper itself as part of the provision of services or products by those business users.<br>&mdash; [Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+
+
+In addition it contains a host of clauses that will enable the Web and third parties via the Web to compete fairly on all operating systems. Specifically it has clauses that:
+
+* Browsers must be allowed to port their own engines
+* Third parties services such as browsers must be given access to operating system APIs and hardware subject to narrow scope and strictly necessary security requirements
+* Operating system and browser gatekeepers will not be able to self preference their own services in a number of ways
+
+In **March** we had the opportunity to present at the [EU’s Digital Markets Act Workshop ](https://www.youtube.com/watch?v=S6oETjUprlQ) to express our viewpoints on this new act and how it should be implemented. We also had the opportunity to meet the DMA team in person and talk through our concerns. Since then we have extensively engaged with their team seeking to aid them in effectively applying the DMA to fix anti-competitive issues related to browsers and Web Apps.
+
+On **September** 6th 2023 the [European Commission designated six gatekeepers](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) - Alphabet, Amazon, Apple, ByteDance, Meta, Microsoft under the Digital Markets Act (DMA). Under these 6 gatekeepers 22 core platform services provided by gatekeepers were designated. It is these that must comply with the rules of the DMA. These companies have 6 months to be in compliance with the act from this date.
+
+In September, Apple hilariously tried to claim with a straight face to the EU, that it offers not one, but [three distinct web browsers all coincidentally named Safari](https://www.theregister.com/2023/11/02/apple_safari_browser/).
+
+Apple made this attempt despite the Digital Markets Act containing specific clauses to address this exact behavior:
+
+> Article 13(1): An undertaking providing core platform services shall not segment, divide, subdivide, fragment or split those services through contractual, commercial, technical or any other means in order to circumvent the quantitative thresholds laid down in Article 3(2). No such practice of an undertaking shall prevent the Commission from designating it as a gatekeeper pursuant to Article 3(4).
+
+Lucky for us the team at the EC [dismissed this ludicrous gambit](https://ec.europa.eu/competition/digital_markets_act/cases/202344/DMA_100025_228.pdf) and painstakingly ripped Apple's argument to shreds. It is baffling to us why Apple's legal team is willing to sacrifice their credibility on something that has such a low chance of success.
+
+Unfortunately they [had better luck with iPadOS](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/) and were able to convince the EU that it was distinct from iOS. However, the EU has determined that iPadOS has sufficient market share and power to [warrant an investigation as to whether iPadOS should be considered a gatekeeper](https://ec.europa.eu/competition/digital_markets_act/cases/202343/DMA_100047_5136.pdf) on a standalone basis. OWA had the opportunity to respond as to why we believe that iPadOS must be designated a Gatekeeper and should not be considered separate from iOS in general.
+
+In our [own submission](https://open-web-advocacy.org/files/OWA%20-%20Response%20to%20EU%20regarding_Apple_iPadOS_-_v1.1.pdf) we argued that iPadOS is a subset of iOS and that even if it were not it, it has sufficient market power to be designated core platform service.   
+
+
+**2024 will be an exciting year in the EU for browser and Web App competition. We are engaging closely with the regulator on a range of topics including:**
+
+* Allowing third party browsers to be ported to iOS
+* Allowing browsers fair and effective access to system and hardware APIs
+* Allowing Web Apps to compete fairly and effectively with their Native App counterparts
+* Stopping companies from overriding users choice of default browser
+* Preventing unfair self-preferencing of gatekeepers browsers
+
+**March 6th 2024 is the key date by which all gatekeepers must be in compliance**, but the changes required by the act are many and there is great technical complexity that various gatekeepers can hide behind. Given that literally billions are at stake, expect fireworks and lawsuits. We will be doing our best to keep the regulator, developers and the general public informed with all the key technical details and outline a path to a future where the Web can compete fairly.
+
+## UK
+
+As readers may remember the CMA conducted a Market Study into Mobile Ecosystems.
+
+The CMA [found in their market investigation](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report/interim-report#:~:text=Impact%20of%20the%20WebKit%20restriction) that:
+
+> As a result of the WebKit restriction, there is no competition in browser engines on iOS and Apple effectively dictates the features that browsers on iOS can offer (to the extent that they are governed by the browser engine as opposed to by the UI).
+
+> Importantly, due to the WebKit restriction, Apple makes decisions on whether to support features not only for its own browser, but for all browsers on iOS. This not only restricts competition (as it materially limits the potential for rival browsers to differentiate themselves from Safari on factors such as speed and functionality) but also limits the capability of all browsers on iOS devices, depriving iOS users of useful innovations they might otherwise benefit from.
+
+Based on the findings of their Market Study in which OWA heavily consulted, the CMA decided to launch a Market Investigation Reference into Browser and Cloud Gaming.
+
+In their [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) they listed the following potential remedies:
+
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services.
+
+In **April** 2023 Apple [won a judgment against the government](https://theplatformlaw.blog/2022/11/28/the-cmas-investigation-of-competition-restrictions-regarding-browsers/) in the [Competition Appeal Tribunal](https://www.catribunal.org.uk/), halting an [already delayed Market Investigation Reference that included examination of Apple’s iOS browser policies](https://theplatformlaw.blog/2022/11/28/the-cmas-investigation-of-competition-restrictions-regarding-browsers/). 
+
+
+The decision was both unexpected and [disappointing](https://mastodon.social/@owa/110120581945462519). Apple hadn’t argued that its policies were fair, or that the Competition and Markets Authority (CMA) was wrong in its findings. Rather, Apple argued that the CMA hadn’t regulated fast enough after [finding in June 2022](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study) that Apple and Google’s App Store and browser policies harmed UK businesses and consumers.
+
+
+This judgment put progress on real browser choice in the UK on hold for an indeterminate amount of time. The only remaining hope was an appeal through the courts that could take months or years, or that the long-proposed [Digital Markets, Competition and Consumers Bill](https://bills.parliament.uk/bills/3453) (DMCC) might make progress through Parliament without being gutted by lobbyists. 
+
+The DMCC would give the CMA’s successor statutory authority to regulate more quickly. Even if that came to pass, at least a year of delay would have been won by Apple, as the CMA’s Market Investigation was the (slow) “fast path”. Our hopes were not high.
+
+After months of radio silence, *good news arrived from the UK on two fronts*.
+
+First, the [the DMCC Bill](https://theplatformlaw.blog/2023/11/17/digital-markets-competition-and-consumers-bill/) was [passed through the House of Commons](https://bills.parliament.uk/bills/3453/stages) without fatal changes, and now looks set to become law in early 2024.
+
+Then, at the end of the month, we learned that the CMA’s appeal to overturn the April judgment [had succeeded](/blog/apple-loses-on-appeal/), with the caveat that Apple could still appeal the loss to the UK’s Supreme Court. The findings from the Court of Appeal were nothing short of excoriating, with the Court rebuking the Competition Appeal Tribunal for [having lost sight of the law’s goals to protect businesses and consumers.](https://caselaw.nationalarchives.gov.uk/ewca/civ/2023/1445)
+
+
+In **December**, [Apple declined to appeal the November finding by the three week deadline,](/blog/cma-reopens-investigation-into-apple/) ensuring that the CMA’s Market Investigation will restart in January from where it was frozen in April.
+
+**Meanwhile**, the DMCC Bill has [progressed in the House of Lords without incident](https://bills.parliament.uk/bills/3453/stages), setting the stage for a beefed up UK digital regulator in 2024 with expanded powers to intervene in unfair browser competition.
+
+
+## Japan
+
+In **April 2022**, the Headquarters for Digital Market Competition published [a report](https://www.kantei.go.jp/jp/singi/digitalmarket/pdf_e/documents_22220601.pdf) where they recommend reversing Apple’s ban on rival browser engines and allowing third party browser vendors to port their real browsers to iOS. OWA heavily consulted with the HDMC on the topic of browser and web app competition, see this report for our [detailed viewpoints](https://open-web-advocacy.org/files/OWA%20-%20HDMC%20(Japan)%20-%20Competition%20in%20the%20Mobile%20App%20Ecosystem%20-%20v1.1.pdf).
+
+
+Then in **February 2023**, the Japan Fair Trade Commission (JFTC) published [an exhaustive report examining the mobile app and browser ecosystem.](https://www.jftc.go.jp/en/pressreleases/yearly-2023/February/230209.html) The report summary finds that Apple and Google have an effective duopoly over the mobile market, and that (contra Apple’s claims) there’s little pressure on App Stores from Web Apps, in part, due to suppression of key features via browser engine policy and prevention of discovery of Web Apps within App Stores.
+
+And **just this week** [the Japanese government is preparing to move legislation to give the JFTC powers to directly intervene in mobile OSes](https://asia.nikkei.com/Business/Technology/Japan-to-crack-down-on-Apple-and-Google-app-store-monopolies). The new legislation will have 4 main priorities:
+
+* App Stores and Payments
+* Search
+* Browsers
+* Operating Systems
+
+OWA will continue to engage with the JFTC and the HDMC to ensure that browsers and Web Apps can compete effectively and fairly.
+
+
+## Australia
+
+**Last year** the Competition & Consumer Commission (ACCC) [published a report](https://www.accc.gov.au/inquiries-and-consultations/digital-platform-services-inquiry-2020-25/september-2022-interim-report) outlining competition issues in digital markets. OWA is heavily quoted in the report. The report contains a number of considered remedies including:
+
+> The code of conduct for mobile OS services could require Designated Digital Platforms to allow third-party browser engines to be used on their mobile OS. This could allow third-party providers of browsers and web apps to compete on their merits.
+
+> We also consider that the additional competition measures should include the ability to provide third-party providers of apps and services with reasonable and equivalent access to hardware, software and functionality through their mobile OS.
+
+In **September** we [outlined our vision for a web that can truly compete at Web Directions Summit in Sydney](https://webdirections.org/summit/speakers/alex-moore.php).
+
+We also had the opportunity to meet with the ACCC, [and brief them in person](https://mastodon.social/@owa/111304830543180059)
+
+In **December**, [promising legislative action has finally emerged](/blog/new-digital-competition-laws-for-australia/) from the ACCC’s inquiry. The laws will be based on the ACCC recommendations in their 5th report. It specifically calls for meaningful browser choice, including engine competition, which OWA believes to be critical for the health of the web.
+
+## Korea, Brazil, India
+In **July**, the Indian Parliament recommended the introduction of an ex-ante regime through a new ‘[Digital Competition Act](https://www.cnbctv18.com/technology/explained--indias-upcoming-digital-competition-act-and-what-is-the-debate-around-it-all-about-17222501.htm)’ (DCA), to ensure a fair and transparent digital ecosystem in India.
+
+In **September**, Brazil [announced Bill 2768](https://www.ipea.gov.br/cts/en/all-contents/articles/articles/381-regulation-of-markets-mediated-by-digital-platforms-in-brazil-an-open-discussion), a new law related to improving digital competition and interoperability.
+
+In **December**, the Korea Fair Trade Commission (“KFTC”) announced its proposal to enact the “Platform Competition Promotion Act” (“PCPA”) for [ex-ante regulation of platforms](https://www.lexology.com/library/detail.aspx?g=d4a4ff96-2a6a-45d1-980a-a4786e3834a2) by designating “dominant platform operators”. 
+
+
+## 2024: A Big Year for Browser Competition
+
+Even if nothing happens beyond the already locked-in statutory and process deadlines in the EU and the UK, **2024 is shaping up to be the biggest year for digital competition regulation in a generation**.
+
+On **January 22nd**, the UK’s House of Lords is set to bring the amended [Digital Markets, Competition & Consumers Bill](https://bills.parliament.uk/bills/3453/stages) to [Committee stage](https://www.parliament.uk/about/how/laws/passage-bill/lords/lrds-lords-committee-stage/), one of the final steps before the Bill becomes an Act. OWA understands the quick progress of the DMCC in recent months to indicate high potential for a competent regulator on the job with expanded powers and a mandate to act swiftly. While it will take months beyond Bill passage for the proposed Digital Markets Unit (DMU) to be stood up, OWA is excited to see both the expansion of capacity to regulate questions related to browser choice, as well as the strong support in the legislative process for redressing the market distortions of the status quo.
+
+Next, the UK’s CMA will regain its power to continue a Market Investigation into [Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) beginning **January 24th**. This restart of the mothballed investigation will once again begin the clock ticking down to intervention by the CMA using statutory powers it already has, with a possible outcome mandating true browser engine choice on iOS. Such a ruling would be a sea change, stands to bring the UK into alignment with emerging EU regulation, and will let the Web truly compete with native apps. 
+
+On **March 6th, 2024** the 6-month countdown from the [EU’s Digital Markets Act (DMA) designation decisions](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) will conclude, requiring that Apple, Alphabet/Google, Amazon, ByteDance, Meta, and Microsoft to be in compliance of the terms of the DMA.
+
+OWA anticipates that the plain language of the DMA will compel true browser choice and an end to Apple’s ban on competing browsers, along with a pile of other improvements to browser competition across Android and Windows. The penalties for non-compliance are severe, and so we remain hopeful that [rumors of browser ports from Chromium and Gecko](https://www.theregister.com/2023/02/07/mozilla_google_apple_webkit/) will become real products early next year. Where competitors aren’t able to bring their best products to designated OSes, OWA will continue to facilitate information sharing between all parties to ensure that the lines are clear and that compliance is toothsome.
+
+If nothing else were to happen in 2024, OWA’s docket would be full. Each regulator (empowered by new legislation) that opens investigations into browsers, web apps and digital competition involves hundreds of hours of preparation for briefings to highlight issues that impact consumers, competitors and web developers, and as the EU and UK move into implementation, the workload will only increase.
+
+In addition to OWA’s continued direct advocacy toward browser and OS vendors, we have remained in constant contact with regulators around the world, responding to dozens of requests for information and briefing this year alone. This behind-the-scenes work only occasionally becomes public, but it’s the in-the-weeds problem-description and guidance-giving that changes the agenda and has enabled so many regulators to emphasize the importance to consumers of effective browser and Web App competition.
+
+It’s only through the [generous support of donors and volunteers](/donate/) that we’re able to continue this work, and we hope you’ll [get involved](/get-involved/) to help us continue to shape the future of digital competition. **We would like to say a special thank you to particularly generous donations from [startsmall](https://mastodon.social/@owa/111218243374658469) and [store.app](https://store.app/).** 
+
+Together we can fix these anti-competitive issues and allow the Web to fairly compete to its full potential. 
+
+**Happy New Year from everyone at Open Web Advocacy!**
+
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/owa-eu-dma-submission-apple-ipados.md
+++ b/src/ja/posts/owa-eu-dma-submission-apple-ipados.md
@@ -1,0 +1,39 @@
+---
+title: OWA submits response to EU DMA investigation into Apple iPadOS
+date: '2023-11-21'
+tags:
+  - Policy
+  - Updates
+  - EU
+author: Frances Berriman
+permalink: /ja/blog/owa-eu-dma-submission-apple-ipados/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+As the EU further rolls out the Digital Marketing Act, they have designated a variety of companies and their platforms as “Gatekeepers”. You can see the [complete list of Gatekeepers](https://ec.europa.eu/commission/presscorner/detail/en/ip_23_4328) and some really useful explainers on what being a [Gatekeeper means on the EU’s very informative website](https://commission.europa.eu/strategy-and-policy/priorities-2019-2024/europe-fit-digital-age/digital-markets-act-ensuring-fair-and-open-digital-markets_en).
+
+Now that Gatekeepers have been designated, the companies that operate those services have had the opportunity to rebut their designations. 
+
+A particularly interesting response was from Apple, who have made the case that iPadOS is an entirely separate operating system from iOS, both of which are currently designated as platforms subject to the DMA, along with the Apple App Store. Their arguments boil down to:
+* iPadOS has some unique features
+* iPadOS has an optional secondary input (the Apple Pencil)
+* The most popular apps on iPad are different from the most popular apps on iPhone
+
+We disagree with this claim. iPadOS is a subset of the iOS ecosystem. Indeed it was called iOS up until 2019 and very little has happened since then to significantly distinguish it. Unfortunately the EU has for now accepted the argument that iPadOS is a separate OS from iOS.
+
+Further, according to statistics supplied by Apple, iPadOS has less than the 45 million users required to be automatically designated a Gatekeeper. The EU has determined that iPadOS has sufficient market share and power to [warrant an investigation as to whether iPadOS should be considered a gatekeeper on a standalone basis](https://ec.europa.eu/competition/digital_markets_act/cases/202343/DMA_100047_5136.pdf). OWA had the opportunity to respond as to why we believe that iPadOS must be designated a Gatekeeper and should not be considered separate from iOS in general.
+
+In broad strokes, OWA argued that:
+
+* Apple’s argument about the size of the EU iPad market is in dispute. [IDC](https://www.idc.com/getdoc.jsp?containerId=IDC_P36344), for example, shows the iPad market in Europe (the UK inclusive) to be about 43 million devices. This suggests the bar for arguing that iPadOS should be declared a gatekeeper by bridging the gap between actual and required quantitative threshold should not be high. Further Apple's calculations as to active users need to be scrutinised.
+
+* The distinction between iOS and iPadOS is minor, the primary difference being a number of features to take advantage of the larger screen. For most of the history of the iPad, iOS was it’s operating system, and the launch schedules and differences in feature sets have not substantially diverged [since the 2019 marketing change](https://en.wikipedia.org/wiki/IPadOS#History). 
+
+* The cross-device impacts of Apple’s wealthier customer base influence technology choices and investments far in excess of the install base. Discounting the network effects of the iOS/iPadOS App Store-based logic of software development and distribution is to focus on the trees, rather than the forest. 
+
+* The DMA contains clauses explictly designed to reject the attempts at artificial subdivision that Apple has put forward here. Further iPadOS is a critical part of the iOS ecosystem and it is essential to recognise the anticompetitive architecture of Apple’s influence over app stores, and the interlocking ways they do so across the Apple ecosystem. Allowing Apple to evade its DMA obligations for so significant segment of its ecosystem, will allow Apple great power to not only increaselock-in, reduce interoperability and hobble competition on iPad but also to curtail the effectiveness of the DMA with regards to Apple’s obligations on iPhone.
+
+Apple gates proprietary API access on iOS in exactly the same ways, and through the same terms and conditions, with the same anti-competitive restraints on browser and applications choice, on iOS as it does on the lately-rebranded iPadOS. This is a sizable entrypoint to wealthy consumers across the EU, which amplifies the effects of the restrictions.
+
+You can read both [Apple’s submission to the EU here](https://ec.europa.eu/competition/digital_markets_act/cases/202344/DMA_100025_228.pdf) (sections 74 - 94), and, of course, you can also read OWA’s [full report](/files/OWA%20-%20Response%20to%20EU%20regarding_Apple_iPadOS_-_v1.1.pdf).

--- a/src/ja/posts/owa-review-apple-dma-compliance-for-web.md
+++ b/src/ja/posts/owa-review-apple-dma-compliance-for-web.md
@@ -1,0 +1,299 @@
+---
+title: OWA’s Review of Apple’s DMA Compliance Proposal for the Web
+date: '2024-01-29'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /ja/blog/owa-review-apple-dma-compliance-for-web/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+## Will Apple ever let browsers and Web Apps compete fairly?
+
+We believe that third party browsers should be allowed to compete fairly on iOS using the same engines they safely deliver to every other platform. Further, that Web Apps enabled by the functionality, stability and security delivered via intense competition between browsers should allow developers to bypass and contest the gatekeepers App Store via the world's only truly interoperable platform, the Web.
+
+With this in mind OWA has been looking over [Apple’s proposals for compliance with the EU’s Digital Markets Act](https://developer.apple.com/support/dma-and-apps-in-the-eu/#browser-alt-eu) to determine whether Apple intends to genuinely comply with its legal obligations regarding browsers and web apps. As OWA has [argued at length](/walled-gardens-report/), true choice in browsers is the most important counterbalance to gatekeeper monopoly power, so the answer to this question matters enormously. 
+
+**Unfortunately so far it appears that the answer is "no".**
+
+Let’s dig into our three bigger point of interests:
+
+1. Will browser vendors be effectively able to bring their own engine to iOS?
+2. Will browser vendors be able to implement proper web app support on iOS?
+3. Will browser vendors be able to compete fairly with Safari?
+
+
+## Will browser vendors be effectively able to bring their own engine to iOS?
+
+As OWA anticipated, Apple is proposing a new [Web Browser Engine Entitlement](https://developer.apple.com/support/alternative-browser-engines/#web-entitlement) that allows browser apps some of the extended privileges any modern, safe browser requires. Apple also proposes requirements browser vendors must meet to be eligible. Some deal with functional aspects of web content rendering, ensuring that browser engines are minimally standards compliant. Others deal with security aspects of web browsing, and yet others impose specific constraints related (in Apple’s view) to privacy. 
+
+The security requirements are the least objectionable, and major browsers are already compliant with the [NIST guidelines for critical software supply chains.](https://www.nist.gov/itl/executive-order-improving-nations-cybersecurity/security-measures-eo-critical-software-use-2) and thus, presumably, with Apple’s looser restatements of those processes. OWA's stance is that it is reasonable (and allowed by the act) for Apple to set a minimum bar on the proviso that the rules are reasonable, proportional, and do not preclude smaller browser vendors that take security seriously from competing on iOS with their own engine.
+
+
+The DMA only grants Apple the right to _“strictly necessary and proportionate, measures to ensure that third-party software applications or software application stores do not endanger the integrity of the hardware or operating system”,_ with the burden of proof as to their necessity and proportionality resting on Apple. We concur with the intent of the act, but believe aspects such as performance and functionality should be left to competition.
+
+Apple requires that browsers secure a _“90% from Web Platform Tests”,_ but this is nonsensical, requiring immediate clarification. The [Web Platform Tests project](https://wpt.fyi/about) is a comprehensive corpus of tests for browser engines, but there is no generally accepted set out of which 90% can be measured, as each engine project enables or disables test groups based on features that are minimally implemented. An engine that implements very few features could easily maintain a 90% pass rate _of the features it provides_, while falling well short of the goal of broad standards conformance. The test corpus also changes between the desktop and mobile versions of browsers. Without clarification about which group of tests the 90% will be calculated from, developers live under a cloud of doubt. It’s also problematic that Apple’s language potentially demands pass-rate statistics that cannot be produced, as no set of WPT tests are run on iOS for any browser, using any engine (although Android browsers are tested) &mdash; including Safari. 
+
+The privacy requirements in Apple's policy give rise to deep concerns. Instead of enabling market competition to improve privacy, Apple is demanding specific technical mechanisms that its own products do not abide (e.g., “boostrap” cookies for Web App installation to the homescreen). It also creates vague, unenforceable terms about “informed user activation” that read like a blank check for Apple’s reviewers to reject browsers based on vibes, rather than analysis. Even with a very brief investigation, we found Apple [does not yet follow these guidelines](https://webkit.org/blog/8311/intelligent-tracking-prevention-2-0/#:~:text=Temporary%20Compatibility%20Fix%3A%20Automatic%20Storage%20Access%20for%20Popups). Apple’s own track record regarding many of the issues it is performatively demanding conformance with is poor, and OWA believes that much of this language needs to be trimmed and made more objective. The primary concern here is that Apple may use this rule as a tool to deny third party browsers the ability to implement important Web App functionality with the aim of keeping that functionality exclusive to Native Apps sold via their App Store.
+
+Requirements demanding alternative browsers implement specific APIs related to input are even more worrying. Apple requires specific iOS APIs to be used for features such as text input, scrolling, dragging, and contextual menus. This may seem appropriate to provide iOS users with a uniform experience, but consistency can be achieved in many ways. Indeed, most browser engines work extremely hard to integrate well into their host OSes and provide the best possible experience. Hard requirements in this area seem hard to justify given macOS Safari’s long history of private API abuse for competitive advantage.
+
+One of the aims of the act is to allow third parties such as browser vendors to provide users with more choice and higher quality software than that of the gatekeeper. Third party browsers already have their own code for performing much of this functionality (such as scrolling) built into their own browsers. Web developers [have](https://open-web-advocacy.org/walled-gardens-report/#:~:text=of%20the%20time-,Safari%20is%20always%20years%20behind%20Edge/Chrome%20and%20has%20many%20many%20many%20bugs%20related%20to%20viewheight/scroll.,-iOS%20Safari%20is) [long](https://open-web-advocacy.org/walled-gardens-report/#:~:text=Safari%20is%20always%20years%20behind%20Edge/Chrome%20and%20has%20many%20many%20many%20bugs%20related%20to%20viewheight/scroll.%20iOS%20Safari%20is%20the%20biggest%20limiting%20factor%20in%20all%20web%20development.) complained that iOS [Safari is riddled with scrolling bugs](https://github.com/web-platform-tests/interop/issues/84) for all but the simplest of use cases. Mandating that third party browsers must replace this code with Apple’s libraries when they have their own, arguably superior, libraries blunts competition and may impose significant additional work with no legal justification or user benefit.
+
+Mandating that browser vendors adopt these APIs may, perversely, hurt quality and delay release of competing browsers for months without materially improving consistency. This is particularly egregious in light of the [last-minute](https://www.europarl.europa.eu/RegData/etudes/ATAG/2022/739226/EPRS-AaG-739226-DMA-Application-timeline-FINAL.pdf)(pdf) announcement of these APIs, Apple’s attempt at limiting their use to the EU, and Cupertino’s years-long campaign of delay. The wrongs the DMA seeks to right are multiplied by time, and terms that prevent competitors from entering the market in a timely way run counter to the spirit of the law.
+
+Indeed, some of these APIs have deep implications for competing engine codebases. It is therefore likely to increase the complexity of competing engines and make further development and its maintenance harder for browser teams. When Apple [shipped Safari on non-Apple platforms](https://www.apple.com/newsroom/2007/06/11Apple-Introduces-Safari-for-Windows/), it was not subject to similar restrictions and would be highly unlikely to accept them for iOS Safari itself. Adoption of such APIs should be optional, leaving vendors free to incorporate them as they see fit, and at their own pace.
+
+## Will browser vendors be able to implement proper web app support on iOS?
+
+While some APIs have been made available (and mandatory) for browser engines to implement specific features, others are notable by their absence. 
+
+Since the first iPhone in 2007, Safari has had access to private APIs for installing and managing Web Apps, and yet this core, long-standing API is missing from Apple’s compliance proposal. Just like Safari, alternate browsers must be able to add Web Apps to the home screen, to the app library, and have them appear in the system settings so users can see and modify each individual Web App settings. They must also be able to run in the same engine as the browser that installs them &mdash; just as Safari-installed Web Apps have for 15 years. Our reading of the documentation made available thus far suggests alternate browsers will not have access to such capabilities.
+
+
+The DMA explicitly mentions browser competition (including the ability to use your own engine) as being important to prevent gatekeepers from determining the functionality available to Web Apps.
+
+
+> In particular, each browser is built on a web browser engine, which is responsible for key browser functionality such as speed, reliability and web compatibility. **When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality** and standards that will apply not only to their own web browsers, but also **to competing web browsers and, in turn, to web software applications**.
+> <cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+(emphasis added)</cite>
+
+
+The UK Competition and Markets Authority noted that Apple had incentive to prevent Web Apps from fairly competing:
+
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)
+(emphasis added)</cite>
+
+Finally, Apple states in the opening paragraph of their App Store Guidelines that the Web (i.e Web Apps) is the alternative to their App Store.
+
+> For everything else there is always the open Internet. If the App Store model and guidelines are not best for your app or business idea that’s okay, we provide Safari for a great web experience too.
+><cite>[Apple App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)</cite>
+
+
+With all of these in mind, combined with [Apple’s refusal to implement key features in iOS Safari such as install prompts](https://open-web-advocacy.org/walled-gardens-report/#ios-web-app-installation---a-well-hidden-safari-exclusive) (keeping Web Apps hidden from the public), [other missing features](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features), and [significant and crippling bugs](https://open-web-advocacy.org/walled-gardens-report/#safari-has-been-buggy-for-a-long-time), the question of whether third party browsers could offer Web Apps something better becomes critical. As it stands there is nothing in Apple’s proposal to suggest that they ever intend to let third party browsers install Web Apps powered by their own engine.
+
+Alternate browsers should also be able to handle Push Notifications for Web Apps, as well as badging when they are installed. There is no mention of APIs allowing the implementation of such features in Apple’s documentation.
+
+Web Apps should also be allowed to open when the user taps a link to a URL related to it anywhere on the OS. This is a pattern that Apple calls “universal links”, and according to the documentation, browsers cannot implement an equivalent for Web Apps: _[“Apps that have the com.apple.developer.web-browser managed entitlement may not claim to respond to Universal Links for specific domains.”](https://developer.apple.com/documentation/xcode/preparing-your-app-to-be-the-default-browser#Adhere-to-browser-restrictions)_ [Specifications for enabling this](https://wicg.github.io/web-app-launch/) for Web Apps [have been implemented by other browsers,](https://chromestatus.com/feature/5722383233056768) and Apple’s prohibition on the capability represents an undue restraint on competitors and will undermine the ability of Web Apps to compete on a level playing field.
+
+The DMA states that gatekeepers cannot prevent third-parties from accessing OS or device features, and if these issues are simply oversights, we hope the Commission and Apple will resolve them rapidly. Time is of the essence.
+
+## Will browser vendors be able to compete fairly with Safari?
+
+### Apple’s proposed browser choice screen
+
+As mandated by the DMA, Apple plans to introduce a choice screen for default browsers the first time a user opens Safari. We have little information about the design of the choice screen at this point, [except that it will present the 12 most popular browsers in the user’s EU country in random order](https://9to5mac.com/2024/01/26/apple-shares-more-details-about-the-new-default-web-browser-prompt-in-ios-17-4/). There are a number of ways Apple can manipulate that choice screen to make it ineffective, so we will watch carefully how it ends up being implemented. 
+
+
+The extent of Apple’s anti-competitive behavior towards third party browsers is hard to overstate. For **a dozen years**, it _wasn’t even possible_ to set a different browser as default. This thumb on the scales has spotted Safari an extensive market lead. The impact of choice screens against this sort of aggressive, persistent, long-standing self-preferencing is debatable, but OWA welcomes the attempt and urges the commission to scrupulously oversee the process. It should also not rule out re-running a choice ballot for users who have already been subject to one if the previous version is ruled out of compliance.
+
+### Apple system provided In-App Browser ignores the users choice of default browser
+
+Apple also self-preferences towards Safari through the [OS-provided “in-app browser” mechanism](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller). OWA expected to see mention of APIs for default competing browsers to handle navigation from apps through this facility, but it is missing. The cumulative effect of Apple’s ongoing self-preferencing in this regard is to make the web forgetful. Even when users make a competitor their default, that browser is not used to handle a sizable portion of browsing. This is a competitive restraint and is incompatible with the spirit of the DMA, and Apple’s proposal ignores the users choice of default browser.
+
+
+### Apple will restrict these changes to the EU
+
+Apple proposes only to allow competitors to ship their own engines inside the EU. This is an attempt to add poison pills, driving up costs for competitors to maintain multiple iOS browsers (one for Europe, another for the rest of the world), and to impose costs that Apple does not bear and would never stand for if imposed by a competitor. OWA expected some amount of awful-but-lawful malicious compliance, but continued restrictions on engine choice outside the EU are egregious.
+
+
+This additional burden can be unbearable for small browsers and will handicap all of them compared to Safari, adding to the harm done by 15 years of anti-competitive behavior that OWA has repeatedly described in reports and regulatory filings. [Mozilla is already on record citing these terms as _“creating barriers to prevent true browser competition on iOS”,](https://www.theverge.com/2024/1/26/24052067/mozilla-apple-ios-browser-rules-firefox)_ and OWA agrees.
+
+Another implication of Apple’s gating of this change to the EU is the difficulty for web developers to test their Web Apps and websites across that boundary. EU web developers won’t be able to test their work with the WebKit-based versions of alternate browsers. These iOS browsers are already hard to test “frankenbrowsers” owing to Apple’s WebKit restrictions, and this adds further cost and complication.
+
+Users outside of the EU will be using different versions of “Firefox”, “Chrome”, “Opera”, and given the difficulty in bringing modern experiences up to par on Apple’s browsers, adding to this work increases the pain for businesses attempting to build competitive web experiences in lieu of native apps.
+
+Likewise, developers outside of the EU won’t be able to test their sites on browsers only available in the EU. This will result in major issues and bugs both for EU users and users of EU Web Apps and websites outside of it, further harming EU businesses and users. These issues, however, will only affect users of alternate browsers. Safari will have a significant advantage, its engine being the same everywhere in the world.
+
+
+Obviously, the Commission does not have jurisdiction outside the EU and cannot mandate that its terms adhere worldwide, but Apple’s proposal to limit true browser choice to the EU shows that far from being embarrassed at having effectively banned third party browsers from iOS for over a decade, Apple will persist in this behavior till legally compelled not to in each and every major jurisdiction on the planet.. 
+
+### Apple will preclude third party browsers from competing on iPad
+
+Apple has chosen to restrict these browser changes to iPhone, and not to share them with iPad for users. This is currently allowed due to an [ongoing dispute with the EU as to whether or not iPadOS is covered by the DMA](https://open-web-advocacy.org/blog/owa-eu-dma-submission-apple-ipados/). In our submission, we argued that iPadOS is a subset of iOS with minor changes and that even were it not it is of sufficient market size and power in the EU to be a designated core platform service in its own right.
+
+There is no legitimate reason as to why browsers should be allowed to compete on iPhone but not iPad. This is simply a case of Apple trying to do the bare minimum possible which comes with the added bonus of scuttling browser or web app competition on iPad.
+
+
+### Will browser vendors be able to update their existing browsers?
+
+> Be a separate binary from any app that uses the system-provided web browser engine
+><cite>[Apple Documentation](https://developer.apple.com/support/alternative-browser-engines/)</cite>
+
+Apple is disconcertingly vague on how updating existing browser apps to now use their own engine will work and it is not clear whether:
+
+* Browser vendors must ship a separate app using their own browser engine.
+* Browser vendors can seamlessly swap over their existing users to the updated browser now using its own browser engine.
+
+
+If it is the first, that is deeply problematic as it essentially resets every third party browser that wants to use its own engine back to zero users. Given that the choice screen will take place prior to browser vendors having the opportunity to ship their real browsers, it is critical that this is not the case.
+
+Browser vendors need to be able to roll out their engines in a stable, predictable manner.  This means complete control over swapping webkit with their own engine including the ability to do browser engine phased releases and to be able to rollback.
+
+
+### Apple’s new contract for browsers that wish to use their own engine
+
+No one on our team is a lawyer, but to our un-lawyerly eyes a number of clauses in Apple’s contract seem not only unfair, but also in direct violation of the DMA. 
+
+To our knowledge a specific contract to be “allowed” to use bring a browser engine is unique to Apple in the history of successful consumer operating systems.
+
+> While in no way limiting Apple’s other rights under this Addendum or the Developer Agreement, or any other remedies at law or equity, if Apple has reason to believe You or Your Alternative Web Browser Engine App (EU) have failed to comply with the requirements of this Addendum or the Developer Agreement, Apple reserves the right to revoke to Your access to any or all of the Alternative Web Browser Engine APIs immediately upon notice to You; require You to remove Your Entitlement Profile from Your Alternative Web Browser Engine Application (EU); terminate this Addendum; block updates of, hide, or remove Your Alternative Web Browser Engine App (EU) and/or other Applications from the App Store; block Your Applications from distribution on Apple platforms; and/or to suspend or remove You from the Apple Developer Program.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+
+This clause basically says that if you fail to abide by all of Apple’s terms (some of which are pretty vague and possibly in contravention of the DMA), that they can not only reject that update, block your app until it is fixed, ban your app but that they can actually permanently remove and ban every single app your company has from distributions on all Apple platforms (presumably including macOS).
+
+
+Another clause states that browsers must also abide by the Apple App Store Guidelines ("guidelines" being a delightfully Orwellian phrase  for ironclad rules). Apple does not have the best reputation as to being a fair judge of what counts as a violation of its app store rules.
+
+> It should not surprise you to know that Apple’s interpretation of its text often seems capricious at best and at worst seems like it’s motivated by self-dealing.
+><cite>[Dieter Bohn - The Verge](https://www.theverge.com/2020/6/17/21293813/apple-app-store-policies-hey-30-percent-developers-the-trial-by-franz-kafka)</cite>
+
+> Nothing herein shall imply that Apple will accept Your Alternative Web Browser Engine App (EU) for distribution on the App Store, and You acknowledge and agree that Apple may, in its sole discretion, reject, or cease distributing Your Alternative Web Browser Engine App (EU) for any reason. For clarity, once Your Alternative Web Browser Engine App (EU) has been selected for distribution via the App Store it will be considered a “Licensed Application” under the Developer Agreement.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+This clause basically says they can reject your browser for any reason. 
+
+Luckily the DMA does not allow this. The rules need to be fair, reasonable, and non-discriminatory. Further browser vendors will be able to appeal app store rulings to an alternative dispute settlement mechanism.
+
+> The gatekeeper shall apply fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).
+> For that purpose, the gatekeeper shall publish general conditions of access, including an alternative dispute settlement mechanism.
+> The Commission shall assess whether the published general conditions of access comply with this paragraph.
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Any%20practice%20that%20would%20in%20any%20way%20inhibit%20or%20hinder%20those%20users%20in%20raising%20their%20concerns%20or%20in%20seeking%20available%20redress%2C%20for%20instance%20by%20means%20of%20confidentiality%20clauses%20in%20agreements%20or%20other%20written%20terms%2C%20should%20therefore%20be%20prohibited.)</cite>
+
+
+> Apple may at any time, and from time to time, with or without prior notice to You, modify, remove, or reissue the Apple Materials or the Alternative Web Browser Engine APIs, or any part thereof. You understand that any such modifications may require You to change or update Your Alternative Web Browser Engine App (EU) at Your own cost and that features and functionality of such App may cease to function. Except as required by applicable law, Apple has no express or implied obligation to provide, or continue to provide, the Apple Materials or Alternative Web Browser Engine APIs, and may suspend or discontinue all or any portion of Your access to them at any time.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)</cite>
+
+This clause says that Apple can break, remove or change any API without any notice. This hardly seems fair or reasonable.
+
+> Confidentiality
+> You agree that any non-public information regarding the Alternative Web Browser Engine APIs or Alternative Web Browser Engine (EU) Entitlement Profile shall be considered and treated as “Apple Confidential Information” in accordance with the terms of Section 9 (Confidentiality) of the Developer Agreement. You agree to use such Apple Confidential Information solely for the purpose of exercising Your rights and performing Your obligations under this Addendum and agree not to use such Apple Confidential Information for any other purpose, for Your own or any third party’s benefit, without Apple's prior written consent. You further agree not to disclose or disseminate Apple Confidential Information to anyone other than those of Your employees or contractors who have a need to know and who are bound by a written agreement that prohibited unauthorized use or disclose of the Apple Confidential Information.
+><cite>[Apple’s New Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)
+
+This bans discussing Apple’s APIs publically or sharing information about them with any party except for employees or contractors who are bound by a similar agreement. Aside from the obvious attempt to stifle public discussion of shortcomings or anti-competitive behavior in Apple’s APIs this also appears to run afoul of the DMA. Given that the code bases of all the major browser engines are open source (including Safari’s) there does not appear to be any legitimate need for such a confidentiality clause.
+
+> Any practice that would in any way inhibit or hinder those users in raising their concerns or in seeking available redress, for instance by means of confidentiality clauses in agreements or other written terms, should therefore be prohibited.
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Any%20practice%20that%20would%20in%20any%20way%20inhibit%20or%20hinder%20those%20users%20in%20raising%20their%20concerns%20or%20in%20seeking%20available%20redress%2C%20for%20instance%20by%20means%20of%20confidentiality%20clauses%20in%20agreements%20or%20other%20written%20terms%2C%20should%20therefore%20be%20prohibited)</cite>
+
+### Third-party browsers will be effectively precluded from shipping their browsers on third party app stores on iOS
+
+Apple's proposal includes plans for allowing third-party native app stores to compete with their own on iOS. This is directly compelled by the act.
+
+While allowing third party native app stores is not part of the fight of our organization, it is relevant in so far as browsers, being free products, would like to list on every major app store available on iOS. Apple's proposal seems designed to prevent any free app from ever even considering listing on a third party native app store on iOS.
+
+In order to list their app on a third party app store, the app developer must sign an alternative contract allowing them the rights granted under the DMA but which comes with significantly different pricing. To our non-lawyer minds, having an optional alternate contract that semi-abides by the law and a standard contract which does not is baffling.
+
+The pricing difference between the contracts is worth scrutiny, particularly for free apps like browsers. If vendors choose the second contract, Apple will waive some app store fees but add a new  "Core Technology Fee" which boils down to a 50c charge per user, per year.
+
+
+In Apple's own words the fee is: 
+
+> The Core Technology Fee (CTF) is an element of the new business terms in the European Union (EU) that reflects the value Apple provides developers through ongoing investments in the tools, technologies, and services that enable them to build and share innovative apps with users around the world. Developers can choose to remain on the App Store’s current business terms or adopt the new business terms for iOS apps in the EU.
+><cite>[Apple Documentation](https://developer.apple.com/support/core-technology-fee/)</cite>
+
+This sounds awfully like a fee for access to hardware and software APIs. But the DMA specifically precludes such a fee:
+
+> Article 6(7) The gatekeeper shall allow providers of services and providers of hardware, **free of charge, effective interoperability with, and access for the purposes of interoperability to, the same hardware and software features accessed or controlled via the operating system** or virtual assistant listed in the designation decision pursuant to Article 3(9) as are available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business users and alternative providers of services provided together with, or in support of, core platform services, **free of charge, effective interoperability with, and access for the purposes of interoperability to, the same operating system, hardware or software features, regardless of whether those features are part of the operating system, as are available to, or used by, that gatekeeper when providing such services.**
+><cite>[Digital Markets Act](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)
+(emphasis added)</cite>
+
+“Free of charge” being the key phrase.
+
+Astonishingly, Apple has added wording that prevents developers from switching back to the standard contract, while granting themselves the right to change either contract at any time:
+
+> Developers who adopt the new business terms at any time will not be able to switch back to Apple’s existing business terms for their EU apps. Apple will continue to give developers advance notice of changes to our terms, so they can make informed choices about their businesses moving forward.
+><cite>[Apple Documentation](https://developer.apple.com/support/dma-and-apps-in-the-eu/#dev-qa:~:text=Developers%20who%20adopt%20the%20new%20business%20terms%20at%20any%20time%20will%20not%20be%20able%20to%20switch%20back%20to%20Apple%E2%80%99s%20existing%20business%20terms%20for%20their%20EU%20apps.%20Apple%20will%20continue%20to%20give%20developers%20advance%20notice%20of%20changes%20to%20our%20terms%2C%20so%20they%20can%20make%20informed%20choices%20about%20their%20businesses%20moving%20forward.)</cite>
+
+
+How much it would cost for a browser to list on one of these third party app stores? iOS has 1.65 billion users. 1% browser market share represents 16.5 million users. If a browser vendor dares to list their app on a third party store, even once, and even if no one downloads it from that third party store, Apple will bill them $8.25 million per a year per 1% share every year with no recourse to change back to the previous contract.
+
+In our view (and the view of many others) is that this is designed to make it as difficult as possible for free apps to list on third party app stores as possible, depriving these app stores of these apps, and sapping their ability to get off the ground.
+
+The DMA also contains additional provisions that likely prohibit this behavior:
+
+> Article 6(12) The gatekeeper shall apply **fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores**, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).
+
+Apple’s policy is unfair, unreasonable, and discriminatory &mdash; both to free apps such as browsers, and to third party app stores.
+
+If Apple's proposal sounds ludicrous to you, you are not alone. We are confused as to how Apple's lawyers thought this would possibly be compliant with the DMA, and the degree to which this would alienate native app developers. Their willingness to pursue these proposals, despite presumably being aware how unpopular they would be, is itself a striking example of market power.
+
+We hope that the EU rejects this proposal and forces Apple to come up with a single non-alternative contract for all Native App developers who choose to distribute via Apple's App Store in the EU with fair, reasonable and non-discriminatory terms.
+
+### What Apple should have done and why they will ultimately lose
+
+Apple could have behaved differently here. They could have announced global rules allowing browser competition on iOS. These rules could include a minimum bar for security. They could have been working with the teams of each of the major browser vendors for months on what APIs they need and how to share them effectively. They could have upgraded their in-app browser (SFSafariViewController) and their Web App installation functionality to support the users choice of browser and to allow these third party browsers and Web Apps to compete fairly. They could significantly increase Safari's budget and fought to convince consumers of their vision for the Web in anticipation of intense mobile browser competition.
+
+Apple has done none of this. Even a generous observer would conclude their proposal seems designed to circumvent the intent and letter of the digital markets act. Their announcement is dripping with disdain for the EU regulators.
+
+> These proposals seem less about complying with the DMA and more about maintaining Apple’s walled garden,
+
+> The limited scope of change does little to address the genuine power imbalances within the app ecosystem.
+><cite>[Dr. Maria Rodriguez, Competition Law Expert at the University of Amsterdam](https://pc-tablet.com/clash-of-titans-apples-dma-compliance-proposals-raise-concerns-about-choice-and-competition/)</cite>
+
+This is a mistake, for all Apple's talk of protecting consumers, the focus on revenue and containing the new competition allowed, shows their hand. The public are not fools and they are not fooled.
+
+Even in traditionally pro-Apple forums the response to [Apple's browser competition proposal](https://www.macrumors.com/2024/01/26/mozilla-on-apple-eu-browser-engine-change/) has been extremely negative. Apple is losing whatever reputation for fair play it may have enjoyed. With each market investigation or act passed, this behavior is forced into the open.
+
+## What’s Next
+
+Apple’s compliance proposal is only that: a proposal that the EC can accept or reject, in whole or in part. Apple’s submissions will be reviewed by the EU and are subject to change. The voice of web developers matters now more than ever, as OWA is in contact with regulators and can amplify the concerns of folks working to build competitive experiences on the only open, interoperable, tax-free platform. 
+
+The EU thus far has had only this to say:
+
+> The DMA will open the gates of the internet to competition so that digital markets are fair and open. Change is already happening. As from March 7 we will assess companies' proposals, with the feedback of third parties. If the proposed solutions are not good enough, we will not hesitate to take strong action.
+><cite>[EU Industry Chief Thierry Breton](https://www.reuters.com/technology/apple-faces-strong-action-if-app-store-changes-fall-short-eus-breton-says-2024-01-26/)</cite>
+
+
+Our early reading of Apple’s proposal suggests that its plan does not align with either the letter or spirit of the DMA. We will be providing more updates as we parse the text. Although we have reasons to rejoice because alternate browser engines will now be able to ship to iOS, we remain concerned that this sort of gamesmanship by gatekeepers undermines the intent of the DMA. Fair competition for web browsers and proper support for Web Apps on iOS is not too much to ask. Indeed, we believe it’s now the legal right of EU citizens.
+
+
+> While legal experts expect the EU to challenge Apple's insincere compliance with the DMA, developers should take this opportunity to rethink their native app serfdom. They should push web apps to their limits and then demand further platform improvement.
+> The web doesn't require commission payments, technology fees based on usage, or permission from platform rentseekers. The web can set the iPhone free, even if Apple won't.
+><cite>[Thomas Claburn - The Register](https://www.theregister.com/2024/01/27/apple_europe_ios_analysis/)</cite>
+
+We will keep on fighting and will alert the EU to shortcomings and risks posed by each of the gatekeeper’s compliance plans.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)
+
+
+## Links 
+We believe it's important that readers be able to make up their own minds.
+
+[This is the full text](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG) of the DMA. Of most interest is [Article 5](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=on%2Dgoing%20basis.-,CHAPTER%20III,PRACTICES%20OF%20GATEKEEPERS%20THAT%20LIMIT%20CONTESTABILITY%20OR%20ARE%20UNFAIR,-Article%C2%A05) and [Article 6](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=Obligations%20for%20gatekeepers%20susceptible%20of%20being%20further%20specified%20under%20Article%C2%A08) which are only a few pages, however the recitals which start on the first page provide context for these articles, such as the reference to [web apps](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=web%20software%20applications).
+
+
+The following is a list of links to Apple’s documentation on their new browser engine rules and APIs.
+
+* [Apple announces changes to iOS, Safari and the App Store in the European Union](https://www.apple.com/au/newsroom/2024/01/apple-announces-changes-to-ios-safari-and-the-app-store-in-the-european-union/)
+* [Update on apps distributed in the European Union](https://developer.apple.com/support/dma-and-apps-in-the-eu/)
+* [Embedded Browser Engine](https://developer.apple.com/contact/request/download/embedded_browser_engine.pdf)
+* [Web Browser Engine Contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf)
+* [Using alternative browser engines in the European Union](https://developer.apple.com/support/alternative-browser-engines/)
+* [BrowserEngineKit Documentation](https://developer.apple.com/documentation/browserenginekit)
+* [Scroll UI Container Documentation](https://developer.apple.com/documentation/browserenginekit/bescrollview)
+* [Drag UI Documentation](https://developer.apple.com/documentation/browserenginekit/bedraginteraction)
+* [Browser Engine Core Documentation](https://developer.apple.com/documentation/browserenginecore)
+* [Preparing your app to be the default web browser](https://developer.apple.com/documentation/xcode/preparing-your-app-to-be-the-default-browser)
+* [No mention of default settings for browsers](https://developer.apple.com/support/dma-and-apps-in-the-eu/#app-controls:~:text=Expanded%20default%20app%20controls%20for%20users%20in%20the%C2%A0EU)
+* [Requesting interoperability with iOS in the European Union](https://developer.apple.com/support/ios-interoperability/)
+* [Alternative distribution on iOS in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu/#ios-app-eu)
+* [Terms for alternative distribution and payments in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu/#distribution-eu)
+* [Fee Calculator for Apps in the EU](https://developer.apple.com/support/fee-calculator-for-apps-in-the-eu/)
+* [Core Technology Fee](https://developer.apple.com/support/core-technology-fee/)
+* [Alternate EU Terms Contract](https://developer.apple.com/contact/request/download/alternate_eu_terms_addendum.pdf)
+* [Apple AppStore Guidelines](https://developer.apple.com/app-store/review/guidelines/) Note: Ones with the “key” symbol apply to third party apps delivered outside of Apple’s AppStore.
+* [AppStore Guidelines  2.5.6](https://developer.apple.com/app-store/review/guidelines/#:~:text=2.5.6%20Apps%20that%20browse%20the%20web%20must%20use%20the%20appropriate%20WebKit%20framework%20and%20WebKit%20JavaScript.%20You%20may%20apply%20for%20an%20entitlement%20to%20use%20an%20alternative%20web%20browser%20engine%20in%20your%20app.%20Learn%20more%20about%20these%20entitlements.)
+* [AppStore Guideline Changes](https://developer.apple.com/news/?id=7j1f99yf)

--- a/src/ja/posts/security-updates-browser-choice.md
+++ b/src/ja/posts/security-updates-browser-choice.md
@@ -1,0 +1,33 @@
+---
+title: iOS Safari zero-day security bugs and how browser choice affects user safety
+date: '2023-12-05'
+tags:
+  - Security
+  - Browsers
+author: Frances Berriman
+permalink: /ja/blog/security-updates-browser-choice/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+In the last couple of weeks we've seen a few browser security bugs pop up, giving us the opportunity to talk about how a competitive landscape for web browsers is vital to protecting users online.
+
+## Nasty Bugs All Around
+
+Firstly, we saw a [set of zero-day bugs identified in Webkit](https://www.infosecurity-magazine.com/news/apple-patches-actively-exploited/). Apple landed a fix for those in a [subsequent iOS update](https://support.apple.com/en-us/HT214031).
+
+Secondly, a [nasty security bug in Google Chrome](https://nvd.nist.gov/vuln/detail/CVE-2023-6345), also subsequently [patched.](https://www.malwarebytes.com/blog/news/2023/11/update-now-chrome-fixes-actively-exploited-zero-day-vulnerability)
+
+Both bugs were “high” severity, meaning attackers could compromise devices using malicious web pages. This is your friendly reminder to make sure your devices are up to date!
+
+## Compare and Contrast
+
+What's different about these two situations? 
+
+If a security bug shows up on a browser on Android, MacOS, Windows or most other OSs, users can opt to pick a different browser for a time until a patch has landed and their browsing experience is safe again. If their browser has a bad security track record, they can also switch to a better built one. Additionally, Chrome or any other browser on Android etc., can be patched without OS updates. Users don't have to wait for a new version of Android, wait for huge downloads, or reboot their devices.
+
+Users on iOS are less fortunate. Having [no other browsers to choose from](/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers), they must hope that the security update doesn't catch them out in some way as they wait for an iOS update, as Safari isn't able to independently ship changes. With no choice, they have no option to wait it out on safer shores.
+
+This choice of software architecture - coupling a browser to an OS, or not - has been played out before. It wasn't long ago that Windows users had to wait for OS updates to receive patches for IE [because it was so tightly tied to OS components.](https://learn.microsoft.com/en-us/troubleshoot/developer/browsers/installation/prerequisite-updates-for-ie-11) Microsoft’s strategy handicapped their ability to keep browsers current. Eventually, they changed the design with Chromium-based Edge because decoupled updates are safer. Even without that design change, Windows users still had choices available to them in times of need. 
+
+All users deserve to have that choice.

--- a/src/ja/posts/stuart-langridge-the-mazy-web.md
+++ b/src/ja/posts/stuart-langridge-the-mazy-web.md
@@ -1,0 +1,20 @@
+---
+title: 'Stuart Langridge: The Mazy Web'
+date: '2024-10-08'
+tags:
+  - Policy
+  - Apple
+  - EU
+author: OWA
+permalink: /ja/blog/stuart-langridge-the-mazy-web/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+If you have a spare half hour, we highly recommend listening to Stuart Langridge's insightful and eloquent talk about why the open web is special. Stuart shares his passion for the internet and its incredible potential. In his talk, he delves into the unique qualities that make the web such a powerful tool and why it's crucial for us all to advocate for and explain its significance.
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube-nocookie.com/embed/Mn2YFU_UkEI?si=aTV2iXhIsEvfQzAP' frameborder='0' allowfullscreen title="Stuart Langridge - The mazy web she whirls:starting Open Web Advocacy"></iframe></div>
+
+If you understand why the open web unlocks doors and what makes it is special, please advocate on its behalf and help spead that message.
+
+

--- a/src/ja/posts/the-digital-markets-act-is-in-force-what-happens-now.md
+++ b/src/ja/posts/the-digital-markets-act-is-in-force-what-happens-now.md
@@ -1,0 +1,275 @@
+---
+title: The Digital Markets Act is in force! What happens now?
+date: '2024-03-07'
+tags:
+  - Policy
+  - Apple
+  - Google
+  - Microsoft
+  - Meta
+  - Bytedance
+  - EU
+author: OWA
+permalink: /ja/blog/the-digital-markets-act-is-in-force-what-happens-now/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The Digital Markets Act (DMA) grace period for gatekeepers to comply has now ended.
+
+[The DMA is EU legislation](https://en.wikipedia.org/wiki/Digital_Markets_Act) that came into law on the 1st of November 2022 that aims to improve fairness, contestability and interoperability in very large platforms that operate in the EU that have significant and durable market power. In order to not impose expensive compliance obligations on small and medium businesses, the act only applies to truly massive companies with significant revenue that operate platforms used by tens of millions of EU consumers.
+
+The DMA comes with serious teeth, they have the power to fine gatekeepers up to 10% of global revenue repeatedly until they comply with the act. For reference Apple had a global revenue of $383 billion USD in 2023 and their net profit was $100 billion USD, meaning that the maximum cost of a single fine under the DMA is $38.3 billion USD, a sum any gatekeeper would surely blink at. In the case of repeated non-compliance they can fine up-to 20% of global revenue in a single fine. 
+
+Currently there are six gatekeepers who have been designated: Amazon, Apple, Bytedance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
+
+These gatekeepers have a number of “core platform services” that have been formally designated under the DMA. To be automatically designated the service must have at least  45 million users in the EU and at least ten thousand business users. Further they need to be of a type of platform covered by the act. Currently the types listed in the act are:
+* online intermediation services
+* online search engines
+* online social networking services
+* video-sharing platform services
+* number-independent interpersonal communications services
+* virtual assistants
+* cloud computing services
+* online advertising services
+* operating systems
+* web browsers
+
+Being designated means that the gatekeeper must make sure the designated core platform service is **fully compliant with the DMA before the end of the 6 month grace period**. That grace period ended today. The DMA is ex-ante which means it is the gatekeepers responsibility to make sure and show that they are in compliance.
+
+The core platform services that have been designated, split by type are:
+
+**Intermediation**
+* Amazon Marketplace
+* Apple App Store
+* Google Maps
+* Google Play
+* Google Shopping
+* Meta Marketplace
+
+**Social Networks**
+* Facebook
+* Instagram
+* LinkedIn
+* TikTok
+
+**Number-independent Interpersonal Communications Services**
+* Messenger
+* Whatsapp
+
+**Online Advertising Services**
+* Amazon
+* Google
+* Meta
+
+**Search**
+* Google
+
+**Video Sharing**
+* Youtube
+
+**Operating Systems**
+* iOS
+* Android
+* Windows
+
+**Browsers**
+* Chrome
+* Safari
+
+That grace period has now officially ended, so what happens now?  First each of the gatekeepers is required to have submitted a compliance report to the Commission as well as a public summary. Then, likely for the first few weeks nothing. The EU Commission is an evidence based organisation and will need time to assess how well each of the gatekeepers are complying with the DMA and select the highest priority targets to start proceedings against first.
+
+[Many observers](https://theplatformlaw.blog/2024/01/26/when-apple-takes-the-european-commission-for-fools-an-initial-overview-of-apples-new-terms-and-conditions-for-ios-app-distribution-in-the-eu/), including us, believe that Apple due to its combative and belligerent approach will be the first to be hit, likely with multiple proceedings. Indeed fireworks came early with [Apple’s attempt to sabotage Web Apps in the EU](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/) prior to the DMA coming into force.
+
+Luckily for the web, Apple’s plan faced massive backlash. [Our open letter to Tim Cook](https://letter.open-web-advocacy.org/) on the subject had 4640 individuals and 483 organisations sign. Signatures included two European MEPs (Karen Melchior & Patrick Breyer); a number of significant EU companies such as social media platform Mastodon; and individuals (advocating in their personal capacity) who work for SwissLife, Tchibo, W3C, Mozilla, Google, Microsoft, Vivaldi, BBC, Financial Times, ​​Red Hat, Oracle, Amazon, Wikimedia, Vercel, Netlify, Shopify, Spotify, AirBNB, Berlin University of the Arts, Open State Foundation - Netherlands, Cloudflare, Meta, Chase, Squarespace, Reddit, Atlassian, Maersk, Paypal, Salesforce, block, Adobe, ebay, Zynga, booking.com and thoughtworks; and many other developers and organisations from over 100 countries.
+
+The EU Commission [promptly opened an investigation](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) into the matter.
+
+**Three days later Apple caved and reversed their decision to break all Web Apps in the EU for millions of consumers.**
+
+The EU Commission said [in a statement](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) that:
+“Contrary to Apple’s public representation, the removal of Home Screen Web Apps on iOS in the EU was neither required, nor justified, under the Digital Markets Act,”
+
+Three European parliament MEPs — Karen Melchior, Tiemo Wölken, and Patrick Breyer — said [in a statement to the Financial Times](https://www.ft.com/content/d2f7328c-5851-4f16-8f8d-93f0098b6adc) that it would be “in flagrant violation of the spirit, and likely the word of the DMA”, and reminded the company of the EU’s power to enforce fines of up to 10 percent of a company’s annual turnover under the new rules.
+
+Given Apple is not a company that backs down easily or quickly, the only plausible explanation is that Apple’s lawyers decided that the plan to sabotage Web Apps in the EU (and in effect globally) would subject Apple to immediate and serious legal risk, and recommended reversing course. This is important as it shows that public outreach combined with regulatory intervention can curb the worst of Apple’s anti-competitive behaviour and not even their billion dollar a year legal budget is sufficient to maintain it. The combination of strong laws and advocacy can protect the open web.
+
+Our non-profit organisation has two aims:
+* Fair and effective browser competition on all general purpose operating systems
+* Fair and effective Web App competition on all general purpose operating systems, in particular we are aiming for feature parity between Web Apps and Native Apps.
+
+For readers who are unaware, [Apple has effectively banned third party browsers on iOS](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers) for the last 15 years by preventing them from using their own browser engine. Instead third party browsers vendors were forced to build a thin user interface shell around the WebKit WkWebView shipped with iOS, making them reskinned versions of Safari.
+
+This means there is **no browser competition on iOS** and that Apple can unilaterally set a ceiling on the feature set of Web Apps. Despite Apple [repeatedly](https://www.youtube.com/watch?v=H6eYLCxxQdA&t=306s) [claiming that](https://9to5mac.com/2021/03/25/bypass-the-app-store-says-apple/) [Web Apps are the alternative to their App Store](https://developer.apple.com/app-store/review/guidelines/#:~:text=For%20everything%20else%20there%20is%20always%20the%20open%20Internet.%20If%20the%20App%C2%A0Store%20model%20and%20guidelines%20or%20alternative%20app%20marketplaces%20and%20Notarization%20for%20iOS%20apps%20are%20not%20best%20for%20your%20app%20or%20business%20idea%20that%E2%80%99s%20okay%2C%20we%20provide%20Safari%20for%20a%20great%20web%20experience%20too.), Web Apps are currently not able to effectively contest it due to [missing features](https://open-web-advocacy.org/walled-gardens-report/#safari-lags-behind-and-is-missing-key-features) and [bugs in Safari](https://open-web-advocacy.org/walled-gardens-report/#ios-safari-is-buggy). No third party browser can improve the situation due to Apple’s browser engine ban.
+
+With that context and these aims in mind, it's worth exploring the DMA and what changes it brings to the EU in relation to browsers, Web Apps and Web and what exactly the gatekeepers are obligated to do.
+
+## Key Passages
+
+### Recital 43
+
+> When gatekeepers operate and impose web browser engines, they are in a position to determine the functionality and standards that will apply not only to their own web browsers, but also to competing web browsers and, in turn, to web software applications.
+> </br><cite>[Digital Markets Act - Recital 43](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG#:~:text=When%20gatekeepers%20operate%20and%20impose%20web%20browser%20engines%2C%20they%20are%20in%20a%20position%20to%20determine%20the%20functionality%20and%20standards%20that%20will%20apply%20not%20only%20to%20their%20own%20web%20browsers%2C%20but%20also%20to%20competing%20web%20browsers%20and%2C%20in%20turn%2C%20to%20web%20software%20applications.)</cite>
+
+This section is particularly important as it outlines what the DMA’s purpose is in prohibiting banning browser engines. Specifically it is to prevent gatekeepers from blocking competitors from providing functionality to competing browsers and to “web software applications”.
+
+This was likely, at least in part, based on the conclusions of the UK regulator who stated:
+> Apple generates revenue through its App Store, both by charging developers for access to the App Store and by taking a commission for payments made via Apple IAP. Apple therefore benefits from higher usage of native apps on iOS. By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> <cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)<br>
+(emphasis added)</cite>
+
+### Article 5(7)
+
+> Articles 5(7) **The gatekeeper shall not require end users to use, or business users to use, to offer, or to interoperate with**, an identification service, **a web browser engine** or a payment service, or technical services that support the provision of payment services, such as payment systems for in-app purchases, of that gatekeeper in the context of services provided by the business users using that gatekeeper’s core platform services.
+> </br><cite>[Digital Markets Act - Article 5(7)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)<br>
+(emphasis added)</cite>
+
+This is the specific part of the act that actually prohibits gatekeepers from imposing browser engines. It does not allow the gatekeeper any leeway to prevent this.
+
+### Article 6(7)
+
+> Article 6(7) The gatekeeper shall allow providers of services and providers of hardware, free of charge, effective interoperability with, and access for the purposes of interoperability to, the same hardware and software features accessed or controlled via the operating system or virtual assistant listed in the designation decision pursuant to Article 3(9) as are available to services or hardware provided by the gatekeeper. Furthermore, the gatekeeper shall allow business users and alternative providers of services provided together with, or in support of, core platform services, free of charge, effective interoperability with, and access for the purposes of interoperability to, the same operating system, hardware or software features, regardless of whether those features are part of the operating system, as are available to, or used by, that gatekeeper when providing such services.</br></br>
+> The gatekeeper shall not be prevented from taking strictly necessary and proportionate measures to ensure that interoperability does not compromise the integrity of the operating system, virtual assistant, hardware or software features provided by the gatekeeper, provided that such measures are duly justified by the gatekeeper.
+> </br><cite>[Digital Markets Act - Article 6(7)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that designated operating systems must provide API access to third parties for the purpose of interoperability (i.e. making their software/hardware work on or with the device). Importantly it states that this must be provided “free of charge”.
+
+The “free of charge” appears to throw a spanner in the works of Apple’s Core Technology Fee which is a 50c per user per year fee for API access that Apple will charge for all app downloads (including app downloads from Apple’s App Store) of any developers that dares to list their app on a different app store on iOS. It’s hard to see how Apple’s lawyers possibly thought this would be compliant but does give some insight as to the level of hubris and belligerence that Apple is operating at here.
+
+Gatekeepers are only allowed strictly necessary, proportional and justified security measures to prevent compromising “the integrity of the operating system”. Justified here means that the burden of proof is on the gatekeeper to show that the measure is strictly necessary and proportional.
+
+### Recital 49, Recital 52 and Article 6(5)
+
+> A gatekeeper can use different means to favour its own or third-party services or products on its operating system, virtual assistant or web browser, to the detriment of the same or similar services that end users could obtain through other third parties.
+> </br><cite>[Digital Markets Act - Recital 49](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+> In such situations, the gatekeeper should not engage in any form of differentiated or preferential treatment in ranking on the core platform service, and related indexing and crawling, whether through legal, commercial or technical means, in favour of products or services it offers itself or through a business user which it controls. To ensure that this obligation is effective, the conditions that apply to such ranking should also be generally fair and transparent. Ranking should in this context cover all forms of relative prominence, including display, rating, linking or voice results and **should also include instances where a core platform service presents or communicates only one result to the end user**.
+> </br><cite>[Digital Markets Act - Recital 52](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)<br>
+(emphasis added)</cite>
+
+> Article 6(5) The gatekeeper shall not treat more favourably, in ranking and related indexing and crawling, services and products offered by the gatekeeper itself than similar services or products of a third party. The gatekeeper shall apply transparent, fair and non-discriminatory conditions to such ranking.
+> </br><cite>[Digital Markets Act - Article 6(5)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+These recitals and articles state that the gatekeeper can not self-preference themselves in various forms of ranking. This could apply to the user interface design of iOS where in the settings Apple’s apps get special locations, [various undermining of browser choice by Microsoft on Windows](https://research.mozilla.org/files/2024/01/Over-the-Edge-Report-January-2024.pdf) or Google prompting users to download Chrome on google.com or youtube.com in locations that competitors can not. All of these behaviours are now prohibited in the EU.
+
+### Article 6(3)
+
+> Article 6(3) The gatekeeper shall allow and technically enable end users to easily un-install any software applications on the operating system of the gatekeeper, without prejudice to the possibility for that gatekeeper to restrict such un-installation in relation to software applications that are essential for the functioning of the operating system or of the device and which cannot technically be offered on a standalone basis by third parties.</br></br>
+> The gatekeeper shall allow and technically enable end users to easily change default settings on the operating system, virtual assistant and web browser of the gatekeeper that direct or steer end users to products or services provided by the gatekeeper. That includes prompting end users, at the moment of the end users’ first use of an online search engine, virtual assistant or web browser of the gatekeeper listed in the designation decision pursuant to Article 3(9), to choose, from a list of the main available service providers, the online search engine, virtual assistant or web browser to which the operating system of the gatekeeper directs or steers users by default, and the online search engine to which the virtual assistant and the web browser of the gatekeeper directs or steers users by default.
+> </br><cite>[Digital Markets Act - Article 6(3)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article mandates browser and search engine choice screens in the EU. Mozilla [recently did a study](https://research.mozilla.org/files/2023/09/Can-browser-choice-screens-be-effective_-Mozilla-experiment-report.pdf) that showed a well designed choice screen could cause significant changes in market share, specifically Firefox could increase its market share to 20%. 
+
+### Article 6(4)
+
+> Article 6(4) The gatekeeper shall allow and technically enable the installation and effective use of third-party software applications or software application stores using, or interoperating with, its operating system and allow those software applications or software application stores to be accessed by means other than the relevant core platform services of that gatekeeper. The gatekeeper shall, where applicable, not prevent the downloaded third-party software applications or software application stores from prompting end users to decide whether they want to set that downloaded software application or software application store as their default. The gatekeeper shall technically enable end users who decide to set that downloaded software application or software application store as their default to carry out that change easily.</br></br>
+> The gatekeeper shall not be prevented from taking, to the extent that they are strictly necessary and proportionate, measures to ensure that third-party software applications or software application stores do not endanger the integrity of the hardware or operating system provided by the gatekeeper, provided that such measures are duly justified by the gatekeeper.</br></br>
+> Furthermore, the gatekeeper shall not be prevented from applying, to the extent that they are strictly necessary and proportionate, measures and settings other than default settings, enabling end users to effectively protect security in relation to third-party software applications or software application stores, provided that such measures and settings other than default settings are duly justified by the gatekeeper.
+> </br><cite>[Digital Markets Act - Article 6(4)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that operating system gatekeepers need to allow third parties to be able to install their apps both by other app stores and directly (i.e. via a link over the internet).
+
+The gatekeeper is allowed to take strictly necessary, proportional and justified security measures to protect the integrity of the hardware or operating system.
+
+### Article 6(12)
+
+> Article 6(12) The gatekeeper shall apply fair, reasonable, and non-discriminatory general conditions of access for business users to its software application stores, online search engines and online social networking services listed in the designation decision pursuant to Article 3(9).</br></br>
+> For that purpose, the gatekeeper shall publish general conditions of access, including an alternative dispute settlement mechanism.</br></br>
+> The Commission shall assess whether the published general conditions of access comply with this paragraph.
+> </br><cite>[Digital Markets Act - Article 6(12)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This states that the terms of the app stores shall be fair, reasonable and non-discriminatory. It seems likely the exact meaning of “fair” will be extensively litigated in the EU. The act contains this paragraph to explain what “fair” means in more detail: 
+
+> Pricing or other general access conditions should be considered unfair if they lead to an imbalance of rights and obligations imposed on business users or confer an advantage on the gatekeeper which is disproportionate to the service provided by the gatekeeper to business users or lead to a disadvantage for business users in providing the same or similar services as the gatekeeper. The following benchmarks can serve as a yardstick to determine the fairness of general access conditions: prices charged or conditions imposed for the same or similar services by other providers of software application stores; prices charged or conditions imposed by the provider of the software application store for different related or similar services or to different types of end users; prices charged or conditions imposed by the provider of the software application store for the same service in different geographic regions; prices charged or conditions imposed by the provider of the software application store for the same service the gatekeeper provides to itself
+
+Crucially the terms the gatekeeper is allowed to set is for being on the app store, not being on the operating system. Gatekeepers have no ability under the act to set terms for being on the operating system beyond strictly necessary, proportional and heavily justified security measures.
+
+### Article 13(4)
+
+> Article 13(4) The gatekeeper shall not engage in any behaviour that undermines effective compliance with the obligations of Articles 5, 6 and 7 regardless of whether that behaviour is of a contractual, commercial or technical nature, or of any other nature, or consists in the use of behavioural techniques or interface design.
+> </br><cite>[Digital Markets Act - Article 13(4)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article grants the commission extremely broad powers to prevent gatekeepers seeking to avoid their obligations via “malicious compliance”. Clearly it was anticipated that at least a few of the gatekeepers would seek to undermine and circumvent the act.
+
+### Article 13(6)
+
+> Article 13(6) The gatekeeper shall not degrade the conditions or quality of any of the core platform services provided to business users or end users who avail themselves of the rights or choices laid down in Articles 5, 6 and 7, or make the exercise of those rights or choices unduly difficult, including by offering choices to the end-user in a non-neutral manner, or by subverting end users’ or business users' autonomy, decision-making, or free choice via the structure, design, function or manner of operation of a user interface or a part thereof.
+> </br><cite>[Digital Markets Act - Article 13(6)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article is to prevent gatekeepers from circumventing obligations by degrading the core platform service. It seems likely that this applied to Apple’s attempt to remove Web App installation in the EU as a method to avoid sharing it with third party browsers using their own engines, thus circumventing their obligations under Article 5(7). Apple essentially admitted this was the purpose of removing the functionality in their initial statement where [they stated](https://developer.apple.com/support/dma-and-apps-in-the-eu#8:~:text=Addressing%20the%20complex,in%20the%20EU.): 
+
+> Addressing the complex security and privacy concerns associated with **web apps using alternative browser engines would require building an entirely new integration architecture** that does not currently exist in iOS and was not practical to undertake given the other demands of the DMA and the very low user adoption of Home Screen web apps. **And so, to comply with the DMA’s requirements, we had to remove the Home Screen web apps feature in the EU**.
+> </br><cite>[Apple's statement on breaking Web Apps in the EU](https://developer.apple.com/support/dma-and-apps-in-the-eu#8:~:text=Addressing%20the%20complex,in%20the%20EU.)<br>
+(emphasis added)</cite>
+
+### Article 30(1)
+
+> Article 30(1) In the non-compliance decision, the Commission may impose on a gatekeeper fines not exceeding 10 % of its total worldwide turnover in the preceding financial year where it finds that the gatekeeper, intentionally or negligently, fails to comply with:<br>
+> (a) any of the obligations laid down in Articles 5, 6 and 7;<br>
+> (b) measures specified by the Commission in a decision adopted pursuant to Article 8(2);<br>
+> (c) remedies imposed pursuant to Article 18(1);<br>
+> (d) interim measures ordered pursuant to Article 24; or<br>
+> (e) commitments made legally binding pursuant to Article 25.
+> </br><cite>[Digital Markets Act - Article 30(1)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article outlines the fines the commission can impose on gatekeepers that violate any part of Article 5, 6 or 7. In this case the maximum individual fine is 10% of global revenue.
+
+### Article 30(2)
+
+> Article 30(2).   Notwithstanding paragraph 1 of this Article, in the non-compliance decision the Commission may impose on a gatekeeper fines up to 20 % of its total worldwide turnover in the preceding financial year where it finds that a gatekeeper has committed the same or a similar infringement of an obligation laid down in Article 5, 6 or 7 in relation to the same core platform service as it was found to have committed in a non-compliance decision adopted in the 8 preceding years.
+> </br><cite>[Digital Markets Act - Article 30(2)](https://eur-lex.europa.eu/legal-content/EN/TXT/?toc=OJ%3AL%3A2022%3A265%3ATOC&uri=uriserv%3AOJ.L_.2022.265.01.0001.01.ENG)</cite>
+
+This article states that if the gatekeeper commits the same violation twice the commission can fine them up to 20% of global revenue in a single fine.
+
+## What changes is OWA pushing for?
+
+OWA is a global organisation and in order for both browser and web app competition to be both fair and effective these changes need to happen in as many jurisdictions as possible, and push for global uniformity. 
+
+That said, securing these changes in the EU will be a massive win for two reasons. First EU consumers and businesses can experience the benefits of increased competition and interoperability. Second, every major regulator on the planet is looking carefully at the DMA and planning their own regimes. Any success in the EU will provide these regulators with a mountain of evidence and a blueprint to force these gatekeepers to behave.
+
+Some important aims that could be achieved under the DMA are:
+1. **Allow other browsers to compete fairly and effectively on iOS with their own engine**<br>
+	Currently [Apple’s browser engine entitlement contract](https://developer.apple.com/contact/request/download/web_browser_engine.pdf) (a contract specifically for allowing API access) [is riddled with outrageously unfair terms](https://open-web-advocacy.org/blog/owa-review-apple-dma-compliance-for-web/#apple%E2%80%99s-new-contract-for-browsers-that-wish-to-use-their-own-engine) and given that Apple is only allowed to have strictly necessary, proportional and heavily justified security clauses in the contract it will need to be rewritten in order to be compliant with the DMA.
+
+2. **Force both Apple and Google to let other browsers install web apps powered by their own engine**<br>
+	Currently Apple does not let browsers install web apps on iOS powered by the browsers own engine at all.  Google does not let other browsers install web apps properly to achieve full system integration via WebAPK minting which is locked to Chrome. Both companies must open this up to third party browsers to be compliant with the DMA.
+
+3. **Ensure users choice of  default browser is respected**<br>
+In many cases on both iOS and Android the user’s choice of default browser is completely ignored. The default browser should be opened or invoked when the user clicks on a link in a non-browser app. Instead in many cases it is silently hijacked and replaced by a completely different in-app browser. Neither the operating system or the non-browser apps on it should engage in browser-jacking.
+
+4. **Stop Apple from preventing browsers being listed on third party app stores on iOS**<br>
+As discussed earlier, Apple’s Core Technology Fee for API access is clearly designed to prevent developers from listing their apps on third party apps stores on iOS. Given that API access is mandated to be “free of charge” under the act, Apple will need to update this in order to be in compliance with the DMA.<br><br>
+Further having a separate alternative contract with which developers can opt into their rights under the DMA at different fee structures is both bizarre and ridiculous.
+
+5. **Stop companies self preferencing their own browser by their core platform services**<br>
+Apple, Google and Microsoft have all engaged in behaviours and dark patterns to self preference their browsers by their various designated core platform services. These behaviours are now prohibited in the EU by the DMA.
+
+6. **Safari needs to allow fair competition of competing payment providers**<br>
+Currently Safari only supports Apple Pay, as a core platform service Apple is obligated to update it so that the user can choose alternative payment providers.
+
+7. **Reduce the power of default browser with a choice screen**<br>
+Ensure that both Apple and Google implement effective designs for their browser choice screens. Specifically the choice screen should not self preference their own browsers, should grant the chosen browser the “hotseat” and should appear on all existing devices once and all new devices (including after backup and restore).
+
+8. **Ensure that backups and restore works for Web Apps**<br>
+Currently on both iOS and Android Web Apps are not included in device backups. This puts Web Apps at a disadvantage to Native Apps and needs to be fixed by both Apple and Google.
+
+To be clear these obligations needed to have been already met by today, the fact they aren't means that they are already in breach of the DMA.  From OWA’s perspective we will lodge complaints about gatekeepers who have not met their obligations unless they are making timely good faith efforts to push as quickly as possible towards compliance.
+
+## Why is this important?
+
+If fair and effective competition for both browsers and Web Apps was allowed, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often better than native apps.  Native Apps will still have a lead in cutting edge graphics and gaming technology but here’s the thing, if companies see the Web platform as viable, they’ll invest in it and this gap will get narrower and narrower.
+
+Over the next ten years the Web will provide more and more for consumers. Simply put, what the Web “can't do” is shrinking while its advantages are only increasing.
+
+But for certain clear anti-competitive behaviour, mobile Web Apps would already be viable and thriving. Absent laws to prevent them from doing so, large gatekeepers are incentivized to block products they can’t excessively tax OR that compete with their own products.
+
+The Web can do so much more on mobile, we just have to let it.
+
+## How can you help?
+
+OWA has so much more work to do advocating for the web all over the globe. We will always need your support, and you can do that in many ways:
+* [Donate to help with our running costs](https://open-web-advocacy.org/donate/)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* We need help with advocacy, engineering, documentation, outreach and help in each jurisdiction/country.
+* Comment on articles in the media
+* Keep sharing the message and our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/) and the [OWA blog](https://open-web-advocacy.org/blog/).

--- a/src/ja/posts/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition.md
+++ b/src/ja/posts/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition.md
@@ -1,0 +1,192 @@
+---
+title: UK’s Browser and Cloud Investigation may fail to allow Web App competition
+date: '2024-08-20'
+tags:
+  - Policy
+  - CMA
+  - UK
+author:
+  - OWA
+permalink: >-
+  /ja/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+**TL;DR:** We believe the UK Market Investigation Reference is missing [critical remedies](/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/#remedies). Most importantly *"Apple shall allow third-party browsers to install and manage Web Apps using their own browser engine."*. [**We need YOU to write to the CMA**](/blog/uk-browser-and-cloud-investigation-may-fail-to-allow-web-app-competition/#we-need-your-help!-act-today!) (before August 29th) and provide feedback on why allowing browsers to compete in providing Web App functionality is important.
+
+## What’s happening?
+
+As readers may recall, the UK Competition and Markets Authority launched a Market Investigation Reference (MIR) into [mobile browsers and cloud gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) on June 10th 2022. Apple was briefly able to halt this via legal technicalities but thankfully the [CMA won in the high court late last year restarting the investigation](https://open-web-advocacy.org/blog/cma-reopens-investigation-into-apple/).  
+
+From our extensive work in supporting the [Mobile Ecosystems Study](https://www.gov.uk/cma-cases/mobile-ecosystems-market-study), we know the key reason the [Market Investigation Reference into Browsers and Cloud Gaming](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) was launched was to enable the free, open and interoperable ecosystem of the web to contest Apple’s and Google’s app stores, reducing costs for UK’s consumers and businesses. While regulators across the world were focused on app stores, the UK was the only regulator that was looking towards the web and web apps to solve these issues on mobile ecosystems. This aim was made clear by the [opening statements of the Browsers and Cloud MIR](https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming):
+
+
+> We all rely on browsers to use the internet on our phones, and **the engines that make them work have a huge bearing on what we can see and do**. Right now, **choice in this space is severely limited** and that has real impacts – **preventing innovation and reducing competition from web apps**. We need to give innovative tech firms, many of which are ambitious start-ups, a fair chance to compete.
+> </br><cite>[Andrea Coscelli - Chief Executive of the UK's Competition and Markets Authority](https://www.gov.uk/government/news/cma-plans-market-investigation-into-mobile-browsers-and-cloud-gaming)</br>(emphasis added)
+</cite>
+
+Last week the browsers and cloud MIR released their [remedies paper](https://assets.publishing.service.gov.uk/media/66b484020808eaf43b50dea8/Working_paper_7_Potential_Remedies_8.8.24.pdf) outlining their initial thoughts on remedies and asking for feedback. While the paper contains a number of excellent remedies, not least of which is prohibiting Apple from banning browser engines from iOS, we are deeply concerned that the MIR will fail in its goal of allowing third party browsers to enable effective competition from Web Apps.
+
+<details>
+<summary>Full List of Remedies</summary>
+<br></br>
+
+This list is on page 21 of the [Browsers and Cloud Remedies Paper](https://assets.publishing.service.gov.uk/media/66b484020808eaf43b50dea8/Working_paper_7_Potential_Remedies_8.8.24.pdf).
+<br></br>
+**Issue 1 – Apple’s WebKit restriction**
+
+* A1 - Requirement for Apple to grant access to alternative browser engines to iOS.
+
+* A2 - Requirement for Apple to grant equivalent access to iOS to browsers using alternative browser engines. 
+
+* A3 - Requirement for Apple to grant equivalent access to APIs used by WebKit and Safari to browsers using alternative browser engines.
+
+**Issue 2 – Apple’s and Google’s control over supply of browser engines to restrict access to functionalities**
+
+* A4 - Requirement for Google to grant equivalent access to APIs used by Chrome.
+
+**Issue 3 – Apple preventing all rival browser vendors from offering remote tab IABs on iOS**
+
+* B1 - A requirement for Apple to enable remote tab IABs for WebKit-based browsers.
+
+* B2 - A requirement for Apple to enable remote tab IABs for browsers wishing to use alternative browser engines.
+
+**Issue 4 – Apple preventing rival browser engines from offering nonWebKit based webview IABs, including bundled engine IABs to app developers on iOS**
+
+* B3 - A requirement for Apple to allow alternative webviews to Apple’s iOS WKWebView.
+
+**Issue 5 – on Android, default settings and preinstallation of Android WebView make it difficult for app developers to use IABs based on alternative webviews**
+
+* No remedies proposed.
+
+**Issue 6 – Apple’s and Google’s IAB policies offer users limited choice and control in relation to which browser is used for IAB implementation in native apps**
+
+* B4 - A requirement for Apple and Google to implement remote tab IABs using the default browser.
+
+* B5 - A requirement for Apple and Google to make users aware of being in an IAB by implementing changes to the interface or implement disclosures.
+
+* B6 - A requirement for Apple and Google to implement opt-out settings for in-app browsing.
+
+**Issue 7 - Apple’s and Google’s control of choice architecture in factory settings**
+
+* C1 - A requirement for Apple and Google to ensure that multiple browsers are pre-installed, using defined criteria.
+
+* C2 - A requirement for Apple and Google to ensure the use of browser choice screens at device set-up.
+
+* C3 - A requirement for Apple and Google to ensure the placement of a default browser selected by the user in the ‘dock’ / ‘hot seat’ or on the default home screen at device set-up.
+
+* C4 - A requirement for Apple and Google to ensure that a user’s choice of default browser is always followed across all browser access points.
+
+**Issue 8 - Apple’s and Google’s use of certain choice architecture practices after device set-up**
+
+* C5 - A requirement for Apple and Google to ensure the use of browser choice screen(s) after device set-up.
+
+* C6 - A requirement for Apple and Google to make adaptations to the user journey for changing their default browser.
+
+* C7 - A requirement for Apple and Google to share user data on default browsers settings with browser vendors.
+
+* C8 - A requirement for Apple and Google to ensure that the frequency of default browser prompts and notifications is limited.
+
+* C9 - A requirement for Apple and Google to allow users to uninstall Safari browser app on iOS and Chrome on Android devices.
+
+**Issue 9 – Apple’s App Store policies in relation to cloud gaming services**
+
+* D1 - A requirement for Apple to review and amend its Guidelines to remove the specific restriction identified as restrictive and a prohibition on Apple introducing new restrictions with equivalent effect.
+
+* D2 - A requirement for Apple to enable cloud gaming native apps to operate on a ‘read-only’ basis (i.e. with no ingame purchases or subscriptions) so that games do not need to be re-coded and no commission would therefore be payable to Apple).
+
+**Issue 10 – app store rules in relation to in-app payment systems for in-game transactions**
+
+* D3 - A requirement for Apple and Google to allow CGSPs to incorporate their own or third party in-app payment systems for in-game transactions.
+
+</details>
+
+## Why might the MIR fail?
+
+In the remedies the MIR team is proposing both removing Apple’s rule banning browsers from using their own browser engines and obligating Apple to provide equivalent iOS API access to third party browser vendors that Safari and WebKit have.
+
+### 1. Browsers can’t Install Web Apps using their own Engine
+
+The problem is that these do not fix the core issue, namely, can browsers compete in the provision of Web App functionality using their own browser engine. Apple could plausibly argue that allowing browsers to use their own engine and providing them access to the share menu to install Apple’s WebKit implementation of Web Apps satisfies both requirements.
+
+This could lead to a situation where while browser engines such as Blink (Chrome, Edge, Opera, Vivaldi, DuckDuckGo, Brave) and Gecko (Firefox) could be ported to iOS, browser vendors would be unable to compete to improve the stability, functionality, security or privacy of Web Apps. This would still be under Apple’s sole control.
+
+As noted in the CMA’s mobile ecosystems study, Apple is heavily incentivized not to support Web Apps to their full potential. Certain features such as install prompts that would allow Web Apps to compete more fairly with Apple’s own apps and app store, will almost certainly never be implemented by Apple.
+
+> By requiring all browsers on iOS to use the WebKit browser engine, **Apple is able to exert control over the maximum functionality of all browsers on iOS** and, as a consequence, hold up the development and use of web apps. This limits the **competitive constraint that web apps pose on native apps**, which in turn protects and benefits Apple’s App Store revenues.
+> </br><cite>[UK CMA - Interim Report into Mobile Ecosystems](https://www.gov.uk/government/publications/mobile-ecosystems-market-study-interim-report)</br>(emphasis added)
+</cite>
+
+Worse when faced with the genuine possibility of third-party browsers effectively powering Web Apps due to the EU’s Digital Markets Act, Apple's first instinct was to [remove Web Apps support in the EU entirely with no notice to either businesses or consumers](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/). Luckily, [under significant pressure, Apple backed down](https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/) from this particular stunt at the last moment. 
+
+### 2. Browser Access to Software/Hardware APIs is Insufficient
+
+Next, the wording on remedy A3 ("Requirement for Apple to grant equivalent access to APIs used by WebKit and Safari to browsers using alternative browser engines.") is scoped to only what Safari and WebKit have access to, which is a problem as that could allow Apple to set a ceiling by blocking Safari from having access to stuff Apple does not intend to implement for the Web, i.e. Bluetooth, USB etc. If Apple is not under any legal obligation to share needed Software/Hardware APIs required to support browser or Web App features that Safari does not support, they will not provide access to those APIs.
+
+It is critical that Apple can not reserve functionality for its own apps, system services and apps delivered by its app store by blocking browser vendors access to the required hardware and software APIs. Where feasible browser vendors should have the right to provide feature parity to Web Apps.
+
+### 3. Web Apps can’t succeed without Install Prompts
+
+In order for Web Apps to have a significant opportunity to truly compete on iOS, Safari needs to implement [install prompts](https://web.dev/learn/pwa/installation-prompt/) (the ability for websites to prompt, or provide a button to install them as a Web App). Apple, understanding the importance of reducing friction, has implemented a large variety of ways to install apps from Apple’s app store via Safari including [smart banners](https://open-web-advocacy.org/walled-gardens-report/#smart-app-banners) and [app clips](https://open-web-advocacy.org/walled-gardens-report/#app-clips) while keeping the method of installing Web Apps [hidden away in the share menu](https://open-web-advocacy.org/walled-gardens-report/#ios-safari).
+
+<figure>
+    {% image
+        "/images/blog/InstallPrompts1.png",
+        "Example of Install Prompt in Chrome on Android",
+        null, null,
+        [150, 200, 300],
+        "150px"
+    %}
+    {% image
+        "/images/blog/InstallPrompts2.png",
+        "Example of Expanded Install Prompt in Chrome on Android",
+        null, null,
+        [150, 200, 300],
+        "150px"
+    %}
+    <figcaption>Example of Install Prompt in Chrome on Android</figcaption>
+</figure>
+
+## Remedies
+
+We believe four additional remedies needed in order to allow the Web to compete fairly on iOS:
+
+1. *"Apple shall allow third-party browsers to install and manage Web Apps using their own browser engine."*
+
+
+2. *"A requirement for Apple to implement Install Prompts for iOS Safari."*
+
+
+3. *"A requirement for Apple to grant all software and hardware access to APIs to browsers using alternative browser engines that they require to port their engines and implement stability, functionality, security and privacy. Restrictions on this can be subject to only strictly necessary, proportionate and justified security grounds."*
+
+
+4. *"Where feature parity between Web Apps and Native Apps is possible, Apple must technically enable it and it should not be artificially prevented either by OS rules or OS design. Apple must not self-preference their own Apps, Apps sold via their App Store or their own Services over Web Apps."*
+
+These remedies are required because Apple's actions not only hurt the Web ecosystem, third-party businesses (be they browser vendors or software developers), but also make their devices worse for their own consumers. By depriving their consumers of the choice and competition that fair and effective browser and Web App competition would bring, they are worsening the functionality, interoperability, stability, security, privacy, and price of services on their devices. This MIR has the power to fix this for the UK, which will be a significant step towards fixing the problem globally.
+
+After 3 years of work from the CMA, it would be incredibly disappointing to get to the end of the investigation without resolving the anti-competitive behaviour that is preventing web apps from succeeding and unlocking innovation.
+
+## We need your help! Act today!
+
+The CMA is asking for feedback by the end of **Thursday August 29th 2024** from interested parties, developers and businesses. This is your opportunity to provide feedback to the MIR team.
+
+**We need YOU to write to the CMA**, share your thoughts on the proposed remedies and any remedies you think may be missing. 
+
+If you share our concern that competition issues related to Web Apps will not be resolved by the remedies proposed, please state so in your letter and outline why this is important to you, your business and to the future of tech in the UK.
+
+If possible, explain the harm that has been caused by browsers not being able to compete in the provision of Web App functionality on iOS. 
+
+While we encourage readers to write longer submissions, short but clear emails that explain the key points are still immensely helpful.
+
+Please let the CMA know if your name, business or submission is confidential.
+
+**Please consider spending 15 minutes writing to the regulator. After years of campaigning, this is a critical moment to ensure the Web is able to thrive, and we will not be successful without your support!**
+
+**You should send your letter to the MIR team at [browsersandcloud@cma.gov.uk](mailto:browsersandcloud@cma.gov.uk).**
+
+If you have further questions or concerns about this topic, or your letter writing, please join us in Discord or drop us an email:
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+
+*Note: All mentions of iOS above including quotes from the MIR mean both iOS and iPadOS.*

--- a/src/ja/posts/uk-cma-browser-cloud-gaming-progress-report.md
+++ b/src/ja/posts/uk-cma-browser-cloud-gaming-progress-report.md
@@ -1,0 +1,62 @@
+---
+title: Browser and Cloud Gaming Market Investigation Update
+date: '2024-06-27'
+tags:
+  - Policy
+  - CMA
+  - UK
+author: OWA
+permalink: /ja/blog/uk-cma-browser-cloud-gaming-progress-report/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+The UK’s Competition and Markets Authority, [Browser and Cloud Gaming Market Investigation](https://www.gov.uk/cma-cases/mobile-browsers-and-cloud-gaming) has just released their progress report. Long time readers may remember that this investigation was restarted [after a high court win against Apple](https://open-web-advocacy.org/blog/apple-loses-on-appeal/).
+
+The report delves into Apple’s rule that all browsers on iOS must use the version of WebKit bundled with iOS which is under Apple’s exclusive control.
+
+> The requirement that all browsers on the iOS operating system use a specific version of the WebKit browser engine controlled by Apple, means that there is no competition between browser engines on the platform. Browser vendors cannot switch to an alternative browser engine or make changes to the version of WebKit used on iOS. Similarly, consumers are unable to switch to a browser based on an alternative browser engine. We consider that the lack of competitive pressure is likely to reduce Apple’s incentives to improve WebKit.
+
+> In addition, we have obtained evidence indicating that browser vendors incur 
+additional costs from having to develop and support a version of their browser 
+based on WebKit, which they would not do if the restriction were not in place. 
+Evidence from browser vendors also indicates that Apple is difficult to engage with 
+regarding requests for fixes or the addition of new features to WebKit on iOS.
+
+> Whilst Apple has submitted that the WebKit restriction is necessary to ensure the 
+security, privacy, and performance of iOS devices, and that this is an important 
+aspect of competition between iOS and Android devices, the evidence we have 
+seen to date does not support this conclusion.
+
+Interestingly the report also states that iOS and Android should be considered separate markets for browsers.
+
+> it is our emerging thinking that the supply of mobile browsers on iOS and Android should be considered as two separate product markets”
+
+This market investigation reference was launched by CMA’s Market Study into Mobile Ecosystems. In the [reference decision](https://assets.publishing.service.gov.uk/media/637b65c0d3bf7f7208f6c709/reference_decision__1_.pdf) to the market investigation reference they listed the following potential remedies:
+
+* removing Apple’s restrictions on competing browser engines on iOS devices;
+* mandating access to certain functionality for browsers (including supporting web apps);
+* requiring Apple and Google to provide equal access to functionality through APIs for rival browsers;
+* requirements that make it more straightforward for users to change the default browser within their device settings;
+* choice screens to overcome the distortive effects of pre-installation; and
+* requiring Apple to remove its App Store restrictions on cloud gaming services.
+
+Separately the powers of the CMA has just been significantly strengthened [with the passing of the Digital Markets, Competition and Consumers Bill](https://open-web-advocacy.org/blog/uk-passes-dmcc/). This will allow them to impose “codes of conduct” on large tech firms with “strategic market status”. This is entirely separate from the market investigation reference, however they will likely read each other’s report.
+
+We hope that the CMA will end Apple’s effective ban on third party browsers on iOS either via the MIR or the powers granted by the DMCC bill. 
+
+Right now, if competition was restored, 90% of the apps on your phone could be written as a Web App and would be indistinguishable, significantly cheaper and often BETTER than Native Apps. Native Apps will still have a lead in cutting edge graphics and gaming technology but if companies see the web platform as viable this gap will decrease over time.
+
+It is for this reason that allowing browser competition on iOS is critical. Apple’s effective browser ban prevents the emergence of such an open and free universal platform for mobile apps. Unlike desktop, developers cannot build their application once and have it work across all consumer devices. Instead, these policies combine with Apple’s trailing and feature-poor engine to force companies to create separate applications for iOS, significantly raising the cost and complexity of development and maintenance. This severely undermines any interoperability advantages Web Apps have between iOS and Android. A single prominent OS holding back the Web is enough to undermine its entire value proposition as a frictionless, capable and secure distribution mechanism for Web Apps.
+
+The fight to allow browser and Web App competition on iOS is not over. We would like to thank everyone for their support over the last 3 years and ask that consumers, developers and businesses write in and engage with the market investigation reference to arm them with all the data and information they need to successfully restore competition to a broken mobile ecosystem.
+
+Stay tuned as we will be posting about its progress as more information becomes available.
+
+
+- **Email:**        [contactus@open-web-advocacy.org](mailto:contactus@open-web-advocacy.org)
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **LinkedIn:**     [open-web-advocacy](https://www.linkedin.com/company/open-web-advocacy/)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/uk-passes-DMCC.md
+++ b/src/ja/posts/uk-passes-DMCC.md
@@ -1,0 +1,31 @@
+---
+title: 'UK passes Digital Markets, Competition and Consumers Bill'
+date: '2024-05-23'
+tags:
+  - Policy
+  - UK
+author: OWA
+permalink: /ja/blog/uk-passes-DMCC/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+## UK passes Digital Markets, Competition and Consumers Bill
+
+On 23rd May, the Digital Markets, Competition and Consumers Bill was passed in Parliament. It is currently awaiting Royal Assent. As the [UK Government explains](https://www.gov.uk/government/news/new-bill-to-crack-down-on-rip-offs-protect-consumer-cash-onlineand-boost-competition-in-digital-markets), the Bill was introduced 
+
+> to crack down on rip-offs, protect consumer cash online and boost competition in digital markets.
+
+Most importantly for us, the new Act gives more powers to the UK's monopoly regulator, the [Competition and Markets Authority](https://www.gov.uk/government/organisations/competition-and-markets-authority) (CMA):
+
+> The CMA will be able to directly enforce consumer law rather than go through lengthy court processes…
+>
+> As part of the Bill, a Digital Markets Unit (DMU) within the CMA will be given new powers to tackle the excessive dominance that a small number of tech companies have held over consumers and businesses in the UK…
+> 
+> For example, the biggest tech firms may be instructed by the DMU to provide more choice and transparency to their customers. If firms don’t abide by these rules, the DMU will have the power to fine them up to 10% of their global turnover.
+
+OWA looks forward to continuing working with the CMA to bring about a fairer competitive landscape so that smaller British companies can serve their consumers as they wish to, rather than as Tech giants dictate.
+
+### Update 28 May: CMA opens consultation on digital markets competition regime
+
+The next working day after the DMCC became law, the CMA announced an [Open Consultation on digital markets competition regime guidance](https://www.gov.uk/government/consultations/consultation-on-digital-markets-competition-regime-guidance) which runs until 11:55pm on 12 July 2024. Let them know what you think; they're listening.  

--- a/src/ja/posts/us-doj-files-apple-antitrust-case.md
+++ b/src/ja/posts/us-doj-files-apple-antitrust-case.md
@@ -1,0 +1,27 @@
+---
+title: US Department of Justice files Antitrust lawsuit Against Apple
+date: '2024-03-21'
+tags:
+  - Policy
+  - Apple
+  - US
+author: OWA
+permalink: /ja/blog/us-doj-files-apple-antitrust-case/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+Today, the contents of the US Department of Justice [antitrust lawsuit against Apple were revealed](https://www.404media.co/us-government-antitrust-case-against-apple-documents/). The DOJ along with 16 State's Attorneys General are co-litigants against Apple, claiming a series of unlawful behaviours by the tech giant.
+
+The suit is wide sweeping, and takes issue with Apple's monopolising tactics in the smartphone market.  But, flipping to page 22, we see details of particular interest to OWA and the #AppleBrowserBan:
+
+> "Developers cannot avoid Apple’s control of app distribution and app creation by making web apps—apps created using standard programming languages for web-based content and available over the internet—as an alternative to native apps. **Many iPhone users do not look for or know how to find web apps, causing web apps to constitute only a small fraction of app usage.** Apple recognizes that web apps are not a good alternative to native apps for developers. As one Apple executive acknowledged, “[d]evelopers can’t make much money on the web.” Regardless, **Apple can still control the functionality of web apps because Apple requires all web browsers on the iPhone to use WebKit, Apple’s browser engine—the key software components that third-party browsers use to display web content.**"
+
+The entire suit is fantastic reading for anyone fed up with the bullying tactics of Apple. With this news following so tightly on from the [EU's Digital Markets Act coming into effect](https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/), the dominos are beginning to fall in favour of a fairer, better Open Web!
+
+Stay tuned for more detailed analysis soon.
+
+- **Mastodon:**      [@OpenWebAdvocacy](https://mastodon.social/@owa)
+- **Discord:**      [OpenWebAdvocacy](https://discord.gg/x53hkqrRKx)
+- **Twitter:**      [@OpenWebAdvocacy](https://twitter.com/OpenWebAdvocacy)
+- **Web:**         [https://open-web-advocacy.org](https://open-web-advocacy.org)

--- a/src/ja/posts/website-under-development.md
+++ b/src/ja/posts/website-under-development.md
@@ -1,0 +1,13 @@
+---
+title: OWA has a new website!
+date: '2022-03-02'
+tags:
+  - Meta
+author: James Moore
+permalink: /ja/blog/website-under-development/index.html
+layout: layouts/post.njk
+translated: false
+---
+A team of enthusiastic volunteers has got to work on [OWA](/)'s new site.
+
+To join them, [visit the Github](https://github.com/OpenWebAdvocacy/website).

--- a/src/ja/posts/webventures-an-abridged-history-of-safari-showstoppers.md
+++ b/src/ja/posts/webventures-an-abridged-history-of-safari-showstoppers.md
@@ -1,0 +1,45 @@
+---
+title: 'Webventures: An Abridged History of Safari Showstoppers'
+date: '2024-09-25'
+tags:
+  - Policy
+  - Apple
+  - iOS
+  - Safari
+author:
+  - OWA
+permalink: /ja/blog/webventures-an-abridged-history-of-safari-showstoppers/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+This week, Webventures [published an article outlining various bugs and problems in iOS Safari over the last several years](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/) that were absolute showstoppers for the Web being a competitive constraint and substitute for mobile app stores.
+
+>iOS Safari is more than an inconvenience for developers, it's the fundamental reason interoperability has been stymied in mobile ecosystems; frequent showstopping bugs, a large patch gap, and lack of competing engines ensures the web is not a credible competitor to native. Here are the receipts to prove it
+><cite>[Webventures](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/)</cite>
+
+This is an [excellent and comprehensive article](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/) and we recommend reading it in full.
+
+Web Apps are being held back as businesses and developers can not be confident that they will consistently work on iOS, a platform no business can ignore without losing (in many cases) more than half their customers. 
+
+The critical issue here is that regulators can not regulate a browser not to have bugs or to fix them quickly. Browsers are complex and some level of bugs is to be expected. Browser vendors also need to work out which bugs to prioritise. The problem here is [lack of effective browser competition on iOS](https://open-web-advocacy.org/walled-gardens-report/#effective-competition%3F).
+
+This is due to [Apple's decision to ban rival browsers such as Firefox, Chrome, Edge, Opera, Vivaldi and Brave from porting their "real" browsers to iOS using their own engines](https://open-web-advocacy.org/walled-gardens-report/#apple-has-effectively-banned-all-third-party-browsers). Apple does this by rule 2.5.6 of their app store guidelines.
+
+When a critical bug breaks Web Apps on iOS for months, Apple has no great fear it will lose Safari users to rival browsers because they are introducing the exact same bugs into their rivals browsers via imposing their browser engine on third-party browsers. Rival browser vendors have very little control here when it comes to stability on iOS. This lack of fear of losing users removes a powerful incentive to be better.
+
+The solution is clear: fair and effective browser competition on iOS globally. This involves both allowing browser vendors to port their browsers, removing rules that prevent them from competing and giving the software and hardware API access they need to implement and compete in features, stability, performance security and privacy. This will place great pressure on Apple to improve and improve fast. It also provides an alternative for both developers and consumers should they fail to do so.
+
+Already we can see that regulatory pressure has led to some improvement but in order to be truly effective the underlying competition issues need to be fixed, and fixed globally.
+
+## How can you help?
+
+If you spot any mistakes or have additional issues that you believe should be included please [contact the author](https://webventures.rejh.nl/blog/2024/history-of-safari-show-stoppers/#anchor--did-we-miss-anything). If any of the unfixed tickets referenced in the article are important to you or your team, **please comment on them**; this is important as it's evidence to both Apple and regulators that these issues are important and need to be fixed. If you're active on social media, you can point Safari developer relations to the link to your comment, too.
+
+As an organisation, our aim is to allow fair and effective browser and Web App competition on all major consumer operating systems. OWA has so much more work to do advocating for the web all over the globe. 
+
+We will always need your support, and you can do that in many ways:
+* [Donate to help with our running costs](https://www.paypal.com/donate/?hosted_button_id=3FD5DUWT4DNBG)
+* [Join our community of volunteers and supporters on Discord](https://discord.com/invite/x53hkqrRKx)
+* Comment on articles in the media
+* Keep sharing our campaigns and follow us on social media on [Twitter/X](https://twitter.com/OpenWebAdvocacy), [Mastodon](https://mastodon.social/@owa) and [LinkedIn](https://www.linkedin.com/company/open-web-advocacy/).

--- a/src/ja/posts/why-browser-choice-matters.md
+++ b/src/ja/posts/why-browser-choice-matters.md
@@ -1,0 +1,34 @@
+---
+title: Why is browser choice vital for the future of the Open Web?
+date: '2023-11-13'
+tags:
+  - Browsers
+author: Frances Berriman
+permalink: /ja/blog/why-browser-choice-matters/index.html
+layout: layouts/post.njk
+translated: false
+---
+
+OWA’s key goal is to enable true competition and browser choice across all devices. But, why do we care so deeply about this, and what would success look like?
+
+### Cost
+
+Currently, businesses that want to grow across many markets must develop not only a good website, but also native apps for any platforms they want to reach that don’t have [modern browser features available](https://infrequently.org/2021/04/progress-delayed/). Additionally, deriving most of their user base from native applications and app stores mean that they’re forced into giving a cut to those app stores (usually 30% of any payments made through the app store). It’s not uncommon for businesses to [pass that fee on to users as an extra cost](https://www.washingtonpost.com/technology/2023/02/24/apps-subscription-costs/).
+
+In a fairer world, businesses would be able to rely on modern web browsers being available to all of their users, regardless of the platform they choose, enabling businesses to opt out of app stores and serve their customers from a single application, avoiding the app-store tax.
+
+### Privacy and Security
+
+Although the web in general has a variety of issues in regards to privacy (hello ad-trackers!), browsers offer a sandboxed experience that is superior to native app security - Apple even knows this, and spoke about it in their recent [filing to the EU](https://assets.publishing.service.gov.uk/media/62277271d3bf7f158779fe39/Apple_11.3.22.pdf). 
+
+With that said, browsers that are stuck inside native applications are at the mercy of that application - [information can be freely read and tracked](https://infrequently.org/2021/07/hobsons-browser/) - so with browser choice available to an end user, they can regain control of their privacy and deprive those that would like to farm their data from their behaviours within their applications.
+
+### Innovation
+
+The most obvious reason that a lack of competition is an issue for everyone is it stifles innovation. With no fair way to deploy new browsers to all users, no new ones will be born. [The market is already showing this](https://gs.statcounter.com/browser-market-share#yearly-2009-2023) by the practical loss of Opera and the downward trend of Firefox - neither can succeed in today’s market.
+
+Currently, Google and Apple run a duopoly that essentially ensures that they are the only two active participants in deciding what happens to the open web (and mobile computing, in general), because they disallow anyone else to compete against them, preferentially favouring their own, closed, ecosystems of native apps. 
+
+If you want a choice in which company you trust with your web experience, the businesses that create those options need to know they have a fair chance to succeed. 
+
+If you want to read more about why closed ecosystems are a problem, take a look at our [Walled Gardens Report](/walled-gardens-report/). 

--- a/src/ja/robot-meta/tags.md
+++ b/src/ja/robot-meta/tags.md
@@ -1,0 +1,19 @@
+---
+title: Tag Archive
+layout: layouts/feed.njk
+pagination:
+  data: collections
+  size: 1
+  alias: tag
+  filter:
+    - all
+    - nav
+    - blog
+    - work
+    - featuredWork
+    - people
+    - rss
+permalink: '/ja/tag/{{ tag | slug }}/'
+translated: false
+---
+


### PR DESCRIPTION
## Related Issue
Second of three PRs to resolve https://github.com/OpenWebAdvocacy/website/issues/182. One further PR to come for full resolution.

## Summary of Changes
1. [x] Add script to autogenerate non-translated pages for each language
2. [x] Update contributing.md with new language instructions
3. [x] Generated missing non-translated pages for Spanish and Japanese

### Notes
Each page/post/tag included in this PR is a duplicate of the english version with the front matter updated to:
- Update or add the permalink to include the language code
- Add `translated: false` which the final following PR will hook into to display a "not yet translated" banner
- Add layout to blog posts

The main content of the file has not been altered. 

The "not yet translated" banner will be added in a subsequent PR.

### Testing
- View the preview and update the langauge with the toggle to Spanish or Japanese
- Confirm links in the header, footer, blog, and sidebar take you to a page with the same language. You can tell its the same langauge by the language code in the url and the header/footer/sidebar text. The main content of the page will still be in english because this has not been translated. 