### PR TITLE
Fix tiny typo in `languages_base.json`

### DIFF
--- a/src/_data/languages_base.json
+++ b/src/_data/languages_base.json
@@ -65,7 +65,7 @@
     "languages": "言語",
     "language": "日本語",
     "pressCoverageHeading": "OWAのメディア報道",
-    "pressCoverageParagraph": "メディアにがOWAの活動をどのように報道しているか確認してください。",
+    "pressCoverageParagraph": "メディアがOWAの活動をどのように報道しているか確認してください。",
     "promoHeading": "プロモーション・リソース",
     "promoParagraph": "オープンなウェブへの支持を表明するために、ロゴや宣伝用イラストを自由に印刷して使用できます。",
     "rssFeedHeading": "RSSフィード",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N/A

## Summary of Changes
Sorry, I found a very small typo in my previous Japanese translation (forgot deleting just one character).