### PR TITLE
Add translation banner under header

### DIFF
--- a/src/_data/languages_base.json
+++ b/src/_data/languages_base.json
@@ -25,7 +25,8 @@
     "rssFeedHeading": "RSS feed",
     "rssFeedParagraph": "Subscribe to the latest news from OWA.",
     "siteFooterPoweredBy": "This site is powered by Netlify",
-    "skipLinkText": "Skip to content"
+    "skipLinkText": "Skip to content",
+    "translationNotAvailable": "Unfortunately this page has not been translated into your preferred language yet. If you'd like to help us translate it, please join #translation on the OWA discord."
   },
   "es": {
     "ariaLabelPaginationlinks": "Enlaces de paginación",
@@ -48,7 +49,8 @@
     "rssFeedHeading": "Feed RSS",
     "rssFeedParagraph": "Suscríbete a las últimas noticias de OWA.",
     "siteFooterPoweredBy": "Este sitio funciona con Netlify",
-    "skipLinkText": "Saltar al contenido"
+    "skipLinkText": "Saltar al contenido",
+    "translationNotAvailable": "Lamentablemente, esta página aún no se ha traducido a tu idioma preferido. Si deseas ayudarnos a traducirla, únete a #translation en el Discord de OWA."
   },
   "ja": {
     "ariaLabelPaginationlinks": "ページネーションリンク",
@@ -71,6 +73,7 @@
     "rssFeedHeading": "RSSフィード",
     "rssFeedParagraph": "OWAの最新ニュースを購読する。",
     "siteFooterPoweredBy": "このサイトはNetlifyを利用しています",
-    "skipLinkText": "コンテンツにスキップする"
+    "skipLinkText": "コンテンツにスキップする",
+    "translationNotAvailable": "残念ながら、このページはまだ日本語に翻訳されていません。翻訳にご協力いただける場合は、OWA Discord の #translation にご参加ください。"
   }
 }

--- a/src/_data/languages_base.json
+++ b/src/_data/languages_base.json
@@ -26,7 +26,7 @@
     "rssFeedParagraph": "Subscribe to the latest news from OWA.",
     "siteFooterPoweredBy": "This site is powered by Netlify",
     "skipLinkText": "Skip to content",
-    "translationNotAvailable": "Unfortunately this page has not been translated into your preferred language yet. If you'd like to help us translate it, please join #translation on the OWA discord."
+    "translationNotAvailable": "Unfortunately this page has not been translated into your preferred language yet. If you'd like to help us translate it, please join <a href=\"https://discord.gg/x53hkqrRKx\">#translation on the OWA discord</a>."
   },
   "es": {
     "ariaLabelPaginationlinks": "Enlaces de paginación",
@@ -50,7 +50,7 @@
     "rssFeedParagraph": "Suscríbete a las últimas noticias de OWA.",
     "siteFooterPoweredBy": "Este sitio funciona con Netlify",
     "skipLinkText": "Saltar al contenido",
-    "translationNotAvailable": "Lamentablemente, esta página aún no se ha traducido a tu idioma preferido. Si deseas ayudarnos a traducirla, únete a #translation en el Discord de OWA."
+    "translationNotAvailable": "Lamentablemente, esta página aún no se ha traducido a tu idioma preferido. Si deseas ayudarnos a traducirla, únete a <a href=\"https://discord.gg/x53hkqrRKx\">#translation en el Discord de OWA</a>."
   },
   "ja": {
     "ariaLabelPaginationlinks": "ページネーションリンク",
@@ -74,6 +74,6 @@
     "rssFeedParagraph": "OWAの最新ニュースを購読する。",
     "siteFooterPoweredBy": "このサイトはNetlifyを利用しています",
     "skipLinkText": "コンテンツにスキップする",
-    "translationNotAvailable": "残念ながら、このページはまだ日本語に翻訳されていません。翻訳にご協力いただける場合は、OWA Discord の #translation にご参加ください。"
+    "translationNotAvailable": "残念ながら、このページはまだ日本語に翻訳されていません。翻訳にご協力いただける場合は、<a href=\"https://discord.gg/x53hkqrRKx\">OWA Discord の #translation</a> にご参加ください。"
   }
 }

--- a/src/_data/languages_base.json
+++ b/src/_data/languages_base.json
@@ -26,7 +26,7 @@
     "rssFeedParagraph": "Subscribe to the latest news from OWA.",
     "siteFooterPoweredBy": "This site is powered by Netlify",
     "skipLinkText": "Skip to content",
-    "translationNotAvailable": "Unfortunately this page has not been translated into your preferred language yet. If you'd like to help us translate it, please join <a href=\"https://discord.gg/x53hkqrRKx\">#translation on the OWA discord</a>."
+    "translationNotAvailable": "Unfortunately this page has not been translated into your preferred language yet. If you'd like to help us translate it, please join <a href=\"https://discord.gg/x53hkqrRKx\">#translation on the OWA Discord</a>."
   },
   "es": {
     "ariaLabelPaginationlinks": "Enlaces de paginación",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -57,11 +57,14 @@
     {% else %}
       {% include "partials/site-header.njk" %}
     {% endif %}
+    {% if translated === false %}
+      {% include "partials/banner-translation.njk" %}
+    {% endif %}
     {% if isHome %}
       {% block homecontent %}{% endblock %}
     {% else %}
       <div class="inner-wrapper">
-        <main tabindex="-1" id="main-content" class="inner"> {% block content %}{% endblock %}
+        <main tabindex="-1" id="main-content" class="inner" {% if translated === false %} lang="en" {% endif %}> {% block content %}{% endblock %}
           {% if not isPaperLayout %}
             {% set postListItems = collections.blog %}
           {% endif %}

--- a/src/_includes/partials/banner-translation.njk
+++ b/src/_includes/partials/banner-translation.njk
@@ -1,5 +1,5 @@
 {% set content = languages_base[page.lang] %}
 
 <div class="banner">
-  <p>{{ content.translationNotAvailable}}</p>
+  <p>{{ content.translationNotAvailable | safe }}</p>
 </div>

--- a/src/_includes/partials/banner-translation.njk
+++ b/src/_includes/partials/banner-translation.njk
@@ -1,0 +1,5 @@
+{% set content = languages_base[page.lang] %}
+
+<div class="banner">
+  <p>{{ content.translationNotAvailable}}</p>
+</div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1375,6 +1375,22 @@ img.rounded {
   border-radius: 0.5rem;
 }
 
+/* Banners */
+
+.banner {
+  background: var(--n-light);
+  padding: 1em;
+  text-align: center;
+
+  p {
+    max-width: none;
+  }
+}
+
+.site-header:has(+ .banner) {
+  margin-bottom: 0;
+}
+
 .emergency-banner {
   color: var(--text-inv);
   background-color: var(--main-dark);


### PR DESCRIPTION
## Related Issue
Final PR to resolve https://github.com/OpenWebAdvocacy/website/issues/182 (3/3)

## Summary of Changes

1. [x] Add new translation banner to base template underneath navigation header

Note: Banner copy translations into Spanish and Japanese were verified in closed PR #193. 

## Testing

- View any page in another language that has not been translated yet, eg  https://deploy-preview-202--owa-production.netlify.app/ja/blog/
- Confirm banner appears

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5704e9d4-bc70-4398-bb50-92f170f6ccf6" />

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/5d7792ab-76a3-4872-aa71-51a06be9f955" />
