### PR TITLE
Added basic json schema markup

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -12,6 +12,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+    {% include "partials/schema-json.njk" %}
     {% include "partials/meta-info.njk" %} <link rel="alternate" type="application/rss+xml" href="{{ site.url }}/feed.xml"/>
     <link rel="me" href="https://mastodon.social/@owa"/>
     <link

--- a/src/_includes/partials/schema-json.njk
+++ b/src/_includes/partials/schema-json.njk
@@ -1,0 +1,39 @@
+<script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": ["Organization", "NGO"],
+        "@id": "https://en.wikipedia.org/wiki/Open_Web_Advocacy",
+        "url": "https://open-web-advocacy.org",
+        "name": "Open Web Advocacy",
+        "alternateName": "OWA",
+        "email": "contactus@open-web-advocacy.org",
+        "description": "Open Web Advocacy (OWA) is an international not-for-profit digital rights group, consisting mostly of individual software engineers who are advocating for the future of the open web.",
+        "logo": "https://open-web-advocacy.org/images/prom-gallery/logo-full-white.svg",
+        "image": "https://open-web-advocacy.org/images/prom-gallery/logo-full-white.svg",
+        "foundingDate": "2021",
+        "founder": [
+            {
+                "@type": "Person",
+                "name": "Alex Moore"
+            },
+            {
+                "@type": "Person", 
+                "name": "James Moore"
+            }
+        ],
+        "sameAs": [
+            "https://open-web-advocacy.org",
+            "https://en.wikipedia.org/wiki/Open_Web_Advocacy", 
+            "https://mastodon.social/@owa",
+            "https://x.com/OpenWebAdvocacy",
+            "https://www.youtube.com/@openwebadvocacy"
+        ],
+        "areaServed": "Worldwide",
+        "knowsAbout": [
+            "Digital Rights",
+            "Internet Activism",
+            "Web Browser Technology",
+            "Progressive Web Apps"
+        ]
+    }
+</script>


### PR DESCRIPTION
## Summary of Changes
Added a JSON Schema to improve our search engine visibility. It essentially hints search engines like google what other internet properties belong to the OWA (like our mastodon, youtube, wiki etc) and on Google it should theoretically give us an organization card/panel on the right side. 

p.s. I created a separate partial for the json object to not increase the length of the `base.njk` file too much. I'm guessing the `include` should work — never tried including inline JSON this way with Nunjucks before — but please feel free to double check it 😅