### PR TITLE
Capitalize tags via CSS, not njk filter

### DIFF
--- a/src/_includes/partials/post-meta.njk
+++ b/src/_includes/partials/post-meta.njk
@@ -5,7 +5,7 @@
         <ul class="tags-list" aria-label="Tags">
         {% for tag in tags %}
             <li>
-            <a href="{{ ('/tag/' + (tag | slug) + '/') | locale_url }}" class="p-category">#{{ tag | replace(' ', '') | capitalize }}</a>
+            <a href="{{ ('/tag/' + (tag | slug) + '/') | locale_url }}" class="p-category">#{{ tag | replace(' ', '') }}</a>
             </li>
         {% endfor %}
         </ul>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1204,6 +1204,7 @@ p.social {
 .tags-list {
   margin: 0;
   list-style: none;
+  text-transform: capitalize;
   font-variation-settings: var(--fvs-bold);
   color: #666;
 }


### PR DESCRIPTION
## Summary of Changes

Capitalize tags via CSS, not njk filter (the njk filter forces all characters except the first to lowercase, which changes "EU" to "Eu", "DMA" to "Dma", etc.

<img width="1290" height="490" alt="image" src="https://github.com/user-attachments/assets/0446ec85-a2f7-4f60-a622-038cf294a328" />

1. [x] Remove njk `capitalize` filter for tags
2. [x] Add `text-transform: capitalize;` for `.tags-list`