### PR TITLE
Fix typo: 'Bytedance' should be 'ByteDance'

### DIFF
--- a/src/es/pages/apple-dma-review.html
+++ b/src/es/pages/apple-dma-review.html
@@ -5290,7 +5290,7 @@ translated: false
       <dd>271 pages</dd>
       <dt>Meta</dt>
       <dd>57</dd>
-      <dt>Bytedance</dt>
+      <dt>ByteDance</dt>
       <dd>52 pages</dd>
       <dt>Amazon</dt>
       <dd>32 pages</dd>

--- a/src/es/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
+++ b/src/es/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
@@ -9,7 +9,7 @@ tags:
   - Google
   - Microsoft
   - Meta
-  - Bytedance
+  - ByteDance
 author: OWA
 permalink: /es/blog/its-time-for-a-fairer-more-competitive-app-ecosystem/index.html
 layout: layouts/post.njk
@@ -80,7 +80,7 @@ The following issues remain unresolved:
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-**Bytedance:**
+**ByteDance:**
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
@@ -89,6 +89,3 @@ For this reason we are adding our voice to many others asking for a fairer, more
 We urge MEPs of the ECON and IMCO Committees to hold the gatekeepers accountable for compliance with the DMA.
 
 Read [our joint letter here](/files/Open%20Letter%20-%20DMA%20enforcement.pdf).
-
-
-

--- a/src/es/posts/owa-2024-review.md
+++ b/src/es/posts/owa-2024-review.md
@@ -242,7 +242,7 @@ There are still a vast amount of issues to fix here, and we will continue to wor
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-#### Bytedance
+#### ByteDance
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 

--- a/src/es/posts/the-digital-markets-act-is-in-force-what-happens-now.md
+++ b/src/es/posts/the-digital-markets-act-is-in-force-what-happens-now.md
@@ -7,7 +7,7 @@ tags:
   - Google
   - Microsoft
   - Meta
-  - Bytedance
+  - ByteDance
   - EU
 author: OWA
 permalink: /es/blog/the-digital-markets-act-is-in-force-what-happens-now/index.html
@@ -21,7 +21,7 @@ The Digital Markets Act (DMA) grace period for gatekeepers to comply has now end
 
 The DMA comes with serious teeth, they have the power to fine gatekeepers up to 10% of global revenue repeatedly until they comply with the act. For reference Apple had a global revenue of $383 billion USD in 2023 and their net profit was $100 billion USD, meaning that the maximum cost of a single fine under the DMA is $38.3 billion USD, a sum any gatekeeper would surely blink at. In the case of repeated non-compliance they can fine up-to 20% of global revenue in a single fine. 
 
-Currently there are six gatekeepers who have been designated: Amazon, Apple, Bytedance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
+Currently there are six gatekeepers who have been designated: Amazon, Apple, ByteDance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
 
 These gatekeepers have a number of “core platform services” that have been formally designated under the DMA. To be automatically designated the service must have at least  45 million users in the EU and at least ten thousand business users. Further they need to be of a type of platform covered by the act. Currently the types listed in the act are:
 * online intermediation services

--- a/src/ja/pages/apple-dma-review.html
+++ b/src/ja/pages/apple-dma-review.html
@@ -5290,7 +5290,7 @@ translated: false
       <dd>271 pages</dd>
       <dt>Meta</dt>
       <dd>57</dd>
-      <dt>Bytedance</dt>
+      <dt>ByteDance</dt>
       <dd>52 pages</dd>
       <dt>Amazon</dt>
       <dd>32 pages</dd>

--- a/src/ja/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
+++ b/src/ja/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
@@ -9,7 +9,7 @@ tags:
   - Google
   - Microsoft
   - Meta
-  - Bytedance
+  - ByteDance
 author: OWA
 permalink: /ja/blog/its-time-for-a-fairer-more-competitive-app-ecosystem/index.html
 layout: layouts/post.njk
@@ -80,7 +80,7 @@ The following issues remain unresolved:
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-**Bytedance:**
+**ByteDance:**
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
@@ -89,6 +89,3 @@ For this reason we are adding our voice to many others asking for a fairer, more
 We urge MEPs of the ECON and IMCO Committees to hold the gatekeepers accountable for compliance with the DMA.
 
 Read [our joint letter here](/files/Open%20Letter%20-%20DMA%20enforcement.pdf).
-
-
-

--- a/src/ja/posts/owa-2024-review.md
+++ b/src/ja/posts/owa-2024-review.md
@@ -242,7 +242,7 @@ There are still a vast amount of issues to fix here, and we will continue to wor
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-#### Bytedance
+#### ByteDance
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 

--- a/src/ja/posts/the-digital-markets-act-is-in-force-what-happens-now.md
+++ b/src/ja/posts/the-digital-markets-act-is-in-force-what-happens-now.md
@@ -7,7 +7,7 @@ tags:
   - Google
   - Microsoft
   - Meta
-  - Bytedance
+  - ByteDance
   - EU
 author: OWA
 permalink: /ja/blog/the-digital-markets-act-is-in-force-what-happens-now/index.html
@@ -21,7 +21,7 @@ The Digital Markets Act (DMA) grace period for gatekeepers to comply has now end
 
 The DMA comes with serious teeth, they have the power to fine gatekeepers up to 10% of global revenue repeatedly until they comply with the act. For reference Apple had a global revenue of $383 billion USD in 2023 and their net profit was $100 billion USD, meaning that the maximum cost of a single fine under the DMA is $38.3 billion USD, a sum any gatekeeper would surely blink at. In the case of repeated non-compliance they can fine up-to 20% of global revenue in a single fine. 
 
-Currently there are six gatekeepers who have been designated: Amazon, Apple, Bytedance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
+Currently there are six gatekeepers who have been designated: Amazon, Apple, ByteDance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
 
 These gatekeepers have a number of “core platform services” that have been formally designated under the DMA. To be automatically designated the service must have at least  45 million users in the EU and at least ten thousand business users. Further they need to be of a type of platform covered by the act. Currently the types listed in the act are:
 * online intermediation services

--- a/src/pages/apple-dma-review.html
+++ b/src/pages/apple-dma-review.html
@@ -5289,7 +5289,7 @@ paperSize: '4.95 MB'
       <dd>271 pages</dd>
       <dt>Meta</dt>
       <dd>57</dd>
-      <dt>Bytedance</dt>
+      <dt>ByteDance</dt>
       <dd>52 pages</dd>
       <dt>Amazon</dt>
       <dd>32 pages</dd>

--- a/src/posts/apples-browser-engine-ban-persists-even-under-the-dma.md
+++ b/src/posts/apples-browser-engine-ban-persists-even-under-the-dma.md
@@ -29,7 +29,7 @@ Our primary concern is [Apple's rule banning third-party browser engines from iO
 
 We engaged extensively with the UK's CMA and the EU on this topic and to our delight specific text was added to the EU's Digital Markets Act **explicitly prohibiting the banning of third-party browser engines,** and stating that the purpose was to prevent gatekeepers from determining the performance, stability and functionality of third-party browsers **and the web apps they power**.
 
-The first batch of designated gatekeepers Apple, Google, Meta, Amazon, Bytedance, Microsoft **were required to be in compliance with the DMA by March 7th, 2024.**
+The first batch of designated gatekeepers Apple, Google, Meta, Amazon, ByteDance, Microsoft **were required to be in compliance with the DMA by March 7th, 2024.**
 
 Apple's compliance did not start well. Faced with the genuine possibility of third-party browsers effectively powering web apps, [Apple's first instinct was to remove web app support entirely from iOS](https://open-web-advocacy.org/blog/its-official-apple-kills-web-apps-in-the-eu/) with no notice to either businesses or consumers. Under significant pressure from us and the Commission, [Apple canceled their plan to sabotage web apps in the EU](https://open-web-advocacy.org/blog/apple-backs-off-killing-web-apps/).
 

--- a/src/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
+++ b/src/posts/its-time-for-a-fairer-more-competitive-app-ecosystem.md
@@ -1,7 +1,7 @@
 ---
 title: "It's time for a fairer, more competitive app ecosystem"
 date: '2024-10-24'
-tags: ['Policy', 'EU', 'DMA', 'Apple', 'Google', 'Microsoft', 'Meta', 'Bytedance']
+tags: ['Policy', 'EU', 'DMA', 'Apple', 'Google', 'Microsoft', 'Meta', 'ByteDance']
 author: "OWA"
 ---
 
@@ -69,7 +69,7 @@ The following issues remain unresolved:
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-**Bytedance:**
+**ByteDance:**
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
@@ -78,6 +78,3 @@ For this reason we are adding our voice to many others asking for a fairer, more
 We urge MEPs of the ECON and IMCO Committees to hold the gatekeepers accountable for compliance with the DMA.
 
 Read [our joint letter here](/files/Open%20Letter%20-%20DMA%20enforcement.pdf).
-
-
-

--- a/src/posts/owa-2024-review.md
+++ b/src/posts/owa-2024-review.md
@@ -236,7 +236,7 @@ There are still a vast amount of issues to fix here, and we will continue to wor
 
 * [Respect the user's choice of default browser in apps such as Facebook Messenger and Instagram.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 
-#### Bytedance
+#### ByteDance
 
 * [Respect the user's choice of default browser in TikTok.](https://open-web-advocacy.org/blog/in-app-browsers-the-worst-erosion-of-user-choice-you-havent-heard-of/)
 

--- a/src/posts/the-digital-markets-act-is-in-force-what-happens-now.md
+++ b/src/posts/the-digital-markets-act-is-in-force-what-happens-now.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Digital Markets Act is in force! What happens now?'
 date: '2024-03-07'
-tags: ['Policy', 'Apple', 'Google', 'Microsoft', 'Meta', 'Bytedance', 'EU', 'hotseat']
+tags: ['Policy', 'Apple', 'Google', 'Microsoft', 'Meta', 'ByteDance', 'EU', 'hotseat']
 author: "OWA"
 ---
 
@@ -11,7 +11,7 @@ The Digital Markets Act (DMA) grace period for gatekeepers to comply has now end
 
 The DMA comes with serious teeth, they have the power to fine gatekeepers up to 10% of global revenue repeatedly until they comply with the act. For reference Apple had a global revenue of $383 billion USD in 2023 and their net profit was $100 billion USD, meaning that the maximum cost of a single fine under the DMA is $38.3 billion USD, a sum any gatekeeper would surely blink at. In the case of repeated non-compliance they can fine up-to 20% of global revenue in a single fine. 
 
-Currently there are six gatekeepers who have been designated: Amazon, Apple, Bytedance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
+Currently there are six gatekeepers who have been designated: Amazon, Apple, ByteDance, Google, Meta, and Microsoft. Reportedly X (formerly Twitter) and travel website group Booking [could be added to the list in the near future](https://www.politico.eu/article/elon-musks-x-tiktoks-ad-service-could-face-eu-antitrust-crackdown-under-new-rules/).
 
 These gatekeepers have a number of “core platform services” that have been formally designated under the DMA. To be automatically designated the service must have at least  45 million users in the EU and at least ten thousand business users. Further they need to be of a type of platform covered by the act. Currently the types listed in the act are:
 * online intermediation services


### PR DESCRIPTION
## Summary of Changes

1. [x] Replace all `Bytedance` with `ByteDance`