### PR TITLE
Fix inconsistent get-involved div sizing

### DIFF
--- a/src/css/queries.css
+++ b/src/css/queries.css
@@ -305,8 +305,13 @@
   }
 
   div.contact-entry {
-    min-width: 340px;
+    flex-basis: 45%;
+    min-width: 360px;
     margin-top: 0;
+  }
+
+  div.who-entry {
+    flex-basis: 55%;
   }
 
   div.presentation {


### PR DESCRIPTION
This manually sets min-width for contact-box a little larger than the minimum needed for social media text/logos to not spill onto the next line in Spanish (the language with the longest text) on the homepage. This doesn't affect Chromium/WebKit much, but makes the box wide enough on Firefox, where previously it was far too narrow (Spanish text/logos were spilling over).

I've also added flex-basis 55% to `who-entry` as previously Chromium/WebKit wasn't being affected by the flex-basis 45% set for `contact-entry`, which makes behaviour much more similar between it and Firefox now. The end result still differs ever so slightly between them (although that might just be the different scroll bar), but not enough to be noticeable.

This isn't necessarily a permanent fix, if a longer social media or translation is added to the box it might need increasing again in future, but it was the most effective/simple way I found to fix this issue.

Closes https://github.com/OpenWebAdvocacy/website/issues/275

## Firefox

### Before
<img width="2880" height="1632" alt="image" src="https://github.com/user-attachments/assets/98c298c4-7a66-43f5-8403-7c4d39fa7f00" />

### After
<img width="2880" height="1632" alt="image" src="https://github.com/user-attachments/assets/9f81ecac-fa60-46e6-8296-3ad6ab377663" />

## Chromium

### Before
<img width="2880" height="1574" alt="image" src="https://github.com/user-attachments/assets/96fcfb39-a69e-4e4a-afdd-ae908b82caa6" />

### After
<img width="2880" height="1574" alt="image" src="https://github.com/user-attachments/assets/1247fd99-d25f-4afb-ad1b-4baab788706a" />

WebKit (Gnome Web) is the same before and after, very similar to above.