### PR TITLE
fix: fix tag page showing all articles regardless of filtering

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -66,10 +66,10 @@
       {% block homecontent %}{% endblock %}
     {% else %}
       <div class="inner-wrapper">
-        {% if not isPaperLayout %}
-          {% set postListItems = collections.blog %}
-        {% endif %}
         <main tabindex="-1" id="main-content" class="inner" {% if translated === false %} lang="en" {% endif %}> {% block content %}{% endblock %}
+          {% if not isPaperLayout %}
+            {% set postListItems = collections.blog %}
+          {% endif %}
         </main>
         {% if not isPaperLayout %}
           {% include "partials/aside.njk" %}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -2,9 +2,9 @@
 
 {% block homecontent %}
   <div class="home-wrapper">
-    {% set postListItems = collections.blog %}
     <main tabindex="-1" id="main-home">
         {{ content | safe }}
+        {% set postListItems = collections.blog %}
     </main>
     {% include "partials/aside.njk" %}
   </div>


### PR DESCRIPTION
This reverts commit 65d5afe1

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
resolves #330

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
- Reverted the recent refactoring commit: https://github.com/OpenWebAdvocacy/website/commit/65d5afe167a46c201726b50f1e1a3932c6b59664
- I bisected the previous commits and found this one caused the issue. It seems to be an indirect side-effect, though I'm not entirely sure how it happens yet.

### Example

Before: https://open-web-advocacy.org/tag/japan/
After: https://deploy-preview-334--owa-production.netlify.app/tag/japan/

<img width="1512" height="1586" alt="Screenshot of #japan tag page, showing only 7 articles as expected" src="https://github.com/user-attachments/assets/b658ae7f-76b2-4f11-aa35-3120bb684b93" />
