### PR TITLE
refactor: replace `font-variation-settings` with `font-weight`

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -117,7 +117,7 @@ h1,
 h2,
 h3 {
   max-width: 35ch;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   line-height: 1.2;
   letter-spacing: -0.02em;
 }
@@ -135,7 +135,7 @@ h2 {
 
 h3 {
   font-size: calc(1rem + 1vw);
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
 }
 
 h4 {
@@ -277,7 +277,7 @@ a:hover {
 }
 
 strong {
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
 }
 
 img {
@@ -337,13 +337,13 @@ img {
 
 .post h5 {
   font-size: 100%;
-  font-variation-settings: var(--fvs-regular);
+  font-weight: normal;
   font-style: italic;
 }
 
 .post h6 {
   font-size: 90%;
-  font-variation-settings: var(--fvs-regular);
+  font-weight: normal;
   text-indent: 1em;
 }
 
@@ -376,7 +376,7 @@ figure.double p {
 
 figcaption {
   position: relative;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   padding: 1rem 0 0 3rem;
 }
 
@@ -517,7 +517,7 @@ button,
   background-color: var(--n-dark);
   padding: 0.7em 2.5em 0.8em 1.2em;
   border-radius: 2em;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   text-transform: lowercase;
   line-height: 1;
 }
@@ -583,7 +583,7 @@ button,
   background-color: var(--main-color);
   padding: 0.8em .8em 0.8em .8em;
   border-radius: 2em;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   line-height: 1;
 }
 
@@ -618,7 +618,7 @@ div.site-header__inner {
   margin: 0 auto;
 
   & a {
-    font-variation-settings: var(--fvs-black);
+    font-weight: 900;
     text-decoration: none;
     text-transform: lowercase;
     line-height: 1;
@@ -707,7 +707,7 @@ body>footer li {
 }
 
 p.copyright {
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
 }
 
 
@@ -823,7 +823,7 @@ header.home-header h1 {
   font-size: clamp(1.2rem, 5vw, 3.5rem);
   line-height: 1;
   text-transform: lowercase;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   margin-bottom: -0.1em;
 }
 
@@ -865,7 +865,7 @@ div.home-wrapper p {
 p.home-intro {
   max-width: 27em;
   font-size: 1.2em;
-  font-variation-settings: var(--fvs-medium);
+  font-weight: 500;
   margin: 5% 1.5rem 3rem;
 }
 
@@ -913,7 +913,7 @@ dl.counter {
 dl.counter dt {
   position: relative;
   font-size: 1.2em;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   padding-top: 1em;
   padding-left: 4rem;
 }
@@ -926,7 +926,7 @@ dl.counter dt::before {
   top: 0.2em;
   left: 0;
   font: 2rem/1.5em var(--stack);
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   content: counter(counter);
   counter-increment: counter;
   text-align: center;
@@ -1036,7 +1036,7 @@ ul.press-list > li::before {
   content: "EN";
   width: 2em;
   height: 2em;
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
   text-align: center;
   color: var(--text-inv);
   background-color: var(--n-dark);
@@ -1143,7 +1143,7 @@ div.gallery figcaption {
   padding: 0 1rem;
   text-align: center;
   font-size: 80%;
-  font-variation-settings: var(--fvs-regular);
+  font-weight: normal;
 }
 
 div.gallery figcaption::before {
@@ -1307,14 +1307,14 @@ p.social {
 }
 
 .post-meta time {
-  font-variation-settings: var(--fvs-black);
+  font-weight: 900;
 }
 
 .tags-list {
   margin: 0;
   list-style: none;
   text-transform: capitalize;
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
   color: #666;
 }
 
@@ -1437,7 +1437,7 @@ div.license img {
 
 p.baseline {
   font-size: 120%;
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
   line-height: 1.3;
   margin-bottom: 0.5em;
 }
@@ -1616,7 +1616,7 @@ header:not(.home-header) p:has(button.language-picker) {
 .cta-header {
   background: var(--main-color);
   color: white;
-  font-weight: 700;
+  font-weight: bold;
   font-size: 1.4rem;
   text-align: center;
   padding: 1rem 1.5rem;
@@ -1846,8 +1846,7 @@ header:not(.home-header) p:has(button.language-picker) {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 0.83rem;
-  font-weight: 700;
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
   border-bottom: 1px solid color-mix(in srgb, var(--n-dark) 14%, white);
 }
 
@@ -1884,14 +1883,13 @@ header:not(.home-header) p:has(button.language-picker) {
   white-space: normal;
   line-height: 1.35;
   color: color-mix(in srgb, var(--n-dark) 68%, white);
-  font-weight: 700;
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
   font-variant-numeric: tabular-nums;
 }
 
 .owa-table strong {
   color: var(--n-dark);
-  font-variation-settings: var(--fvs-bold);
+  font-weight: bold;
 }
 
 .owa-table__subdate {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -117,7 +117,7 @@ h1,
 h2,
 h3 {
   max-width: 35ch;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   line-height: 1.2;
   letter-spacing: -0.02em;
 }
@@ -135,7 +135,7 @@ h2 {
 
 h3 {
   font-size: calc(1rem + 1vw);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 h4 {
@@ -152,7 +152,7 @@ dl {
 dl {}
 
 dt {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   margin-top: var(--flow-space);
 }
 
@@ -201,7 +201,7 @@ cite:before {
 code {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 0.95em;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 pre {
@@ -277,7 +277,7 @@ a:hover {
 }
 
 strong {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 img {
@@ -337,13 +337,13 @@ img {
 
 .post h5 {
   font-size: 100%;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
   font-style: italic;
 }
 
 .post h6 {
   font-size: 90%;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
   text-indent: 1em;
 }
 
@@ -376,7 +376,7 @@ figure.double p {
 
 figcaption {
   position: relative;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   padding: 1rem 0 0 3rem;
 }
 
@@ -517,7 +517,7 @@ button,
   background-color: var(--n-dark);
   padding: 0.7em 2.5em 0.8em 1.2em;
   border-radius: 2em;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   text-transform: lowercase;
   line-height: 1;
 }
@@ -583,7 +583,7 @@ button,
   background-color: var(--main-color);
   padding: 0.8em .8em 0.8em .8em;
   border-radius: 2em;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   line-height: 1;
 }
 
@@ -618,7 +618,7 @@ div.site-header__inner {
   margin: 0 auto;
 
   & a {
-    font-weight: 900;
+    font-weight: var(--font-weight-black);
     text-decoration: none;
     text-transform: lowercase;
     line-height: 1;
@@ -707,7 +707,7 @@ body>footer li {
 }
 
 p.copyright {
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
 }
 
 
@@ -752,7 +752,7 @@ header nav ul li {
 }
 
 header nav a {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   text-decoration: none;
 }
 
@@ -823,7 +823,7 @@ header.home-header h1 {
   font-size: clamp(1.2rem, 5vw, 3.5rem);
   line-height: 1;
   text-transform: lowercase;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   margin-bottom: -0.1em;
 }
 
@@ -865,7 +865,7 @@ div.home-wrapper p {
 p.home-intro {
   max-width: 27em;
   font-size: 1.2em;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   margin: 5% 1.5rem 3rem;
 }
 
@@ -913,7 +913,7 @@ dl.counter {
 dl.counter dt {
   position: relative;
   font-size: 1.2em;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   padding-top: 1em;
   padding-left: 4rem;
 }
@@ -926,7 +926,7 @@ dl.counter dt::before {
   top: 0.2em;
   left: 0;
   font: 2rem/1.5em var(--stack);
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   content: counter(counter);
   counter-increment: counter;
   text-align: center;
@@ -1036,7 +1036,7 @@ ul.press-list > li::before {
   content: "EN";
   width: 2em;
   height: 2em;
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
   text-align: center;
   color: var(--text-inv);
   background-color: var(--n-dark);
@@ -1143,7 +1143,7 @@ div.gallery figcaption {
   padding: 0 1rem;
   text-align: center;
   font-size: 80%;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 
 div.gallery figcaption::before {
@@ -1216,7 +1216,7 @@ div.prom-banner div.donation-details table {
 }
 
 div.prom-banner div.donation-details th, td {
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 
 /* CONTRIBUTORS PAGE */
@@ -1307,14 +1307,14 @@ p.social {
 }
 
 .post-meta time {
-  font-weight: 900;
+  font-weight: var(--font-weight-black);
 }
 
 .tags-list {
   margin: 0;
   list-style: none;
   text-transform: capitalize;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: #666;
 }
 
@@ -1437,7 +1437,7 @@ div.license img {
 
 p.baseline {
   font-size: 120%;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   line-height: 1.3;
   margin-bottom: 0.5em;
 }
@@ -1616,7 +1616,7 @@ header:not(.home-header) p:has(button.language-picker) {
 .cta-header {
   background: var(--main-color);
   color: white;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   font-size: 1.4rem;
   text-align: center;
   padding: 1rem 1.5rem;
@@ -1846,7 +1846,7 @@ header:not(.home-header) p:has(button.language-picker) {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 0.83rem;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   border-bottom: 1px solid color-mix(in srgb, var(--n-dark) 14%, white);
 }
 
@@ -1883,13 +1883,13 @@ header:not(.home-header) p:has(button.language-picker) {
   white-space: normal;
   line-height: 1.35;
   color: color-mix(in srgb, var(--n-dark) 68%, white);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   font-variant-numeric: tabular-nums;
 }
 
 .owa-table strong {
   color: var(--n-dark);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 .owa-table__subdate {

--- a/src/css/queries.css
+++ b/src/css/queries.css
@@ -146,7 +146,7 @@
   header nav ul {justify-content: space-between;}
 
   header.home-header li {
-    font-variation-settings: var(--fvs-regular);
+    font-weight: normal;
   }
 
   header.home-header nav a {

--- a/src/css/queries.css
+++ b/src/css/queries.css
@@ -146,7 +146,7 @@
   header nav ul {justify-content: space-between;}
 
   header.home-header li {
-    font-weight: normal;
+    font-weight: var(--font-weight-regular);
   }
 
   header.home-header nav a {

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -21,7 +21,13 @@
 }
 
 :root {
+
   --stack: "Kumbh Sans Regular", "Segoe UI", Roboto, "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+  --font-weight-light: 300;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+  --font-weight-black: 900;
 
   --body-text: #333;
   --body-bg: #FFF;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -21,13 +21,7 @@
 }
 
 :root {
-
   --stack: "Kumbh Sans Regular", "Segoe UI", Roboto, "Droid Sans", "Helvetica Neue", Arial, sans-serif;
-  --fvs-light: "wght" 300;
-  --fvs-regular: "wght" 400;
-  --fvs-medium: "wght" 500;
-  --fvs-bold: "wght" 700;
-  --fvs-black: "wght" 900;
 
   --body-text: #333;
   --body-bg: #FFF;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
fix #321 

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
Replaced the low-level `font-variation-settings` CSS with `font-weight`. This would ensure the consistent font weight across all fonts.

MDN also recommends to prioritize `font-weight` unless it's really necessary:
> This property is a low-level mechanism designed to set variable font features where no other way to enable or access those features exist. You should only use it when no basic properties exist to set those features (e.g., [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight), [font-style](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-style)).

ref. font-variation-settings CSS property - CSS | MDN - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variation-settings#description