### PR TITLE
test: initialize Playwright test framework and CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,17 +9,17 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: lts/*
+        node-version-file: '.nvmrc'
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ Thumbs.db
 node_modules
 dist
 src/_includes/css
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "rgjs7": "^0.0.88"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
+        "@types/node": "^26.1.0",
         "netlify-plugin-cache": "^1.0.3",
         "prettier": "^3.9.4"
       },
@@ -1558,6 +1560,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@resvg/resvg-js": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
@@ -1889,6 +1907,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
@@ -4845,6 +4873,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -6091,6 +6166,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "generate": "node generate-language-files.js",
     "build": "npm run production",
     "production": "npm run generate && NODE_ENV=production npx @11ty/eleventy",
-    "updates": "npx npm-check-updates -i --format group"
+    "updates": "npx npm-check-updates -i --format group",
+    "test": "npx playwright test",
+    "test:ui": "npx playwright test --ui",
+    "test:debug": "npx playwright test --debug"
   },
   "engines": {
     "node": ">=26"
@@ -41,6 +44,8 @@
     "rgjs7": "^0.0.88"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
+    "@types/node": "^26.1.0",
     "netlify-plugin-cache": "^1.0.3",
     "prettier": "^3.9.4"
   },
@@ -48,5 +53,10 @@
     "@resvg/resvg-js-darwin-arm64": "^2.6.2",
     "@resvg/resvg-js-linux-x64-gnu": "^2.6.2",
     "sharp": "^0.35.3"
+  },
+  "allowScripts": {
+    "sharp@0.33.5": true,
+    "sharp@0.34.5": true,
+    "sharp@0.35.3": true
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,81 @@
+// @ts-check
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    baseURL: 'http://localhost:8081',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:8081',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,6 +31,16 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,14 +2,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
-
-/**
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
@@ -49,26 +41,6 @@ export default defineConfig({
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
     },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: 'http://localhost:8081',
+    baseURL: 'http://localhost:8080',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -74,7 +74,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run start',
-    url: 'http://localhost:8081',
+    url: 'http://localhost:8080',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,16 +31,6 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -47,7 +47,7 @@ test.describe('translations', () => {
   });
 
   test('non-English tag page has translated tag', async ({page}) => {
-    await page.goto('/ja/tag/japan');
+    await page.goto('/ja/tag/japan/');
     const header = page.getByRole('heading', { level: 1})
     await expect(header).toContainText('日本');
     await expect(header).not.toContainText('Japan');

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -10,8 +10,8 @@ test.describe('tag list page', () => {
     await page.goto('/tag/japan/');
 
     const postLinks = page.locator('main').getByRole('link');
-    const firstPost = await postLinks.first();
-    const lastPost = await postLinks.last();
+    const firstPost = postLinks.first();
+    const lastPost = postLinks.last();
 
     for (const postLink of [firstPost, lastPost]) {
       await postLink.click();

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -38,3 +38,25 @@ test.describe('tag list page', () => {
     await expect(page.getByRole('list', {name: 'Tags'}).getByRole('link', {name: '#Japan'})).not.toBeVisible();
   });
 });
+
+test.describe('translations', () => {
+  test('non-English page has translated text', async ({page}) => {
+    await page.goto('/ja/');
+    await expect(page.locator('.home-intro')).toContainText('開かれたウェブ');
+    await expect(page.locator('.home-intro')).not.toContainText('the open web');
+  });
+
+  test('non-English tag page has translated tag', async ({page}) => {
+    await page.goto('/ja/tag/japan');
+    const header = page.getByRole('heading', { level: 1})
+    await expect(header).toContainText('日本');
+    await expect(header).not.toContainText('Japan');
+  });
+
+  test('translated news article has translated tag', async ({page}) => {
+    await page.goto('/ja/blog/28-percent-faster--the-blink-prototype-that-shows-why-apples-ios-browser-engine-ban-must-end/');
+
+    await expect(page.getByRole('list', {name: 'Tags'}).getByRole('link', {name: '#日本'})).toBeVisible();
+    await expect(page.getByRole('list', {name: 'Tags'}).getByRole('link', {name: '#Japan'})).not.toBeVisible();
+  });
+});

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -1,0 +1,40 @@
+import {expect, test} from '@playwright/test';
+
+test('home page has title', async ({page}) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', {name: 'Open Web Advocacy'})).toBeVisible();
+});
+
+test.describe('tag list page', () => {
+  test('posts in #japan have #japan tag', async ({page}) => {
+    await page.goto('/tag/japan/');
+
+    const postLinks = page.locator('main').getByRole('link');
+    const firstPost = await postLinks.first();
+    const lastPost = await postLinks.last();
+
+    for (const postLink of [firstPost, lastPost]) {
+      await postLink.click();
+
+      await expect(page.getByRole('list', {name: 'Tags'}).getByRole('link', {name: '#Japan'})).toBeVisible();
+
+      await page.goBack();
+    }
+  });
+
+  test('oldest post in #eu does not have #japan tag', async ({page}) => {
+    await page.goto('/tag/eu/');
+
+    const postLinks = page.locator('main').getByRole('link');
+
+    // The oldest post in #eu should be the following post, and it has tags: #Policy #Updates #UK #EU
+    // OWA updates on progress with UK and EU digital competition regulations - Open Web Advocacy
+    // - https://open-web-advocacy.org/blog/CMA-DMA-Nov-22/
+    const lastPostLink = postLinks.last();
+    await expect(lastPostLink).toHaveAttribute('href', '/blog/CMA-DMA-Nov-22/');
+
+    await lastPostLink.click();
+
+    await expect(page.getByRole('list', {name: 'Tags'}).getByRole('link', {name: '#Japan'})).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
resolves https://github.com/OpenWebAdvocacy/website/issues/338

## Summary of Changes
- [x] Set up the Playwright test framework and GitHub Actions workflow
- [x] Added Playwright tests for tag pages to prevent regressions where all posts are shown regardless of filters.

This provides a foundation for adding more E2E tests in the future.