### PR TITLE
chore: enable Japanese font feature settings for proportional alternates

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -113,6 +113,10 @@ body {
   background: var(--body-bg);
 }
 
+html[lang="ja"] > body {
+  font-feature-settings: 'palt';
+}
+
 h1,
 h2,
 h3 {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
https://github.com/OpenWebAdvocacy/website/pull/326#discussion_r3500072278

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
- Improve Japanese font rendering, especially for parentheses and punctuation, by enabling the `palt` (proportional alternates) font property. (Previously shared here: https://github.com/OpenWebAdvocacy/website/pull/326#discussion_r3500072278)


(Note: This is a niche topic in CJK typography and can be technical. If you're not familiar with it, feel free to skip the details.)

I think this needs a bit more explanation for those who are not familiar with Japanese font issues. In the past, Japanese translators often had to manually add a half-width space depending on whether the text was next to punctuation or not.

Currently, the CSS standard is expanding its support for CJK fonts. While `text-autospace` and `text-spacing-trim` should have similar effects, they were introduced by Blink in 2025 and are still waiting for broader adoption.

Since more Japanese fonts and browsers now handle these properties well, we can achieve consistent rendering by using only full-width spaces and the `palt` setting.

ref.
- Syntax for OpenType features in CSS | Fonts - https://helpx.adobe.com/fonts/using/open-type-syntax.html#palt
  - a short explanation of the effects of `palt` property with screenshots by Adobe.
- Using CSS font-feature-settings for better kerning in Japanese text - ICS MEDIA - https://ics.media/en/entry/14087/
  - This is popular media among Japanese web designers and popularized this property. It explains the details.
- Introducing four new international features in CSS  |  Blog  |  Chrome for Developers - https://developer.chrome.com/blog/css-i18n-features
  - An announcement of `text-space-trim` by Chrome team in 2023 but Safari and Firefox hasn't implement yet.