### PR TITLE
Add global @media prefers-reduced-motion override

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -107,6 +107,13 @@ figure.equation {
 
 /* ---------------------- GLOBALS ------------------------ */
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 body {
   font: 100%/1.5 var(--stack);
   color: var(--body-text);


### PR DESCRIPTION
This overrides all CSS transition (of which there's 4) and animation durations to be 0.01ms when prefers-reduced-motion override is on. The setting is set at the [OS level](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion#user_preferences) and followed by browsers.

I've tested this by changing the setting on my OS and this makes all of these animations effectively instant.