### PR TITLE
Add description fallback using first-paragraph-filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,6 +26,7 @@ import localePostsFilter from './src/filters/locale-posts-filter.js';
 import removeLanguageCode from './src/filters/remove-language-code-filter.js';
 import language from './src/filters/language.js';
 import w3DateFilter from './src/filters/w3-date-filter.js';
+import firstParagraphFilter from './src/filters/first-paragraph-filter.js';
 
 // Shortcodes
 import cssInlineShortcode from './src/shortcodes/cssInline.js';
@@ -53,6 +54,7 @@ export default config => {
     const content = post.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>|<[^>]*>/gi, '');
     return content.substr(0, content.lastIndexOf(' ', 400)) + '...';
   });
+  config.addFilter('firstParagraph', firstParagraphFilter);
 
   // Add shortcodes
   config.addNunjucksAsyncShortcode('cssInline', cssInlineShortcode());

--- a/src/_includes/partials/meta-info.njk
+++ b/src/_includes/partials/meta-info.njk
@@ -22,7 +22,7 @@
 {% endif %}
 
 {% if not metaDesc %}
-  {% set metaDesc = summary %}
+  {% set metaDesc = summary or (content | firstParagraph) %}
 {% endif %}
 
 <title>{{ pageTitle }}</title>

--- a/src/filters/first-paragraph-filter.js
+++ b/src/filters/first-paragraph-filter.js
@@ -1,0 +1,20 @@
+export default function firstParagraphFilter(html, maxLength = 160) {
+  if (!html) return '';
+
+  // handles SafeString and any other non-string value
+  const str = String(html);
+
+  // Get the first <p>...</p> anywhere in the page content
+  const match = str.match(/<p[^>]*>([\s\S]*?)<\/p>/i);
+  let text = match ? match[1] : str;
+
+  // Strip any nested tags (links, em, etc.) and collapse whitespace
+  text = text.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+
+  // Truncate on a word boundary appropriate description length, end with '...'
+  if (text.length > maxLength) {
+    text = text.slice(0, maxLength).replace(/\s+\S*$/, '') + '…';
+  }
+
+  return text;
+}

--- a/src/filters/first-paragraph-filter.js
+++ b/src/filters/first-paragraph-filter.js
@@ -11,6 +11,9 @@ export default function firstParagraphFilter(html, maxLength = 160) {
   // Strip any nested tags (links, em, etc.) and collapse whitespace
   text = text.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
 
+  // Strip leading "TL;DR" if there is one, with or without semicolon/colon/dash, case-insensitive
+  text = text.replace(/^\s*TL;?DR\s*[:\-–—]*\s*/i, '');
+
   // Truncate on a word boundary appropriate description length, end with '...'
   if (text.length > maxLength) {
     text = text.slice(0, maxLength).replace(/\s+\S*$/, '') + '…';

--- a/src/filters/first-paragraph-filter.js
+++ b/src/filters/first-paragraph-filter.js
@@ -4,6 +4,9 @@ export default function firstParagraphFilter(html, maxLength = 160) {
   // handles SafeString and any other non-string value
   const str = String(html);
 
+  // Return an empty description for non-string objects used in tag pages
+  if (str === '[object Object]') return '';
+
   // Get the first <p>...</p> anywhere in the page content
   const match = str.match(/<p[^>]*>([\s\S]*?)<\/p>/i);
   let text = match ? match[1] : str;


### PR DESCRIPTION
## Related Issue
#327 

## Summary of changes
- This adds a fallback description for pages which don't have a description or a 'summary' tag set. The description is automatically generated from the first paragraph of an article, truncated to the nearest whole word underneath 160 characters. An ellipsis is added after this, and if there's a 'TL;DR' at the start that's removed. 
- Non-string objects such as the tag page content return blank descriptions
- This affects all blog posts, and also the Apple DMA review page which doesn't currently have a description. It works correctly for different languages.